### PR TITLE
feat: add damage mitigation metrics and related calculations

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -15,6 +15,7 @@ Version v1.9.0 — January 28, 2026
 - Fix tooltip positioning and improve table layout in StatsView
 - Profession icons now support multi-profession tooltips and improved rendering
 - Add Proof of Work modal and metrics specification documentation
+- Damage mitigation now includes WvW reduction skills and expanded audit/spec coverage
 
 ## 🧯 Fixes
 - General errors and minor issues addressed (5-mini)

--- a/mitigation_fetch.py
+++ b/mitigation_fetch.py
@@ -1,0 +1,385 @@
+import re
+import time
+import csv
+import requests
+from urllib.parse import quote
+
+from bs4 import BeautifulSoup
+
+GW2_API = "https://api.guildwars2.com/v2"
+GW2SKILLS = "https://en.gw2skills.net/wiki"
+
+SKILLS = [
+    "Frost Aura",
+    "Frozen Ground",
+    "Dual Orbits: Air and Earth",
+    "Dual Orbits: Fire and Earth",
+    "Dual Orbits: Water and Earth",
+    "Grinding Stones",
+    "Rocky Loop",
+    "Explosive Thrust",
+    "Steel Divide",
+    "Swift Cut",
+    "Restorative Glow",
+    "Infusing Terror",
+    "Perilous Gift",
+    "Resilient Weapon",
+    "Signet of Judgment",
+    "Forced Engagement",
+    "Vengeful Hammers",
+    "Endure Pain",
+    "Spectrum Shield",
+    "Barrier Signet",
+    "\"Guard!\"",
+    "Dolyak Stance",
+    "\"Flash-Freeze!\"",
+    "\"Rise!\"",
+    "Daring Advance",
+    "Rite of the Great Dwarf",
+    "Rampage",
+    "\"Rebound!\"",
+    "Weave Self",
+    "Ancient Echo",
+    "Facet of Nature",
+    "Full Counter",
+    "Drink Ambrosia",
+    "Throw Enchanted Ice",
+    "Enter Shadow Shroud",
+    "Death Shroud",
+    "Reaper's Shroud",
+    "Ritualist's Shroud",
+    "Lesser \"Guard!\"",
+]
+
+# Optional: aliases if the official API uses different names
+ALIASES = {
+    # "Drink Ambrosia": "Some Official API Name",
+    # "Throw Enchanted Ice": "Some Official API Name",
+}
+
+HEADERS = {"User-Agent": "gw2-damage-reduction-scraper/1.1 (personal use)"}
+
+# -------------------------
+# Formatting helpers
+# -------------------------
+def format_elapsed(seconds: float) -> str:
+    if seconds < 0:
+        return "0s"
+    m, s = divmod(int(seconds), 60)
+    h, m = divmod(m, 60)
+    if h:
+        return f"{h}h {m}m {s}s"
+    if m:
+        return f"{m}m {s}s"
+    return f"{s}s"
+
+def format_eta(start_time: float, done: int, total: int) -> str:
+    if done <= 0 or total <= 0:
+        return "ETA ?"
+    elapsed = time.time() - start_time
+    rate = done / max(elapsed, 0.001)
+    remaining = max(total - done, 0)
+    eta = remaining / rate if rate > 0 else 0
+    return f"ETA {format_elapsed(eta)}"
+
+# -------------------------
+# API helpers
+# -------------------------
+def api_get_json(url, params=None, retries=3):
+    for i in range(retries):
+        r = requests.get(url, params=params, headers=HEADERS, timeout=60)
+        if r.status_code == 200:
+            return r.json()
+        time.sleep(0.5 * (i + 1))
+    raise RuntimeError(f"API failed: {r.status_code} {r.text[:200]}")
+
+def norm_name(s: str) -> str:
+    s = s.lower()
+    s = s.replace("’", "'")
+    s = re.sub(r'["“”]', "", s)
+    s = re.sub(r"[^a-z0-9]+", "", s)
+    return s
+
+def build_name_to_id_map():
+    name_to_id = {}
+    start_time = time.time()
+
+    objs = api_get_json(f"{GW2_API}/skills", params={"ids": "all", "lang": "en"})
+    total = len(objs) if isinstance(objs, list) else 0
+
+    for i, obj in enumerate(objs, 1):
+        nm = obj.get("name")
+        sid = obj.get("id")
+        if nm and sid:
+            name_to_id[nm] = sid
+            name_to_id[nm.lower()] = sid
+            name_to_id[norm_name(nm)] = sid
+
+        if i % 500 == 0 or i == total:
+            print(f"[api] Indexed {i}/{total} skills ({format_elapsed(time.time() - start_time)}, {format_eta(start_time, i, total)})")
+            time.sleep(0.02)
+
+    return name_to_id
+
+def resolve_skill_id(name_to_id: dict, nm: str):
+    nm2 = ALIASES.get(nm, nm)
+    return (
+        name_to_id.get(nm2)
+        or name_to_id.get(nm2.lower())
+        or name_to_id.get(norm_name(nm2))
+    )
+
+# -------------------------
+# gw2skills scraping helpers
+# -------------------------
+def gw2skills_url_for_skill(name: str) -> str:
+    slug = name.replace(" ", "_")
+    return f"{GW2SKILLS}/{quote(slug, safe=':_()!')}"
+
+def fetch_gw2skills_html(name: str) -> str:
+    url = gw2skills_url_for_skill(name)
+    r = requests.get(url, headers=HEADERS, timeout=60)
+    if r.status_code != 200:
+        return ""
+    return r.text
+
+def soup_main_text(soup: BeautifulSoup) -> str:
+    # Try common content containers; fall back to body
+    for sel in ["#mw-content-text", ".mw-parser-output", "#content", "main", "article"]:
+        node = soup.select_one(sel)
+        if node:
+            return node.get_text("\n", strip=True)
+    return (soup.body or soup).get_text("\n", strip=True)
+
+def split_mode_blocks(text: str):
+    """
+    Best-effort segmentation:
+    Return dict with keys: "wvw", "pvp", "pve", "all"
+    """
+    lower = text.lower()
+    blocks = {"all": text, "pve": "", "pvp": "", "wvw": ""}
+
+    # Find headings by literal tokens; gw2skills pages frequently include these labels.
+    # We'll slice between occurrences.
+    # If not present, block remains empty and caller falls back.
+    def find_idx(token):
+        i = lower.find(token)
+        return i if i != -1 else None
+
+    idx_pve = find_idx("\npve\n") or find_idx("#### pve") or find_idx("pve")
+    idx_pvp = find_idx("\npvp\n") or find_idx("#### pvp") or find_idx("pvp")
+    idx_wvw = find_idx("\nwvw\n") or find_idx("#### wvw") or find_idx("wvw")
+
+    # Collect found indices (token, idx)
+    found = [(k, v) for k, v in [("pve", idx_pve), ("pvp", idx_pvp), ("wvw", idx_wvw)] if v is not None]
+    found.sort(key=lambda x: x[1])
+
+    # Slice between headings
+    for j, (mode, start) in enumerate(found):
+        end = found[j + 1][1] if j + 1 < len(found) else len(text)
+        blocks[mode] = text[start:end]
+
+    return blocks
+
+# -------------------------
+# Parsing logic
+# -------------------------
+def _pick_best_pct_from_matches(matches):
+    # We want a stable answer: prefer the one closest to "Incoming Damage" wording,
+    # but since matches are already filtered by regex, we just pick max abs within sane range.
+    cleaned = []
+    for v in matches:
+        try:
+            v = int(v)
+        except Exception:
+            continue
+        if -100 <= v <= 100:
+            cleaned.append(v)
+    if not cleaned:
+        return None
+    best = max(cleaned, key=lambda x: abs(x))
+    return abs(best)
+
+def parse_reduction_facts(text_all: str):
+    """
+    Critical fix:
+      - Prefer parsing % reducers FROM WvW BLOCK if present.
+      - Only fall back to full text if WvW block doesn't contain anything.
+      - Exclude boon lines for Protection/Resolution from being misinterpreted as the skill passive.
+    """
+    blocks = split_mode_blocks(text_all)
+    wvw_text = blocks.get("wvw", "").strip()
+
+    # We'll parse reductions primarily from WvW text if available.
+    primary = wvw_text if wvw_text else text_all
+
+    # Strip out known boon effect lines that cause false captures (esp. Signet of Judgment page)
+    # This does NOT affect skills that are literally "Protection" or "Resolution" (not in your list).
+    def remove_boon_lines(t: str) -> str:
+        lines = []
+        for ln in t.splitlines():
+            l = ln.lower()
+            if l.startswith("protection") or l.startswith("resolution"):
+                # keep the line if it is the skill name itself (rare) — otherwise drop
+                continue
+            lines.append(ln)
+        return "\n".join(lines)
+
+    primary = remove_boon_lines(primary)
+
+    # Percent reducers (strict)
+    dmg_matches = [int(x) for x in re.findall(r"([+-]?\d+)\s*%\s+Incoming Damage\b", primary, flags=re.IGNORECASE)]
+    cond_matches = [int(x) for x in re.findall(r"([+-]?\d+)\s*%\s+Incoming Condition Damage\b", primary, flags=re.IGNORECASE)]
+
+    # Fallback patterns (still within primary text only)
+    dmg_matches += [int(x) for x in re.findall(r"([+-]?\d+)\s*%\s+Incoming Strike Damage\b", primary, flags=re.IGNORECASE)]
+    dmg_matches += [int(x) for x in re.findall(r"Incoming damage (?:is )?(?:reduced|decreased) by\s*([+-]?\d+)\s*%", primary, flags=re.IGNORECASE)]
+    dmg_matches += [int(x) for x in re.findall(r"Damage taken (?:is )?(?:reduced|decreased) by\s*([+-]?\d+)\s*%", primary, flags=re.IGNORECASE)]
+    cond_matches += [int(x) for x in re.findall(r"Incoming condition damage (?:is )?(?:reduced|decreased) by\s*([+-]?\d+)\s*%", primary, flags=re.IGNORECASE)]
+
+    dmg = _pick_best_pct_from_matches(dmg_matches)
+    cond = _pick_best_pct_from_matches(cond_matches)
+
+    # If WvW block existed but produced nothing, fall back to full text (still remove boon lines)
+    if wvw_text and dmg is None and cond is None:
+        fallback = remove_boon_lines(text_all)
+        dmg2 = [int(x) for x in re.findall(r"([+-]?\d+)\s*%\s+Incoming Damage\b", fallback, flags=re.IGNORECASE)]
+        cond2 = [int(x) for x in re.findall(r"([+-]?\d+)\s*%\s+Incoming Condition Damage\b", fallback, flags=re.IGNORECASE)]
+        dmg = _pick_best_pct_from_matches(dmg2)
+        cond = _pick_best_pct_from_matches(cond2)
+
+    # Invulnerability detection: use full text (invuln phrasing may not be repeated in WvW section)
+    invuln_strike = bool(re.search(
+        r"take no damage from (attacks|strikes)|invulnerable to (attacks|strikes)",
+        text_all,
+        flags=re.IGNORECASE
+    ))
+    invuln_any = bool(re.search(r"\binvulnerab|\btake no damage\b", text_all, flags=re.IGNORECASE))
+
+    # Classification
+    if invuln_strike:
+        scope = "strike_only"
+        mechanic = "invuln"
+    elif invuln_any:
+        scope = "all"
+        mechanic = "invuln"
+    elif dmg is not None and cond is not None:
+        scope = "all"
+        mechanic = "pct_reduction"
+    elif dmg is not None:
+        scope = "all"
+        mechanic = "pct_reduction"
+    elif cond is not None:
+        scope = "cond_only"
+        mechanic = "pct_reduction"
+    else:
+        scope = "unknown"
+        mechanic = "other"
+
+    # Normalize invuln for downstream math
+    if mechanic == "invuln":
+        if scope == "strike_only":
+            dmg = 100
+        else:
+            dmg = 100
+            cond = 100
+
+    # Duration/cooldown best-effort: prefer WvW block if present
+    timing = wvw_text if wvw_text else text_all
+    cooldown = None
+    duration = None
+
+    mcd = re.search(r"\bRecharge\b\s*:?\s*(\d+)\b", timing, flags=re.IGNORECASE)
+    if mcd:
+        cooldown = int(mcd.group(1))
+
+    mdur = re.search(r"\bDuration\b\s*:?\s*(\d+(?:\.\d+)?)\s*(?:s|sec|seconds)\b", timing, flags=re.IGNORECASE)
+    if mdur:
+        duration = float(mdur.group(1))
+
+    return {
+        "incoming_damage_reduction_pct": dmg,
+        "incoming_condition_damage_reduction_pct": cond,
+        "scope": scope,
+        "mechanic_type": mechanic,
+        "invuln_detected": invuln_any,
+        "invuln_strike_only": invuln_strike,
+        "wvw_duration_s_guess": duration,
+        "wvw_cooldown_s_guess": cooldown,
+    }
+
+# -------------------------
+# Main
+# -------------------------
+def main():
+    overall_start = time.time()
+    print("Building name->id map from official API (ids=all)...")
+    name_to_id = build_name_to_id_map()
+    print(f"[api] Done in {format_elapsed(time.time() - overall_start)}")
+
+    rows = []
+    unresolved = []
+
+    skill_start = time.time()
+    total_skills = len(SKILLS)
+
+    for i, nm in enumerate(SKILLS, 1):
+        sid = resolve_skill_id(name_to_id, nm)
+        if sid is None:
+            unresolved.append(nm)
+
+        html = fetch_gw2skills_html(nm)
+        if html:
+            soup = BeautifulSoup(html, "html.parser")
+            text_all = soup_main_text(soup)
+            facts = parse_reduction_facts(text_all)
+        else:
+            facts = {
+                "incoming_damage_reduction_pct": None,
+                "incoming_condition_damage_reduction_pct": None,
+                "scope": "unknown",
+                "mechanic_type": "other",
+                "invuln_detected": None,
+                "invuln_strike_only": None,
+                "wvw_duration_s_guess": None,
+                "wvw_cooldown_s_guess": None,
+            }
+
+        rows.append({
+            "name": nm,
+            "api_skill_id": sid,
+            "wvw_incoming_damage_reduction_pct": facts["incoming_damage_reduction_pct"],
+            "wvw_incoming_condition_damage_reduction_pct": facts["incoming_condition_damage_reduction_pct"],
+            "scope": facts["scope"],
+            "mechanic_type": facts["mechanic_type"],
+            "invuln_detected": facts["invuln_detected"],
+            "invuln_strike_only": facts["invuln_strike_only"],
+            "wvw_duration_s_guess": facts["wvw_duration_s_guess"],
+            "wvw_cooldown_s_guess": facts["wvw_cooldown_s_guess"],
+            "gw2skills_url": gw2skills_url_for_skill(nm),
+        })
+
+        print(f"[skills] {i}/{total_skills} {nm} ({format_elapsed(time.time() - skill_start)}, {format_eta(skill_start, i, total_skills)})")
+        time.sleep(0.1)
+
+    out = "damage_reduction_wvw.csv"
+    with open(out, "w", newline="", encoding="utf-8") as f:
+        w = csv.DictWriter(f, fieldnames=list(rows[0].keys()))
+        w.writeheader()
+        w.writerows(rows)
+
+    print(f"\nWrote {out} with {len(rows)} rows.")
+
+    if unresolved:
+        print("\n[warn] Could not resolve API ids for:")
+        for nm in unresolved:
+            print(f"  - {nm}")
+        print("\nTip: fill ALIASES for those names, or they may not exist as /v2/skills entries.")
+
+    print("\nNotes:")
+    print("- Parses % reducers from the WvW section when present (fixes Rocky Loop 15->10 and Dual Orbits weirdness).")
+    print("- Filters out Protection/Resolution lines so Signet of Judgment stays at its passive 10/10.")
+    print("- cooldown/duration still best-effort; verify critical skills manually.")
+
+if __name__ == "__main__":
+    main()

--- a/scripts/metrics-audit.mjs
+++ b/scripts/metrics-audit.mjs
@@ -84,6 +84,7 @@ const {
     computeOutgoingCrowdControl,
     computeIncomingDisruptions,
     computeDownContribution,
+    computeDamageMitigationBreakdown,
     computeSquadBarrier,
     computeSquadHealing,
 } = metricsModule;
@@ -101,6 +102,7 @@ const buildMetricsOutput = (sourcePath) => {
 
     const metrics = players.map((player) => {
         const incoming = computeIncomingDisruptions(player, method);
+        const mitigation = computeDamageMitigationBreakdown(player, { buffMap: log.buffMap });
         return {
             name: player.name,
             account: player.account,
@@ -114,6 +116,18 @@ const buildMetricsOutput = (sourcePath) => {
             squadBarrier: computeSquadBarrier(player),
             squadHealing: computeSquadHealing(player),
             stabGeneration: player.stabGeneration || 0,
+            damageMitigation: mitigation.total,
+            damageMitigationBreakdown: {
+                barrierAbsorbed: mitigation.barrierAbsorbed,
+                reductionFraction: mitigation.reductionFraction,
+                estimatedReduction: mitigation.estimatedReduction,
+                blockedCount: mitigation.blockedCount,
+                invulnCount: mitigation.invulnCount,
+                preventedFromBlocks: mitigation.preventedFromBlocks,
+                averageHit: mitigation.averageHit,
+                reductionUptimes: mitigation.reductionUptimes,
+                reductionPerHitUptimes: mitigation.reductionPerHitUptimes,
+            },
         };
     });
 

--- a/src/main/discord.ts
+++ b/src/main/discord.ts
@@ -12,9 +12,12 @@ import {
     getPlayerDeaths,
     getPlayerDistanceToTag,
     getPlayerDodges,
+    getPlayerDownedHealing,
+    getPlayerDamageMitigation,
     getPlayerMissed,
     getPlayerBlocked,
     getPlayerEvaded,
+    getPlayerInvulns,
     getPlayerResurrects,
     getPlayerSquadHealing,
     getPlayerSquadBarrier,
@@ -49,6 +52,11 @@ export interface IEmbedStatSettings {
     showDamageTaken: boolean;
     showDeaths: boolean;
     showDodges: boolean;
+    showDownedHealing: boolean;
+    showDamageMitigation: boolean;
+    showInvulns: boolean;
+    showEvades: boolean;
+    showBlocks: boolean;
     maxTopListRows: number;
     classDisplay: 'off' | 'short' | 'emoji';
 }
@@ -75,6 +83,11 @@ const DEFAULT_EMBED_STATS: IEmbedStatSettings = {
     showDamageTaken: false,
     showDeaths: false,
     showDodges: false,
+    showDownedHealing: false,
+    showDamageMitigation: false,
+    showInvulns: false,
+    showEvades: false,
+    showBlocks: false,
     maxTopListRows: 10,
     classDisplay: 'off',
 };
@@ -503,6 +516,11 @@ export class DiscordNotifier {
                     const getDamageTaken = (p: any) => getPlayerDamageTaken(p);
                     const getDeaths = (p: any) => getPlayerDeaths(p);
                     const getDodges = (p: any) => getPlayerDodges(p);
+                    const getDownedHealing = (p: any) => getPlayerDownedHealing(p);
+                    const getDamageMitigation = (p: any) => getPlayerDamageMitigation(p, { buffMap: jsonDetails.buffMap });
+                    const getInvulns = (p: any) => getPlayerInvulns(p);
+                    const getEvades = (p: any) => getPlayerEvaded(p);
+                    const getBlocks = (p: any) => getPlayerBlocked(p);
 
                     const topListItems: Array<{
                         enabled: boolean;
@@ -621,6 +639,41 @@ export class DiscordNotifier {
                                 title: "Dodges",
                                 sortFn: (a: any, b: any) => getDodges(b) - getDodges(a),
                                 valFn: (p: any) => getDodges(p),
+                        fmtVal: (v: any) => fmtInt(v)
+                            },
+                            {
+                                enabled: settings.showDownedHealing,
+                                title: "Downed Healing",
+                                sortFn: (a: any, b: any) => getDownedHealing(b) - getDownedHealing(a),
+                                valFn: (p: any) => getDownedHealing(p),
+                        fmtVal: (v: any) => fmtInt(v)
+                            },
+                            {
+                                enabled: settings.showDamageMitigation,
+                                title: "Damage Mitigation",
+                                sortFn: (a: any, b: any) => getDamageMitigation(b) - getDamageMitigation(a),
+                                valFn: (p: any) => getDamageMitigation(p),
+                        fmtVal: (v: any) => fmtInt(v)
+                            },
+                            {
+                                enabled: settings.showInvulns,
+                                title: "Invulns",
+                                sortFn: (a: any, b: any) => getInvulns(b) - getInvulns(a),
+                                valFn: (p: any) => getInvulns(p),
+                        fmtVal: (v: any) => fmtInt(v)
+                            },
+                            {
+                                enabled: settings.showEvades,
+                                title: "Evades",
+                                sortFn: (a: any, b: any) => getEvades(b) - getEvades(a),
+                                valFn: (p: any) => getEvades(p),
+                        fmtVal: (v: any) => fmtInt(v)
+                            },
+                            {
+                                enabled: settings.showBlocks,
+                                title: "Blocks",
+                                sortFn: (a: any, b: any) => getBlocks(b) - getBlocks(a),
+                                valFn: (p: any) => getBlocks(p),
                         fmtVal: (v: any) => fmtInt(v)
                             }
                         ];

--- a/src/main/dpsReportTypes.ts
+++ b/src/main/dpsReportTypes.ts
@@ -93,6 +93,9 @@ export interface Defenses {
     dodgeCount: number;
     interruptedCount: number;
     damageTaken: number;
+    damageBarrier?: number;
+    damageBarrierCount?: number;
+    invulnedCount?: number;
     boonStrips?: number; // Incoming strips often appear here or in support depending on parsing context, adding as optional
     boonStripsTime?: number;
     receivedCrowdControl?: number;

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1287,6 +1287,11 @@ if (!gotTheLock) {
             showDamageTaken: false,
             showDeaths: false,
             showDodges: false,
+            showDownedHealing: false,
+            showDamageMitigation: false,
+            showInvulns: false,
+            showEvades: false,
+            showBlocks: false,
             maxTopListRows: 10,
             classDisplay: 'off',
         };

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -105,7 +105,12 @@ function App() {
         embedStatSettings.showBreakbarDamage,
         embedStatSettings.showDamageTaken,
         embedStatSettings.showDeaths,
-        embedStatSettings.showDodges
+        embedStatSettings.showDodges,
+        embedStatSettings.showDownedHealing,
+        embedStatSettings.showDamageMitigation,
+        embedStatSettings.showInvulns,
+        embedStatSettings.showEvades,
+        embedStatSettings.showBlocks
     ].filter(Boolean).length;
     const showClassIcons = notificationType === 'image' || notificationType === 'image-beta';
 

--- a/src/renderer/ExpandableLogCard.tsx
+++ b/src/renderer/ExpandableLogCard.tsx
@@ -1,6 +1,6 @@
 import { motion, AnimatePresence } from 'framer-motion';
 import { ChevronDown, ChevronUp, ExternalLink } from 'lucide-react';
-import { applyStabilityGeneration, getIncomingDisruptions, getPlayerDamage, getPlayerDps, getPlayerDownsTaken, getPlayerDeaths, getPlayerDamageTaken, getPlayerDodges, getPlayerMissed, getPlayerBlocked, getPlayerEvaded, getPlayerResurrects, getPlayerDownContribution, getPlayerOutgoingCrowdControl, getPlayerSquadBarrier, getPlayerSquadHealing, getTargetStatTotal } from '../shared/dashboardMetrics';
+import { applyStabilityGeneration, getIncomingDisruptions, getPlayerDamage, getPlayerDps, getPlayerDownsTaken, getPlayerDeaths, getPlayerDamageTaken, getPlayerDodges, getPlayerDownedHealing, getPlayerDamageMitigation, getPlayerMissed, getPlayerBlocked, getPlayerEvaded, getPlayerInvulns, getPlayerResurrects, getPlayerDownContribution, getPlayerOutgoingCrowdControl, getPlayerSquadBarrier, getPlayerSquadHealing, getTargetStatTotal } from '../shared/dashboardMetrics';
 import { Player } from '../shared/dpsReportTypes';
 import { DEFAULT_DISRUPTION_METHOD, DEFAULT_EMBED_STATS, DisruptionMethod, IEmbedStatSettings } from './global.d';
 import { getProfessionAbbrev, getProfessionEmoji, getProfessionIconPath } from '../shared/professionUtils';
@@ -427,6 +427,41 @@ export function ExpandableLogCard({ log, isExpanded, onToggle, onCancel, screens
             title: "Dodges",
             sortFn: (a: any, b: any) => getDodges(b) - getDodges(a),
             valFn: (p: any) => getDodges(p),
+            fmtVal: (v: number) => v.toString()
+        },
+        {
+            enabled: settings.showDownedHealing,
+            title: "Downed Healing",
+            sortFn: (a: any, b: any) => getPlayerDownedHealing(b) - getPlayerDownedHealing(a),
+            valFn: (p: any) => getPlayerDownedHealing(p),
+            fmtVal: (v: number) => v.toLocaleString()
+        },
+        {
+            enabled: settings.showDamageMitigation,
+            title: "Damage Mitigation",
+            sortFn: (a: any, b: any) => getPlayerDamageMitigation(b, { buffMap: details.buffMap }) - getPlayerDamageMitigation(a, { buffMap: details.buffMap }),
+            valFn: (p: any) => getPlayerDamageMitigation(p, { buffMap: details.buffMap }),
+            fmtVal: (v: number) => v.toLocaleString()
+        },
+        {
+            enabled: settings.showInvulns,
+            title: "Invulns",
+            sortFn: (a: any, b: any) => getPlayerInvulns(b) - getPlayerInvulns(a),
+            valFn: (p: any) => getPlayerInvulns(p),
+            fmtVal: (v: number) => v.toString()
+        },
+        {
+            enabled: settings.showEvades,
+            title: "Evades",
+            sortFn: (a: any, b: any) => getPlayerEvaded(b) - getPlayerEvaded(a),
+            valFn: (p: any) => getPlayerEvaded(p),
+            fmtVal: (v: number) => v.toString()
+        },
+        {
+            enabled: settings.showBlocks,
+            title: "Blocks",
+            sortFn: (a: any, b: any) => getPlayerBlocked(b) - getPlayerBlocked(a),
+            valFn: (p: any) => getPlayerBlocked(p),
             fmtVal: (v: number) => v.toString()
         }
     ];

--- a/src/renderer/SettingsView.tsx
+++ b/src/renderer/SettingsView.tsx
@@ -601,6 +601,11 @@ export function SettingsView({ onBack, onEmbedStatSettingsSaved, onOpenWhatsNew,
             showDamageTaken: enabled,
             showDeaths: enabled,
             showDodges: enabled,
+            showDownedHealing: enabled,
+            showDamageMitigation: enabled,
+            showInvulns: enabled,
+            showEvades: enabled,
+            showBlocks: enabled,
         }));
     };
 
@@ -610,7 +615,9 @@ export function SettingsView({ onBack, onEmbedStatSettingsSaved, onOpenWhatsNew,
         embedStats.showResurrects && embedStats.showDistanceToTag &&
         embedStats.showKills && embedStats.showDowns &&
         embedStats.showBreakbarDamage && embedStats.showDamageTaken &&
-        embedStats.showDeaths && embedStats.showDodges;
+        embedStats.showDeaths && embedStats.showDodges &&
+        embedStats.showDownedHealing && embedStats.showDamageMitigation &&
+        embedStats.showInvulns && embedStats.showEvades && embedStats.showBlocks;
 
     return (
         <div className="flex flex-col h-full min-h-0">
@@ -1226,6 +1233,36 @@ export function SettingsView({ onBack, onEmbedStatSettingsSaved, onOpenWhatsNew,
                                 onChange={(v) => updateEmbedStat('showDodges', v)}
                                 label="Dodges"
                                 description="Number of dodges performed"
+                            />
+                            <Toggle
+                                enabled={embedStats.showDownedHealing}
+                                onChange={(v) => updateEmbedStat('showDownedHealing', v)}
+                                label="Downed Healing"
+                                description="Healing done to downed allies"
+                            />
+                            <Toggle
+                                enabled={embedStats.showDamageMitigation}
+                                onChange={(v) => updateEmbedStat('showDamageMitigation', v)}
+                                label="Damage Mitigation"
+                                description="Barrier + protection/reduction buffs + blocks + invulns"
+                            />
+                            <Toggle
+                                enabled={embedStats.showInvulns}
+                                onChange={(v) => updateEmbedStat('showInvulns', v)}
+                                label="Invulns"
+                                description="Times attacks were made while invulnerable"
+                            />
+                            <Toggle
+                                enabled={embedStats.showEvades}
+                                onChange={(v) => updateEmbedStat('showEvades', v)}
+                                label="Evades"
+                                description="Times attacks were evaded"
+                            />
+                            <Toggle
+                                enabled={embedStats.showBlocks}
+                                onChange={(v) => updateEmbedStat('showBlocks', v)}
+                                label="Blocks"
+                                description="Times attacks were blocked"
                             />
                         </div>
                     </div>

--- a/src/renderer/global.d.ts
+++ b/src/renderer/global.d.ts
@@ -31,6 +31,11 @@ export interface IEmbedStatSettings {
     showDamageTaken: boolean;
     showDeaths: boolean;
     showDodges: boolean;
+    showDownedHealing: boolean;
+    showDamageMitigation: boolean;
+    showInvulns: boolean;
+    showEvades: boolean;
+    showBlocks: boolean;
     maxTopListRows: number;
     classDisplay: 'off' | 'short' | 'emoji';
 }
@@ -77,6 +82,11 @@ export const DEFAULT_EMBED_STATS: IEmbedStatSettings = {
     showDamageTaken: false,
     showDeaths: false,
     showDodges: false,
+    showDownedHealing: false,
+    showDamageMitigation: false,
+    showInvulns: false,
+    showEvades: false,
+    showBlocks: false,
     maxTopListRows: 10,
     classDisplay: 'off',
 };

--- a/src/shared/dashboardMetrics.ts
+++ b/src/shared/dashboardMetrics.ts
@@ -1,5 +1,5 @@
 import { Player } from './dpsReportTypes';
-import { applySquadStabilityGeneration, computeDownContribution, computeIncomingDisruptions, computeOutgoingCrowdControl, computeSquadBarrier, computeSquadHealing, resolveDisruptionValue } from './combatMetrics';
+import { applySquadStabilityGeneration, computeDamageMitigation, computeDownContribution, computeIncomingDisruptions, computeOutgoingCrowdControl, computeSquadBarrier, computeSquadDownedHealing, computeSquadHealing, resolveDisruptionValue } from './combatMetrics';
 import { DisruptionMethod, DEFAULT_DISRUPTION_METHOD } from './metricsSettings';
 
 export const getPlayerDamage = (player: Player) =>
@@ -51,6 +51,12 @@ export const getPlayerBlocked = (player: Player) =>
 export const getPlayerEvaded = (player: Player) =>
     player.defenses?.[0]?.evadedCount || 0;
 
+export const getPlayerInvulns = (player: Player) =>
+    player.defenses?.[0]?.invulnedCount || 0;
+
+export const getPlayerDamageMitigation = (player: Player, context?: { buffMap?: Record<string, any> }) =>
+    computeDamageMitigation(player, context);
+
 export const getPlayerDownsTaken = (player: Player) =>
     player.defenses?.[0]?.downCount || 0;
 
@@ -82,6 +88,9 @@ export const getPlayerDownContribution = (player: Player) =>
 
 export const getPlayerSquadHealing = (player: Player) =>
     computeSquadHealing(player);
+
+export const getPlayerDownedHealing = (player: Player) =>
+    computeSquadDownedHealing(player);
 
 export const getPlayerSquadBarrier = (player: Player) =>
     computeSquadBarrier(player);

--- a/src/shared/dpsReportTypes.ts
+++ b/src/shared/dpsReportTypes.ts
@@ -93,6 +93,9 @@ export interface Defenses {
     dodgeCount: number;
     interruptedCount: number;
     damageTaken: number;
+    damageBarrier?: number;
+    damageBarrierCount?: number;
+    invulnedCount?: number;
     boonStrips?: number; // Incoming strips often appear here or in support depending on parsing context, adding as optional
     boonStripsTime?: number;
     receivedCrowdControl?: number;


### PR DESCRIPTION
- Implemented computeDamageMitigationBreakdown and computeDamageMitigation functions to calculate damage mitigation from various sources.
- Enhanced player metrics to include damage mitigation breakdown in metrics-audit.
- Updated DiscordNotifier to display new metrics: Downed Healing, Damage Mitigation, Invulns, Evades, and Blocks.
- Modified settings and UI components to allow toggling of new metrics.
- Added new functions to fetch and compute squad downed healing and damage mitigation.
- Updated documentation to reflect new metrics and their calculations.
- Created a script to fetch and parse damage reduction data from GW2Skills.