### PR TITLE
feat: add Damage Modifiers and Incoming Damage Modifiers stats sections

### DIFF
--- a/src/main/detailsProcessing.ts
+++ b/src/main/detailsProcessing.ts
@@ -102,7 +102,8 @@ const TOP_LEVEL_KEYS = [
     'combatReplayMetaData', 'skillMap', 'buffMap', 'encounterDuration',
     'player_damage_mitigation', 'player_minion_damage_mitigation',
     'playerDamageMitigation', 'playerMinionDamageMitigation',
-    'damageModMap'
+    'damageModMap',
+    'personalDamageMods'
 ];
 
 /**

--- a/src/main/detailsProcessing.ts
+++ b/src/main/detailsProcessing.ts
@@ -83,7 +83,8 @@ const PLAYER_KEYS = [
     'powerDamage1S', 'conditionDamage1S', 'powerDamageTaken1S', 'targetPowerDamage1S',
     'totalDamageTaken', 'totalDamageTakenDist', 'minions', 'combatReplayData',
     'hasCommanderTag', 'notInSquad', 'account', 'activeTimes',
-    'teamID', 'teamId', 'team', 'teamColor', 'team_color'
+    'teamID', 'teamId', 'team', 'teamColor', 'team_color',
+    'damageModifiers', 'incomingDamageModifiers'
 ];
 
 const TARGET_KEYS = [
@@ -100,7 +101,8 @@ const TOP_LEVEL_KEYS = [
     'permalink', 'uploadLinks', 'success', 'teamBreakdown', 'teamCounts',
     'combatReplayMetaData', 'skillMap', 'buffMap', 'encounterDuration',
     'player_damage_mitigation', 'player_minion_damage_mitigation',
-    'playerDamageMitigation', 'playerMinionDamageMitigation'
+    'playerDamageMitigation', 'playerMinionDamageMitigation',
+    'damageModMap'
 ];
 
 /**

--- a/src/main/dpsReportTypes.ts
+++ b/src/main/dpsReportTypes.ts
@@ -36,6 +36,7 @@ export interface DPSReportJSON {
     buffMap?: { [key: string]: { name: string; stacking: boolean; icon?: string; classification?: string } };
     combatReplayMetaData?: { inchToPixel?: number; pollingRate?: number };
     damageModMap?: Record<string, DamageModifierInfo>;
+    personalDamageMods?: Record<string, number[]>;
 }
 
 export interface Target {

--- a/src/main/dpsReportTypes.ts
+++ b/src/main/dpsReportTypes.ts
@@ -1,3 +1,23 @@
+export interface DamageModifierInfo {
+    name: string;
+    icon: string;
+    description: string;
+    nonMultiplier: boolean;
+    skillBased: boolean;
+    approximate: boolean;
+    incoming: boolean;
+}
+
+export interface DamageModifierData {
+    id: number;
+    damageModifiers: Array<{
+        hitCount: number;
+        totalHitCount: number;
+        damageGain: number;
+        totalDamage: number;
+    }>;
+}
+
 export interface DPSReportJSON {
     evtc: {
         type: string;
@@ -15,6 +35,8 @@ export interface DPSReportJSON {
     skillMap?: { [key: string]: { name: string; icon: string } };
     buffMap?: { [key: string]: { name: string; stacking: boolean; icon?: string; classification?: string } };
     combatReplayMetaData?: { inchToPixel?: number; pollingRate?: number };
+    damageModMap?: Record<string, DamageModifierInfo>;
+    personalDamageMods?: Record<string, number[]>;
 }
 
 export interface Target {
@@ -70,6 +92,8 @@ export interface Player {
     account?: string;
     stabGeneration?: number; // Calculated field
     activeTimes?: number[];
+    damageModifiers?: DamageModifierData[];
+    incomingDamageModifiers?: DamageModifierData[];
 }
 
 export interface StatsAll {

--- a/src/main/dpsReportTypes.ts
+++ b/src/main/dpsReportTypes.ts
@@ -36,7 +36,6 @@ export interface DPSReportJSON {
     buffMap?: { [key: string]: { name: string; stacking: boolean; icon?: string; classification?: string } };
     combatReplayMetaData?: { inchToPixel?: number; pollingRate?: number };
     damageModMap?: Record<string, DamageModifierInfo>;
-    personalDamageMods?: Record<string, number[]>;
 }
 
 export interface Target {

--- a/src/main/dpsReportTypes.ts
+++ b/src/main/dpsReportTypes.ts
@@ -2,9 +2,9 @@ export interface DamageModifierInfo {
     name: string;
     icon: string;
     description: string;
-    nonMultiplier: boolean;
-    skillBased: boolean;
-    approximate: boolean;
+    nonMultiplier?: boolean;
+    skillBased?: boolean;
+    approximate?: boolean;
     incoming: boolean;
 }
 

--- a/src/main/handlers/uploadHandlers.ts
+++ b/src/main/handlers/uploadHandlers.ts
@@ -148,7 +148,7 @@ export function registerUploadHandlers(opts: UploadHandlerOptions) {
             return { success: false, error: 'Missing filePath.' };
         }
         const details = getBulkLogDetails(filePath);
-        if (details && hasUsableFightDetails(details)) {
+        if (details && hasUsableFightDetails(details) && details.damageModMap) {
             return { success: true, details };
         }
         if (permalink) {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -385,7 +385,10 @@ const processLogFile = async (filePath: string, options?: { retry?: boolean }) =
                 console.log(`[Main] Upload successful: ${result.permalink}. Fetching details...`);
             }
 
-            let jsonDetails = cached?.jsonDetails || await uploader.fetchDetailedJson(result.permalink);
+            const cachedDetails = cached?.jsonDetails;
+            // Re-fetch if cached details are missing damageModMap (added in a later version)
+            const needsRefresh = cachedDetails && !cachedDetails.damageModMap;
+            let jsonDetails = (cachedDetails && !needsRefresh) ? cachedDetails : await uploader.fetchDetailedJson(result.permalink);
             if (cached?.entry?.result && isDetailsPermalinkNotFound(jsonDetails)) {
                 console.warn(`[Cache] Cached permalink returned 404 for ${filePath}. Re-uploading to refresh permalink.`);
                 if (cacheKey) {

--- a/src/renderer/StatsView.tsx
+++ b/src/renderer/StatsView.tsx
@@ -29,6 +29,7 @@ import { DamageBreakdownSection } from './stats/sections/DamageBreakdownSection'
 import { BoonTimelineSection } from './stats/sections/BoonTimelineSection';
 import { BoonUptimeSection } from './stats/sections/BoonUptimeSection';
 import { OffenseSection } from './stats/sections/OffenseSection';
+import { DamageModifiersSection } from './stats/sections/DamageModifiersSection';
 import { ConditionsSection } from './stats/sections/ConditionsSection';
 import { BoonOutputSection } from './stats/sections/BoonOutputSection';
 import { DefenseSection } from './stats/sections/DefenseSection';
@@ -109,11 +110,13 @@ const ORDERED_SECTION_IDS = [
     'boon-timeline',
     'boon-uptime',
     'offense-detailed',
+    'damage-modifiers',
     'player-breakdown',
     'damage-breakdown',
     'spike-damage',
     'conditions-outgoing',
     'defense-detailed',
+    'incoming-damage-modifiers',
     'incoming-strike-damage',
     'support-detailed',
     'healing-stats',
@@ -619,6 +622,10 @@ export function StatsView({ logs, onBack: _onBack, mvpWeights, statsViewSettings
     const [cleanseScope, setCleanseScope] = useState<'squad' | 'all'>('all');
     const [timelineFriendlyScope, setTimelineFriendlyScope] = useState<'squad' | 'squadAllies'>('squad');
     const [damageMitigationScope, setDamageMitigationScope] = useState<'player' | 'minions'>('player');
+    const [damageModSearch, setDamageModSearch] = useState('');
+    const [activeDamageMod, setActiveDamageMod] = useState('');
+    const [incomingDamageModSearch, setIncomingDamageModSearch] = useState('');
+    const [activeIncomingDamageMod, setActiveIncomingDamageMod] = useState('');
 
 
 
@@ -3705,6 +3712,14 @@ type SpikeFight = {
                                 setOffenseViewMode={setOffenseViewMode}
                             />
 
+                            <DamageModifiersSection
+                                search={damageModSearch}
+                                setSearch={setDamageModSearch}
+                                activeMod={activeDamageMod}
+                                setActiveMod={setActiveDamageMod}
+                                incoming={false}
+                            />
+
                             <PlayerBreakdownSection
                                 viewMode={playerBreakdownViewMode}
                                 setViewMode={setPlayerBreakdownViewMode}
@@ -3780,6 +3795,14 @@ type SpikeFight = {
                                 setActiveDefenseStat={setActiveDefenseStat}
                                 defenseViewMode={defenseViewMode}
                                 setDefenseViewMode={setDefenseViewMode}
+                            />
+
+                            <DamageModifiersSection
+                                search={incomingDamageModSearch}
+                                setSearch={setIncomingDamageModSearch}
+                                activeMod={activeIncomingDamageMod}
+                                setActiveMod={setActiveIncomingDamageMod}
+                                incoming={true}
                             />
 
                             <SpikeDamageSection
@@ -4052,6 +4075,14 @@ type SpikeFight = {
                             setOffenseViewMode={setOffenseViewMode}
                         />}
 
+                        {isSectionVisible('damage-modifiers') && <DamageModifiersSection
+                            search={damageModSearch}
+                            setSearch={setDamageModSearch}
+                            activeMod={activeDamageMod}
+                            setActiveMod={setActiveDamageMod}
+                            incoming={false}
+                        />}
+
                         {isSectionVisible('player-breakdown') && <PlayerBreakdownSection
                             viewMode={playerBreakdownViewMode}
                             setViewMode={setPlayerBreakdownViewMode}
@@ -4127,6 +4158,14 @@ type SpikeFight = {
                             setActiveDefenseStat={setActiveDefenseStat}
                             defenseViewMode={defenseViewMode}
                             setDefenseViewMode={setDefenseViewMode}
+                        />}
+
+                        {isSectionVisible('incoming-damage-modifiers') && <DamageModifiersSection
+                            search={incomingDamageModSearch}
+                            setSearch={setIncomingDamageModSearch}
+                            activeMod={activeIncomingDamageMod}
+                            setActiveMod={setActiveIncomingDamageMod}
+                            incoming={true}
                         />}
 
                         {isSectionVisible('incoming-strike-damage') && <SpikeDamageSection

--- a/src/renderer/app/hooks/useDetailsHydration.ts
+++ b/src/renderer/app/hooks/useDetailsHydration.ts
@@ -132,7 +132,10 @@ export function useDetailsHydration({
             const statsViewActive = viewRef.current === 'stats';
             const rawCandidates = logsRef.current
                 .filter((log) => {
-                    if (!log.filePath || log.details || log.statsDetailsLoaded) return false;
+                    if (!log.filePath) return false;
+                    // Re-hydrate if details exist but are missing damageModMap (stale pruning)
+                    const hasStaleDetails = log.details && !log.details.damageModMap;
+                    if ((log.details && !hasStaleDetails) || log.statsDetailsLoaded) return false;
                     if (log.detailsAvailable) return true;
                     return (log.status === 'success' || log.status === 'calculating' || log.status === 'discord') && Boolean(log.permalink);
                 })

--- a/src/renderer/stats/__tests__/damageModifierAggregation.test.ts
+++ b/src/renderer/stats/__tests__/damageModifierAggregation.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from 'vitest';
+import { computePlayerAggregation } from '../computePlayerAggregation';
+
+const makePlayer = (overrides: any = {}) => ({
+    account: 'TestPlayer.1234',
+    name: 'TestCharacter',
+    profession: 'Guardian',
+    notInSquad: false,
+    activeTimes: [60000],
+    dpsAll: [{ damage: 0, dps: 0 }],
+    statsAll: [{ connectedDamageCount: 0 }],
+    support: [{ resurrects: 0 }],
+    defenses: [{ downCount: 0, deadCount: 0 }],
+    damage1S: [[]],
+    targetDamage1S: [[[]]],
+    targetDamageDist: [[[]]],
+    totalDamageDist: [[]],
+    ...overrides,
+});
+
+const makeLog = (overrides: any = {}) => ({
+    status: 'success',
+    filePath: 'test-log',
+    details: {
+        durationMS: 60000,
+        fightName: 'Test Fight',
+        success: true,
+        players: [],
+        targets: [],
+        skillMap: {},
+        buffMap: {},
+        ...overrides,
+    },
+});
+
+const defaultArgs = {
+    method: 'count' as const,
+    skillDamageSource: 'target',
+    splitPlayersByClass: false,
+};
+
+describe('computePlayerAggregation (damage modifier aggregation)', () => {
+    it('aggregates outgoing damage modifiers across two fights', () => {
+        const player1 = makePlayer({
+            damageModifiers: [
+                {
+                    id: 44,
+                    damageModifiers: [
+                        { damageGain: 120, hitCount: 3, totalHitCount: 10, totalDamage: 5000 },
+                    ],
+                },
+            ],
+        });
+
+        const player2 = makePlayer({
+            damageModifiers: [
+                {
+                    id: 44,
+                    damageModifiers: [
+                        { damageGain: 80, hitCount: 2, totalHitCount: 8, totalDamage: 3000 },
+                    ],
+                },
+            ],
+        });
+
+        const log1 = makeLog({ players: [player1] });
+        const log2 = makeLog({ filePath: 'test-log-2', players: [player2] });
+
+        const { playerStats } = computePlayerAggregation({
+            validLogs: [log1, log2],
+            ...defaultArgs,
+        });
+
+        const ps = playerStats.get('TestPlayer.1234');
+        expect(ps).toBeTruthy();
+        const mod = ps!.damageModTotals['d44'];
+        expect(mod).toBeTruthy();
+        expect(mod.damageGain).toBe(200);
+        expect(mod.hitCount).toBe(5);
+        expect(mod.totalHitCount).toBe(18);
+        expect(mod.totalDamage).toBe(8000);
+    });
+
+    it('aggregates incoming damage modifiers with negative damageGain values', () => {
+        const player1 = makePlayer({
+            incomingDamageModifiers: [
+                {
+                    id: -58,
+                    damageModifiers: [
+                        { damageGain: -150, hitCount: 4, totalHitCount: 12, totalDamage: 7500 },
+                    ],
+                },
+            ],
+        });
+
+        const player2 = makePlayer({
+            incomingDamageModifiers: [
+                {
+                    id: -58,
+                    damageModifiers: [
+                        { damageGain: -90, hitCount: 3, totalHitCount: 9, totalDamage: 4200 },
+                    ],
+                },
+            ],
+        });
+
+        const log1 = makeLog({ players: [player1] });
+        const log2 = makeLog({ filePath: 'test-log-2', players: [player2] });
+
+        const { playerStats } = computePlayerAggregation({
+            validLogs: [log1, log2],
+            ...defaultArgs,
+        });
+
+        const ps = playerStats.get('TestPlayer.1234');
+        expect(ps).toBeTruthy();
+        const mod = ps!.incomingDamageModTotals['d-58'];
+        expect(mod).toBeTruthy();
+        expect(mod.damageGain).toBe(-240);
+        expect(mod.hitCount).toBe(7);
+        expect(mod.totalHitCount).toBe(21);
+        expect(mod.totalDamage).toBe(11700);
+    });
+
+    it('produces empty damageModTotals and incomingDamageModTotals when no modifier data is present', () => {
+        const player = makePlayer();
+        const log = makeLog({ players: [player] });
+
+        const { playerStats } = computePlayerAggregation({
+            validLogs: [log],
+            ...defaultArgs,
+        });
+
+        const ps = playerStats.get('TestPlayer.1234');
+        expect(ps).toBeTruthy();
+        expect(Object.keys(ps!.damageModTotals)).toHaveLength(0);
+        expect(Object.keys(ps!.incomingDamageModTotals)).toHaveLength(0);
+    });
+});

--- a/src/renderer/stats/computePlayerAggregation.ts
+++ b/src/renderer/stats/computePlayerAggregation.ts
@@ -51,6 +51,8 @@ export interface PlayerStats {
     revives: number;
     outgoingConditions: Record<string, any>;
     incomingConditions: Record<string, any>;
+    damageModTotals: Record<string, { damageGain: number; hitCount: number; totalHitCount: number; totalDamage: number }>;
+    incomingDamageModTotals: Record<string, { damageGain: number; hitCount: number; totalHitCount: number; totalDamage: number }>;
 }
 
 export type DamageMitigationTotals = {
@@ -568,7 +570,7 @@ export const computePlayerAggregation = ({
                     totalDist: 0, distCount: 0, dodges: 0, downs: 0, deaths: 0, totalFightMs: 0,
                     offenseTotals: {}, offenseRateWeights: {}, defenseActiveMs: 0, defenseTotals: {}, defenseMinionDamageTaken: {}, supportActiveMs: 0, supportTotals: {},
                     healingActiveMs: 0, healingTotals: {}, profession: identity.profession, professions: new Set(),
-                    professionTimeMs: {}, squadActiveMs: 0, firstSeenFightTs: 0, lastSeenFightTs: 0, lastSeenFightDurationMs: 0, isCommander: false, damage: 0, dps: 0, revives: 0, outgoingConditions: {}, incomingConditions: {}
+                    professionTimeMs: {}, squadActiveMs: 0, firstSeenFightTs: 0, lastSeenFightTs: 0, lastSeenFightDurationMs: 0, isCommander: false, damage: 0, dps: 0, revives: 0, outgoingConditions: {}, incomingConditions: {}, damageModTotals: {}, incomingDamageModTotals: {}
                 });
             }
             const s = playerStats.get(key)!;
@@ -1046,6 +1048,52 @@ export const computePlayerAggregation = ({
                         incomingSkillDamageMap[entry.id].hits += entry.hits;
                     });
                 });
+            }
+
+            // Aggregate outgoing damage modifiers
+            if (p.damageModifiers) {
+                for (const entry of p.damageModifiers) {
+                    const phase0 = entry.damageModifiers?.[0];
+                    if (!phase0) continue;
+                    const key = `d${entry.id}`;
+                    const existing = s.damageModTotals[key];
+                    if (existing) {
+                        existing.damageGain += phase0.damageGain;
+                        existing.hitCount += phase0.hitCount;
+                        existing.totalHitCount += phase0.totalHitCount;
+                        existing.totalDamage += phase0.totalDamage;
+                    } else {
+                        s.damageModTotals[key] = {
+                            damageGain: phase0.damageGain,
+                            hitCount: phase0.hitCount,
+                            totalHitCount: phase0.totalHitCount,
+                            totalDamage: phase0.totalDamage,
+                        };
+                    }
+                }
+            }
+
+            // Aggregate incoming damage modifiers
+            if (p.incomingDamageModifiers) {
+                for (const entry of p.incomingDamageModifiers) {
+                    const phase0 = entry.damageModifiers?.[0];
+                    if (!phase0) continue;
+                    const key = `d${entry.id}`;
+                    const existing = s.incomingDamageModTotals[key];
+                    if (existing) {
+                        existing.damageGain += phase0.damageGain;
+                        existing.hitCount += phase0.hitCount;
+                        existing.totalHitCount += phase0.totalHitCount;
+                        existing.totalDamage += phase0.totalDamage;
+                    } else {
+                        s.incomingDamageModTotals[key] = {
+                            damageGain: phase0.damageGain,
+                            hitCount: phase0.hitCount,
+                            totalHitCount: phase0.totalHitCount,
+                            totalDamage: phase0.totalDamage,
+                        };
+                    }
+                }
             }
         });
 

--- a/src/renderer/stats/computeStatsAggregation.ts
+++ b/src/renderer/stats/computeStatsAggregation.ts
@@ -140,10 +140,12 @@ export const computeStatsAggregation = ({ logs, precomputedStats, mvpWeights, st
         const splitPlayersByClass = Boolean(activeStatsViewSettings.splitPlayersByClass);
         const total = validLogs.length;
 
-        // Merge damageModMap across all logs (data lives under log.details)
+        // Merge damageModMap and personalDamageMods across all logs (data lives under log.details)
         const mergedDamageModMap: Record<string, { name: string; icon: string; description: string; incoming: boolean }> = {};
+        const personalDamageModKeys = new Set<string>();
         for (const log of validLogs) {
-            const modMap = (log as any).details?.damageModMap;
+            const details = (log as any).details;
+            const modMap = details?.damageModMap;
             if (modMap && typeof modMap === 'object') {
                 for (const [key, value] of Object.entries(modMap)) {
                     if (!mergedDamageModMap[key] && value && typeof value === 'object') {
@@ -154,6 +156,14 @@ export const computeStatsAggregation = ({ logs, precomputedStats, mvpWeights, st
                             description: v.description ?? '',
                             incoming: v.incoming ?? false,
                         };
+                    }
+                }
+            }
+            const personalMods = details?.personalDamageMods;
+            if (personalMods && typeof personalMods === 'object') {
+                for (const ids of Object.values(personalMods)) {
+                    if (Array.isArray(ids)) {
+                        for (const id of ids) personalDamageModKeys.add(`d${id}`);
                     }
                 }
             }
@@ -696,6 +706,7 @@ export const computeStatsAggregation = ({ logs, precomputedStats, mvpWeights, st
                 healingTotals: s.healingTotals, activeMs: s.healingActiveMs
             })),
             damageModMap: mergedDamageModMap,
+            personalDamageModKeys: Array.from(personalDamageModKeys),
             damageModPlayers: Array.from(playerStats.values()).map(s => ({
                 account: s.account, profession: s.profession, professionList: s.professionList,
                 damageModTotals: s.damageModTotals, totalFightMs: s.totalFightMs,

--- a/src/renderer/stats/computeStatsAggregation.ts
+++ b/src/renderer/stats/computeStatsAggregation.ts
@@ -140,6 +140,25 @@ export const computeStatsAggregation = ({ logs, precomputedStats, mvpWeights, st
         const splitPlayersByClass = Boolean(activeStatsViewSettings.splitPlayersByClass);
         const total = validLogs.length;
 
+        // Merge damageModMap across all logs (data lives under log.details)
+        const mergedDamageModMap: Record<string, { name: string; icon: string; description: string; incoming: boolean }> = {};
+        for (const log of validLogs) {
+            const modMap = (log as any).details?.damageModMap;
+            if (modMap && typeof modMap === 'object') {
+                for (const [key, value] of Object.entries(modMap)) {
+                    if (!mergedDamageModMap[key] && value && typeof value === 'object') {
+                        const v = value as any;
+                        mergedDamageModMap[key] = {
+                            name: v.name ?? '',
+                            icon: v.icon ?? '',
+                            description: v.description ?? '',
+                            incoming: v.incoming ?? false,
+                        };
+                    }
+                }
+            }
+        }
+
         const {
             playerStats, skillDamageMap, incomingSkillDamageMap, playerSkillBreakdownMap,
             outgoingCondiTotals, incomingCondiTotals, enemyProfessionCounts,
@@ -675,6 +694,15 @@ export const computeStatsAggregation = ({ logs, precomputedStats, mvpWeights, st
             healingPlayers: Array.from(playerStats.values()).map(s => ({
                 account: s.account, profession: s.profession, professionList: s.professionList,
                 healingTotals: s.healingTotals, activeMs: s.healingActiveMs
+            })),
+            damageModMap: mergedDamageModMap,
+            damageModPlayers: Array.from(playerStats.values()).map(s => ({
+                account: s.account, profession: s.profession, professionList: s.professionList,
+                damageModTotals: s.damageModTotals, totalFightMs: s.totalFightMs,
+            })),
+            incomingDamageModPlayers: Array.from(playerStats.values()).map(s => ({
+                account: s.account, profession: s.profession, professionList: s.professionList,
+                incomingDamageModTotals: s.incomingDamageModTotals, totalFightMs: s.totalFightMs,
             })),
             offensiveMvp,
             offensiveSilver,

--- a/src/renderer/stats/hooks/useStatsNavigation.ts
+++ b/src/renderer/stats/hooks/useStatsNavigation.ts
@@ -1,6 +1,6 @@
 import type { ComponentType } from 'react';
 import { useRef, useState, useEffect, useMemo } from 'react';
-import { Trophy, Shield, ShieldAlert, Zap, Map as MapIcon, Users, Skull, Star, HeartPulse, Keyboard, ListTree, BarChart3, ArrowBigUp, FileText, Swords, GitCompareArrows, Clock3, Target, Route, Waves } from 'lucide-react';
+import { Trophy, Shield, ShieldAlert, ShieldOff, Zap, Map as MapIcon, Users, Skull, Star, HeartPulse, Keyboard, ListTree, BarChart3, ArrowBigUp, FileText, Swords, GitCompareArrows, Clock3, Target, Route, Waves, Flame } from 'lucide-react';
 import { CommanderTagIcon } from '../../ui/CommanderTagIcon';
 import { SupportPlusIcon } from '../../ui/SupportPlusIcon';
 import { Gw2ApmIcon } from '../../ui/Gw2ApmIcon';
@@ -79,9 +79,10 @@ export const STATS_TOC_GROUPS: readonly StatsTocGroup[] = [
         id: 'offense',
         label: 'Offensive Stats',
         icon: Swords,
-        sectionIds: ['offense-detailed', 'player-breakdown', 'damage-breakdown', 'spike-damage', 'conditions-outgoing'],
+        sectionIds: ['offense-detailed', 'damage-modifiers', 'player-breakdown', 'damage-breakdown', 'spike-damage', 'conditions-outgoing'],
         items: [
             { id: 'offense-detailed', label: 'Offense Detailed', icon: Swords },
+            { id: 'damage-modifiers', label: 'Damage Modifiers', icon: Flame },
             { id: 'player-breakdown', label: 'Player Breakdown', icon: ListTree },
             { id: 'damage-breakdown', label: 'Damage Breakdown', icon: BarChart3 },
             { id: 'spike-damage', label: 'Spike Damage', icon: Zap },
@@ -92,9 +93,10 @@ export const STATS_TOC_GROUPS: readonly StatsTocGroup[] = [
         id: 'defense',
         label: 'Defensive Stats',
         icon: Shield,
-        sectionIds: ['defense-detailed', 'incoming-strike-damage', 'defense-mitigation', 'boon-output', 'boon-timeline', 'boon-uptime', 'support-detailed', 'healing-stats', 'heal-effectiveness'],
+        sectionIds: ['defense-detailed', 'incoming-damage-modifiers', 'incoming-strike-damage', 'defense-mitigation', 'boon-output', 'boon-timeline', 'boon-uptime', 'support-detailed', 'healing-stats', 'heal-effectiveness'],
         items: [
             { id: 'defense-detailed', label: 'Defense Detailed', icon: Shield },
+            { id: 'incoming-damage-modifiers', label: 'Incoming Modifiers', icon: ShieldOff },
             { id: 'incoming-strike-damage', label: 'Incoming Strike Damage', icon: ShieldAlert },
             { id: 'defense-mitigation', label: 'Damage Mitigation', icon: Gw2DamMitIcon },
             { id: 'boon-output', label: 'Boon Output', icon: Gw2BoonIcon },

--- a/src/renderer/stats/sections/DamageModifiersSection.tsx
+++ b/src/renderer/stats/sections/DamageModifiersSection.tsx
@@ -79,8 +79,6 @@ export const DamageModifiersSection = ({
             for (const [modId, vals] of Object.entries(modTotals)) {
                 const info = modMap[modId];
                 if (!info) continue;
-                // Filter: only show modifiers matching the incoming flag
-                if (info.incoming !== incoming) continue;
                 if (!summaryMap[modId]) {
                     summaryMap[modId] = {
                         id: modId,

--- a/src/renderer/stats/sections/DamageModifiersSection.tsx
+++ b/src/renderer/stats/sections/DamageModifiersSection.tsx
@@ -1,0 +1,507 @@
+import { useMemo, useState } from 'react';
+import { Maximize2, X } from 'lucide-react';
+import { StatsTableLayout } from '../ui/StatsTableLayout';
+import { StatsTableShell } from '../ui/StatsTableShell';
+import { useStatsSharedContext } from '../StatsViewContext';
+
+type DamageModifiersSectionProps = {
+    search: string;
+    setSearch: (value: string) => void;
+    activeMod: string;
+    setActiveMod: (value: string) => void;
+    incoming: boolean;
+};
+
+const SECTION_CONFIG = {
+    outgoing: {
+        sectionId: 'damage-modifiers',
+        title: 'Damage Modifiers',
+        accentBg: 'bg-rose-500/20',
+        accentText: 'text-rose-200',
+        accentBorder: 'border-rose-500/40',
+        barGradient: 'from-rose-500/40 to-rose-500/15',
+    },
+    incoming: {
+        sectionId: 'incoming-damage-modifiers',
+        title: 'Incoming Damage Modifiers',
+        accentBg: 'bg-blue-500/20',
+        accentText: 'text-blue-200',
+        accentBorder: 'border-blue-500/40',
+        barGradient: 'from-blue-500/40 to-blue-500/15',
+    },
+};
+
+type ModTotals = { damageGain: number; hitCount: number; totalHitCount: number; totalDamage: number };
+type ModMapEntry = { name: string; icon: string; description: string; incoming: boolean };
+
+type ModSummary = {
+    id: string;
+    name: string;
+    icon: string;
+    description: string;
+    squadDamageGain: number;
+};
+
+export const DamageModifiersSection = ({
+    search,
+    setSearch,
+    activeMod,
+    setActiveMod,
+    incoming,
+}: DamageModifiersSectionProps) => {
+    const {
+        stats, formatWithCommas, renderProfessionIcon,
+        expandedSection, expandedSectionClosing,
+        openExpandedSection, closeExpandedSection,
+        isSectionVisible, isFirstVisibleSection,
+        sectionClass, sidebarListClass,
+    } = useStatsSharedContext();
+
+    const config = incoming ? SECTION_CONFIG.incoming : SECTION_CONFIG.outgoing;
+    const isExpanded = expandedSection === config.sectionId;
+
+    // --- Data access ---
+    const modMap: Record<string, ModMapEntry> = (stats as any).damageModMap ?? {};
+    const playerRows: any[] = incoming
+        ? ((stats as any).incomingDamageModPlayers ?? [])
+        : ((stats as any).damageModPlayers ?? []);
+
+    const totalsKey = incoming ? 'incomingDamageModTotals' : 'damageModTotals';
+
+    // --- Build sorted modifier list ---
+    const modSummaries = useMemo<ModSummary[]>(() => {
+        const summaryMap: Record<string, ModSummary> = {};
+        for (const row of playerRows) {
+            const modTotals: Record<string, ModTotals> = row[totalsKey] ?? {};
+            for (const [modId, vals] of Object.entries(modTotals)) {
+                const info = modMap[modId];
+                if (!info) continue;
+                // Filter: only show modifiers matching the incoming flag
+                if (info.incoming !== incoming) continue;
+                if (!summaryMap[modId]) {
+                    summaryMap[modId] = {
+                        id: modId,
+                        name: info.name,
+                        icon: info.icon,
+                        description: info.description,
+                        squadDamageGain: 0,
+                    };
+                }
+                summaryMap[modId].squadDamageGain += vals.damageGain;
+            }
+        }
+        return Object.values(summaryMap).sort(
+            (a, b) => Math.abs(b.squadDamageGain) - Math.abs(a.squadDamageGain)
+        );
+    }, [playerRows, modMap, incoming, totalsKey]);
+
+    // --- Filtered modifiers by search ---
+    const filteredMods = useMemo(() => {
+        const term = search.trim().toLowerCase();
+        if (!term) return modSummaries;
+        return modSummaries.filter((m) => m.name.toLowerCase().includes(term));
+    }, [modSummaries, search]);
+
+    // Auto-select first modifier if active one is gone
+    const effectiveActiveMod = filteredMods.find((m) => m.id === activeMod)
+        ? activeMod
+        : filteredMods[0]?.id ?? '';
+
+    const [collapsedSort, setCollapsedSort] = useState<{ key: 'damageGain' | 'pctTotal' | 'hitCoverage' | 'fightTime'; dir: 'asc' | 'desc' }>({
+        key: 'damageGain', dir: 'desc',
+    });
+
+    const updateCollapsedSort = (key: typeof collapsedSort.key) => {
+        setCollapsedSort((prev) => ({
+            key,
+            dir: prev.key === key ? (prev.dir === 'desc' ? 'asc' : 'desc') : 'desc',
+        }));
+    };
+
+    return (
+        <div
+            id={config.sectionId}
+            data-section-visible={isSectionVisible(config.sectionId)}
+            data-section-first={isFirstVisibleSection(config.sectionId)}
+            className={sectionClass(config.sectionId, `bg-white/5 border border-white/10 rounded-2xl p-6 page-break-avoid stats-share-exclude scroll-mt-24 ${
+                isExpanded
+                    ? `fixed inset-0 z-50 overflow-y-auto h-screen shadow-2xl rounded-none modal-pane flex flex-col pb-10 ${
+                        expandedSectionClosing ? 'modal-pane-exit' : 'modal-pane-enter'
+                    }`
+                    : ''
+            }`)}
+        >
+            {/* Section header */}
+            <div className="flex items-center justify-between mb-4">
+                <h3 className="text-lg font-bold text-gray-200 flex items-center gap-2">
+                    {incoming ? (
+                        <svg className="w-5 h-5 text-blue-300" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                            <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z" />
+                        </svg>
+                    ) : (
+                        <svg className="w-5 h-5 text-rose-300" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                            <polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2" />
+                        </svg>
+                    )}
+                    {config.title}
+                </h3>
+                <button
+                    type="button"
+                    onClick={() => (isExpanded ? closeExpandedSection() : openExpandedSection(config.sectionId))}
+                    className="p-2 rounded-lg border border-white/10 bg-white/5 text-gray-300 hover:text-white hover:border-white/30 transition-colors"
+                    aria-label={isExpanded ? `Close ${config.title}` : `Expand ${config.title}`}
+                    title={isExpanded ? 'Close' : 'Expand'}
+                >
+                    {isExpanded ? <X className="w-4 h-4" /> : <Maximize2 className="w-4 h-4" />}
+                </button>
+            </div>
+
+            {modSummaries.length === 0 ? (
+                <div className="text-center text-gray-500 italic py-8">No {incoming ? 'incoming ' : ''}damage modifier data available</div>
+            ) : (
+                <CollapsedView
+                    config={config}
+                    incoming={incoming}
+                    search={search}
+                    setSearch={setSearch}
+                    filteredMods={filteredMods}
+                    effectiveActiveMod={effectiveActiveMod}
+                    setActiveMod={setActiveMod}
+                    playerRows={playerRows}
+                    totalsKey={totalsKey}
+                    modMap={modMap}
+                    collapsedSort={collapsedSort}
+                    updateCollapsedSort={updateCollapsedSort}
+                    isExpanded={isExpanded}
+                    formatWithCommas={formatWithCommas}
+                    renderProfessionIcon={renderProfessionIcon}
+                    sidebarListClass={sidebarListClass}
+                    expandedSection={expandedSection}
+                />
+            )}
+        </div>
+    );
+};
+
+/* ─────────────────────────────────────────────
+ * COLLAPSED VIEW (sidebar + bar chart + table)
+ * ───────────────────────────────────────────── */
+
+type CollapsedViewProps = {
+    config: typeof SECTION_CONFIG.outgoing;
+    incoming: boolean;
+    search: string;
+    setSearch: (v: string) => void;
+    filteredMods: ModSummary[];
+    effectiveActiveMod: string;
+    setActiveMod: (v: string) => void;
+    playerRows: any[];
+    totalsKey: string;
+    modMap: Record<string, ModMapEntry>;
+    collapsedSort: { key: 'damageGain' | 'pctTotal' | 'hitCoverage' | 'fightTime'; dir: 'asc' | 'desc' };
+    updateCollapsedSort: (key: 'damageGain' | 'pctTotal' | 'hitCoverage' | 'fightTime') => void;
+    isExpanded: boolean;
+    formatWithCommas: (v: number, d: number) => string;
+    renderProfessionIcon: (profession: string | undefined, professionList?: string[], className?: string) => React.JSX.Element | null;
+    sidebarListClass: string;
+    expandedSection: string | null;
+};
+
+const CollapsedView = ({
+    config, incoming, search, setSearch, filteredMods, effectiveActiveMod, setActiveMod,
+    playerRows, totalsKey, modMap, collapsedSort, updateCollapsedSort,
+    isExpanded, formatWithCommas, renderProfessionIcon, sidebarListClass, expandedSection,
+}: CollapsedViewProps) => {
+    const activeModInfo = modMap[effectiveActiveMod];
+
+    // Build player data for the active modifier
+    const activeModPlayerData = useMemo(() => {
+        if (!effectiveActiveMod) return [];
+        return playerRows
+            .map((row: any) => {
+                const modTotals: Record<string, ModTotals> = row[totalsKey] ?? {};
+                const modData = modTotals[effectiveActiveMod];
+                if (!modData) return null;
+                return {
+                    account: row.account,
+                    profession: row.profession,
+                    professionList: row.professionList,
+                    totalFightMs: row.totalFightMs || 0,
+                    damageGain: modData.damageGain,
+                    hitCount: modData.hitCount,
+                    totalHitCount: modData.totalHitCount,
+                    totalDamage: modData.totalDamage,
+                };
+            })
+            .filter(Boolean) as Array<{
+                account: string;
+                profession: string;
+                professionList: string[];
+                totalFightMs: number;
+                damageGain: number;
+                hitCount: number;
+                totalHitCount: number;
+                totalDamage: number;
+            }>;
+    }, [playerRows, effectiveActiveMod, totalsKey]);
+
+    // Sort the player data for the detail table
+    const sortedPlayerData = useMemo(() => {
+        return [...activeModPlayerData].sort((a, b) => {
+            let aVal: number, bVal: number;
+            switch (collapsedSort.key) {
+                case 'damageGain':
+                    aVal = incoming ? Math.abs(a.damageGain) : a.damageGain;
+                    bVal = incoming ? Math.abs(b.damageGain) : b.damageGain;
+                    break;
+                case 'pctTotal':
+                    aVal = a.totalDamage > 0 ? Math.abs(a.damageGain) / a.totalDamage : 0;
+                    bVal = b.totalDamage > 0 ? Math.abs(b.damageGain) / b.totalDamage : 0;
+                    break;
+                case 'hitCoverage':
+                    aVal = a.totalHitCount > 0 ? a.hitCount / a.totalHitCount : 0;
+                    bVal = b.totalHitCount > 0 ? b.hitCount / b.totalHitCount : 0;
+                    break;
+                case 'fightTime':
+                    aVal = a.totalFightMs;
+                    bVal = b.totalFightMs;
+                    break;
+                default:
+                    aVal = 0;
+                    bVal = 0;
+            }
+            const diff = collapsedSort.dir === 'desc' ? bVal - aVal : aVal - bVal;
+            return diff || a.account.localeCompare(b.account);
+        });
+    }, [activeModPlayerData, collapsedSort, incoming]);
+
+    // Bar chart data — always sorted by damageGain desc (absolute value for incoming)
+    const barChartData = useMemo(() => {
+        return [...activeModPlayerData].sort(
+            (a, b) => Math.abs(b.damageGain) - Math.abs(a.damageGain)
+        );
+    }, [activeModPlayerData]);
+
+    const maxAbsGain = barChartData.length > 0 ? Math.abs(barChartData[0].damageGain) : 0;
+
+    return (
+        <StatsTableLayout
+            expanded={isExpanded}
+            sidebarClassName={`bg-black/20 border border-white/5 rounded-xl px-3 pt-3 pb-2 flex flex-col min-h-0 ${expandedSection === config.sectionId ? 'h-full flex-1' : 'self-start'}`}
+            contentClassName={`bg-black/30 border border-white/5 rounded-xl overflow-hidden ${expandedSection === config.sectionId ? 'flex flex-col min-h-0' : ''}`}
+            sidebar={
+                <>
+                    <div className="text-xs uppercase tracking-widest text-gray-500 mb-2">Modifiers</div>
+                    <input
+                        value={search}
+                        onChange={(e) => setSearch(e.target.value)}
+                        placeholder="Search modifiers..."
+                        className="w-full bg-black/30 border border-white/10 rounded-lg px-2 py-1 text-xs text-gray-200 focus:outline-none mb-2"
+                    />
+                    <div className={`${sidebarListClass} ${expandedSection === config.sectionId ? 'max-h-none flex-1 min-h-0' : ''}`}>
+                        {filteredMods.length === 0 ? (
+                            <div className="text-center text-gray-500 italic py-6 text-xs">No modifiers match this filter</div>
+                        ) : (
+                            filteredMods.map((mod) => (
+                                <button
+                                    key={mod.id}
+                                    onClick={() => setActiveMod(mod.id)}
+                                    className={`w-full text-left px-3 py-2 rounded-lg text-xs font-semibold border transition-colors flex items-center gap-2 ${
+                                        effectiveActiveMod === mod.id
+                                            ? `${config.accentBg} ${config.accentText} ${config.accentBorder}`
+                                            : 'bg-white/5 text-gray-300 border-white/10 hover:text-white'
+                                    }`}
+                                >
+                                    {mod.icon && (
+                                        <img src={mod.icon} alt="" className="w-4 h-4 object-contain flex-shrink-0" />
+                                    )}
+                                    <span className="flex flex-col min-w-0">
+                                        <span className="truncate">{mod.name}</span>
+                                        <span className="text-[10px] text-gray-500 font-normal">
+                                            {mod.squadDamageGain >= 0 ? '+' : ''}{formatWithCommas(mod.squadDamageGain, 0)} squad total
+                                        </span>
+                                    </span>
+                                </button>
+                            ))
+                        )}
+                    </div>
+                </>
+            }
+            content={
+                <>
+                    {effectiveActiveMod && activeModInfo ? (
+                        <StatsTableShell
+                            expanded={isExpanded}
+                            header={
+                                <div className="flex items-center gap-3 px-4 py-3 bg-white/5">
+                                    {activeModInfo.icon && (
+                                        <img src={activeModInfo.icon} alt="" className="w-6 h-6 object-contain flex-shrink-0" />
+                                    )}
+                                    <div className="flex flex-col min-w-0">
+                                        <div className="text-sm font-semibold text-gray-200">{activeModInfo.name}</div>
+                                        {activeModInfo.description && (
+                                            <div
+                                                className="text-[11px] text-gray-400 leading-tight mt-0.5"
+                                                dangerouslySetInnerHTML={{ __html: activeModInfo.description }}
+                                            />
+                                        )}
+                                    </div>
+                                </div>
+                            }
+                            columns={
+                                <>
+                                    {/* Bar chart */}
+                                    {barChartData.length > 0 && (
+                                        <div className="px-4 py-3 bg-white/[0.02] border-b border-white/5">
+                                            <div className="flex flex-col gap-1.5">
+                                                {incoming ? (
+                                                    /* Bidirectional bars for incoming */
+                                                    barChartData.map((row) => {
+                                                        const absGain = Math.abs(row.damageGain);
+                                                        const widthPct = maxAbsGain > 0 ? (absGain / maxAbsGain) * 50 : 0;
+                                                        const pctOfTotal = row.totalDamage > 0
+                                                            ? ((absGain / row.totalDamage) * 100).toFixed(2)
+                                                            : '0.00';
+                                                        const isReduction = row.damageGain < 0;
+                                                        return (
+                                                            <div key={row.account} className="flex items-center gap-2 text-xs">
+                                                                <div className="flex items-center gap-1.5 w-28 flex-shrink-0 justify-end">
+                                                                    <span className="truncate text-gray-300">{row.account}</span>
+                                                                    {renderProfessionIcon(row.profession, row.professionList, 'w-3.5 h-3.5')}
+                                                                </div>
+                                                                <div className="flex-1 relative h-5 flex items-center">
+                                                                    {/* Center divider */}
+                                                                    <div className="absolute left-1/2 top-0 bottom-0 w-px bg-white/20" />
+                                                                    {isReduction ? (
+                                                                        /* Green bar extending left from center */
+                                                                        <div className="absolute right-1/2 top-0 bottom-0 flex items-center justify-start" style={{ width: `${widthPct}%` }}>
+                                                                            <div className="w-full h-full rounded-l bg-gradient-to-l from-teal-500/40 to-teal-500/15" />
+                                                                        </div>
+                                                                    ) : (
+                                                                        /* Red bar extending right from center */
+                                                                        <div className="absolute left-1/2 top-0 bottom-0 flex items-center justify-end" style={{ width: `${widthPct}%` }}>
+                                                                            <div className="w-full h-full rounded-r bg-gradient-to-r from-red-500/40 to-red-500/15" />
+                                                                        </div>
+                                                                    )}
+                                                                    {/* Label */}
+                                                                    <div className={`absolute top-0 bottom-0 flex items-center text-[10px] font-mono ${
+                                                                        isReduction ? 'right-1/2 pr-1 justify-end text-teal-300' : 'left-1/2 pl-1 justify-start text-red-300'
+                                                                    }`} style={{ width: '50%' }}>
+                                                                        <span className="truncate">
+                                                                            {isReduction ? '' : '+'}{formatWithCommas(row.damageGain, 0)} ({pctOfTotal}%)
+                                                                        </span>
+                                                                    </div>
+                                                                </div>
+                                                            </div>
+                                                        );
+                                                    })
+                                                ) : (
+                                                    /* Simple horizontal bars for outgoing */
+                                                    barChartData.map((row) => {
+                                                        const widthPct = maxAbsGain > 0 ? (row.damageGain / maxAbsGain) * 100 : 0;
+                                                        const pctOfTotal = row.totalDamage > 0
+                                                            ? ((row.damageGain / row.totalDamage) * 100).toFixed(2)
+                                                            : '0.00';
+                                                        return (
+                                                            <div key={row.account} className="flex items-center gap-2 text-xs">
+                                                                <div className="flex items-center gap-1.5 w-28 flex-shrink-0 justify-end">
+                                                                    <span className="truncate text-gray-300">{row.account}</span>
+                                                                    {renderProfessionIcon(row.profession, row.professionList, 'w-3.5 h-3.5')}
+                                                                </div>
+                                                                <div className="flex-1 relative h-5">
+                                                                    <div
+                                                                        className={`absolute inset-y-0 left-0 rounded bg-gradient-to-r ${config.barGradient}`}
+                                                                        style={{ width: `${Math.max(widthPct, 0)}%` }}
+                                                                    />
+                                                                    <div className={`relative h-full flex items-center px-2 text-[10px] font-mono ${config.accentText}`}>
+                                                                        +{formatWithCommas(row.damageGain, 0)} ({pctOfTotal}%)
+                                                                    </div>
+                                                                </div>
+                                                            </div>
+                                                        );
+                                                    })
+                                                )}
+                                            </div>
+                                        </div>
+                                    )}
+                                    {/* Detail table column headers */}
+                                    <div className="grid grid-cols-[0.3fr_1.3fr_1fr_0.8fr_0.8fr_0.8fr] text-xs uppercase tracking-wider text-gray-400 bg-white/5 px-4 py-2">
+                                        <div className="text-center">#</div>
+                                        <div>Player</div>
+                                        <button
+                                            type="button"
+                                            onClick={() => updateCollapsedSort('damageGain')}
+                                            className={`text-right transition-colors ${collapsedSort.key === 'damageGain' ? config.accentText : 'text-gray-400 hover:text-gray-200'}`}
+                                        >
+                                            Dmg Gain{collapsedSort.key === 'damageGain' ? (collapsedSort.dir === 'desc' ? ' ↓' : ' ↑') : ''}
+                                        </button>
+                                        <button
+                                            type="button"
+                                            onClick={() => updateCollapsedSort('pctTotal')}
+                                            className={`text-right transition-colors ${collapsedSort.key === 'pctTotal' ? config.accentText : 'text-gray-400 hover:text-gray-200'}`}
+                                        >
+                                            % Total{collapsedSort.key === 'pctTotal' ? (collapsedSort.dir === 'desc' ? ' ↓' : ' ↑') : ''}
+                                        </button>
+                                        <button
+                                            type="button"
+                                            onClick={() => updateCollapsedSort('hitCoverage')}
+                                            className={`text-right transition-colors ${collapsedSort.key === 'hitCoverage' ? config.accentText : 'text-gray-400 hover:text-gray-200'}`}
+                                        >
+                                            Hits{collapsedSort.key === 'hitCoverage' ? (collapsedSort.dir === 'desc' ? ' ↓' : ' ↑') : ''}
+                                        </button>
+                                        <button
+                                            type="button"
+                                            onClick={() => updateCollapsedSort('fightTime')}
+                                            className={`text-right transition-colors ${collapsedSort.key === 'fightTime' ? config.accentText : 'text-gray-400 hover:text-gray-200'}`}
+                                        >
+                                            Fight Time{collapsedSort.key === 'fightTime' ? (collapsedSort.dir === 'desc' ? ' ↓' : ' ↑') : ''}
+                                        </button>
+                                    </div>
+                                </>
+                            }
+                            rows={
+                                <>
+                                    {sortedPlayerData.length === 0 ? (
+                                        <div className="px-4 py-8 text-center text-gray-500 italic text-sm">No player data for this modifier</div>
+                                    ) : (
+                                        sortedPlayerData.map((row, idx) => {
+                                            const pctOfTotal = row.totalDamage > 0
+                                                ? ((Math.abs(row.damageGain) / row.totalDamage) * 100).toFixed(2)
+                                                : '0.00';
+                                            const hitCoverage = row.totalHitCount > 0
+                                                ? `${row.hitCount}/${row.totalHitCount}`
+                                                : '—';
+                                            return (
+                                                <div key={`${row.account}-${idx}`} className="grid grid-cols-[0.3fr_1.3fr_1fr_0.8fr_0.8fr_0.8fr] px-4 py-2 text-sm text-gray-200 border-t border-white/5">
+                                                    <div className="text-center text-gray-500 font-mono">{idx + 1}</div>
+                                                    <div className="flex items-center gap-2 min-w-0">
+                                                        {renderProfessionIcon(row.profession, row.professionList, 'w-4 h-4')}
+                                                        <span className="truncate">{row.account}</span>
+                                                    </div>
+                                                    <div className="text-right font-mono text-gray-300">
+                                                        {row.damageGain >= 0 ? '+' : ''}{formatWithCommas(row.damageGain, 0)}
+                                                    </div>
+                                                    <div className="text-right font-mono text-gray-400">
+                                                        {pctOfTotal}%
+                                                    </div>
+                                                    <div className="text-right font-mono text-gray-400">
+                                                        {hitCoverage}
+                                                    </div>
+                                                    <div className="text-right font-mono text-gray-400">
+                                                        {row.totalFightMs ? `${(row.totalFightMs / 1000).toFixed(1)}s` : '—'}
+                                                    </div>
+                                                </div>
+                                            );
+                                        })
+                                    )}
+                                </>
+                            }
+                        />
+                    ) : (
+                        <div className="px-4 py-8 text-center text-gray-500 italic text-sm">Select a modifier from the sidebar</div>
+                    )}
+                </>
+            }
+        />
+    );
+};

--- a/src/renderer/stats/sections/DamageModifiersSection.tsx
+++ b/src/renderer/stats/sections/DamageModifiersSection.tsx
@@ -1,8 +1,7 @@
 import { useMemo, useState } from 'react';
-import { Maximize2, X, Columns, Users, BarChart3, Table2 } from 'lucide-react';
+import { Maximize2, X, Columns, Users } from 'lucide-react';
 import { ColumnFilterDropdown } from '../ui/ColumnFilterDropdown';
 import { DenseStatsTable } from '../ui/DenseStatsTable';
-import { PillToggleGroup } from '../ui/PillToggleGroup';
 import { SearchSelectDropdown, SearchSelectOption } from '../ui/SearchSelectDropdown';
 import { StatsTableLayout } from '../ui/StatsTableLayout';
 import { StatsTableShell } from '../ui/StatsTableShell';
@@ -110,9 +109,6 @@ export const DamageModifiersSection = ({
     const effectiveActiveMod = filteredMods.find((m) => m.id === activeMod)
         ? activeMod
         : filteredMods[0]?.id ?? '';
-
-    // --- View mode state ---
-    const [contentViewMode, setContentViewMode] = useState<'chart' | 'table'>('chart');
 
     // --- Expanded view state ---
     const [selectedColumnIds, setSelectedColumnIds] = useState<string[]>([]);
@@ -247,8 +243,6 @@ export const DamageModifiersSection = ({
                     renderProfessionIcon={renderProfessionIcon}
                     sidebarListClass={sidebarListClass}
                     expandedSection={expandedSection}
-                    contentViewMode={contentViewMode}
-                    setContentViewMode={setContentViewMode}
                 />
             )}
         </div>
@@ -277,15 +271,12 @@ type CollapsedViewProps = {
     renderProfessionIcon: (profession: string | undefined, professionList?: string[], className?: string) => React.JSX.Element | null;
     sidebarListClass: string;
     expandedSection: string | null;
-    contentViewMode: 'chart' | 'table';
-    setContentViewMode: (v: 'chart' | 'table') => void;
 };
 
 const CollapsedView = ({
     config, incoming, search, setSearch, filteredMods, effectiveActiveMod, setActiveMod,
     playerRows, totalsKey, modMap, collapsedSort, updateCollapsedSort,
     isExpanded, formatWithCommas, renderProfessionIcon, sidebarListClass, expandedSection,
-    contentViewMode, setContentViewMode,
 }: CollapsedViewProps) => {
     const activeModInfo = modMap[effectiveActiveMod];
 
@@ -357,14 +348,14 @@ const CollapsedView = ({
         });
     }, [activeModPlayerData, collapsedSort, incoming]);
 
-    // Bar chart data — always sorted by damageGain desc (absolute value for incoming)
-    const barChartData = useMemo(() => {
-        return [...activeModPlayerData].sort(
-            (a, b) => Math.abs(b.damageGain) - Math.abs(a.damageGain)
-        );
+    const maxAbsGain = useMemo(() => {
+        let max = 0;
+        for (const row of activeModPlayerData) {
+            const abs = Math.abs(row.damageGain);
+            if (abs > max) max = abs;
+        }
+        return max;
     }, [activeModPlayerData]);
-
-    const maxAbsGain = barChartData.length > 0 ? Math.abs(barChartData[0].damageGain) : 0;
 
     return (
         <StatsTableLayout
@@ -429,132 +420,45 @@ const CollapsedView = ({
                                             </div>
                                         )}
                                     </div>
-                                    <PillToggleGroup
-                                        value={contentViewMode}
-                                        onChange={setContentViewMode}
-                                        options={[
-                                            { value: 'chart' as const, label: <BarChart3 className="w-3 h-3" /> },
-                                            { value: 'table' as const, label: <Table2 className="w-3 h-3" /> },
-                                        ]}
-                                        activeClassName={`${config.accentBg} ${config.accentText} border ${config.accentBorder}`}
-                                        inactiveClassName="border border-transparent text-gray-400 hover:text-white"
-                                    />
                                 </div>
                             }
                             columns={
-                                <>
-                                    {/* Bar chart */}
-                                    {contentViewMode === 'chart' && barChartData.length > 0 && (
-                                        <div className="px-4 py-3 bg-black/30 border-b border-white/5">
-                                            <div className="flex flex-col gap-1.5">
-                                                {incoming ? (
-                                                    /* Bidirectional bars for incoming */
-                                                    barChartData.map((row) => {
-                                                        const absGain = Math.abs(row.damageGain);
-                                                        const widthPct = maxAbsGain > 0 ? (absGain / maxAbsGain) * 50 : 0;
-                                                        const pctOfTotal = row.totalDamage > 0
-                                                            ? ((absGain / row.totalDamage) * 100).toFixed(2)
-                                                            : '0.00';
-                                                        const isReduction = row.damageGain < 0;
-                                                        return (
-                                                            <div key={row.account} className="flex items-center gap-2 text-xs">
-                                                                <div className="flex items-center gap-1.5 w-28 flex-shrink-0 justify-end">
-                                                                    <span className="truncate text-gray-300">{row.account}</span>
-                                                                    {renderProfessionIcon(row.profession, row.professionList, 'w-3.5 h-3.5')}
-                                                                </div>
-                                                                <div className="flex-1 relative h-5 flex items-center">
-                                                                    {/* Center divider */}
-                                                                    <div className="absolute left-1/2 top-0 bottom-0 w-px bg-white/20" />
-                                                                    {isReduction ? (
-                                                                        /* Green bar extending left from center */
-                                                                        <div className="absolute right-1/2 top-0 bottom-0 flex items-center justify-start" style={{ width: `${widthPct}%` }}>
-                                                                            <div className="w-full h-full rounded-l" style={{ background: 'linear-gradient(to left, rgba(20,184,166,0.4), rgba(20,184,166,0.15))' }} />
-                                                                        </div>
-                                                                    ) : (
-                                                                        /* Red bar extending right from center */
-                                                                        <div className="absolute left-1/2 top-0 bottom-0 flex items-center justify-end" style={{ width: `${widthPct}%` }}>
-                                                                            <div className="w-full h-full rounded-r" style={{ background: 'linear-gradient(to right, rgba(239,68,68,0.4), rgba(239,68,68,0.15))' }} />
-                                                                        </div>
-                                                                    )}
-                                                                    {/* Label */}
-                                                                    <div className={`absolute top-0 bottom-0 flex items-center text-[10px] font-mono ${
-                                                                        isReduction ? 'right-1/2 pr-1 justify-end text-teal-300' : 'left-1/2 pl-1 justify-start text-red-300'
-                                                                    }`} style={{ width: '50%' }}>
-                                                                        <span className="truncate">
-                                                                            {isReduction ? '' : '+'}{formatWithCommas(row.damageGain, 0)} ({pctOfTotal}%)
-                                                                        </span>
-                                                                    </div>
-                                                                </div>
-                                                            </div>
-                                                        );
-                                                    })
-                                                ) : (
-                                                    /* Simple horizontal bars for outgoing */
-                                                    barChartData.map((row) => {
-                                                        const widthPct = maxAbsGain > 0 ? (row.damageGain / maxAbsGain) * 100 : 0;
-                                                        const pctOfTotal = row.totalDamage > 0
-                                                            ? ((row.damageGain / row.totalDamage) * 100).toFixed(2)
-                                                            : '0.00';
-                                                        return (
-                                                            <div key={row.account} className="flex items-center gap-2 text-xs">
-                                                                <div className="flex items-center gap-1.5 w-28 flex-shrink-0 justify-end">
-                                                                    <span className="truncate text-gray-300">{row.account}</span>
-                                                                    {renderProfessionIcon(row.profession, row.professionList, 'w-3.5 h-3.5')}
-                                                                </div>
-                                                                <div className="flex-1 relative h-5">
-                                                                    <div
-                                                                        className="absolute inset-y-0 left-0 rounded"
-                                                                        style={{ width: `${Math.max(widthPct, 0)}%`, background: config.barGradientStyle }}
-                                                                    />
-                                                                    <div className={`relative h-full flex items-center px-2 text-[10px] font-mono ${config.accentText}`}>
-                                                                        +{formatWithCommas(row.damageGain, 0)} ({pctOfTotal}%)
-                                                                    </div>
-                                                                </div>
-                                                            </div>
-                                                        );
-                                                    })
-                                                )}
-                                            </div>
-                                        </div>
-                                    )}
-                                    {/* Detail table column headers */}
-                                    {contentViewMode === 'table' && <div className="grid grid-cols-[0.3fr_1.3fr_1fr_0.8fr_0.8fr_0.8fr] text-xs uppercase tracking-wider text-gray-400 bg-white/5 px-4 py-2">
-                                        <div className="text-center">#</div>
-                                        <div>Player</div>
-                                        <button
-                                            type="button"
-                                            onClick={() => updateCollapsedSort('damageGain')}
-                                            className={`text-right transition-colors ${collapsedSort.key === 'damageGain' ? config.accentText : 'text-gray-400 hover:text-gray-200'}`}
-                                        >
-                                            Dmg Gain{collapsedSort.key === 'damageGain' ? (collapsedSort.dir === 'desc' ? ' ↓' : ' ↑') : ''}
-                                        </button>
-                                        <button
-                                            type="button"
-                                            onClick={() => updateCollapsedSort('pctTotal')}
-                                            className={`text-right transition-colors ${collapsedSort.key === 'pctTotal' ? config.accentText : 'text-gray-400 hover:text-gray-200'}`}
-                                        >
-                                            % Total{collapsedSort.key === 'pctTotal' ? (collapsedSort.dir === 'desc' ? ' ↓' : ' ↑') : ''}
-                                        </button>
-                                        <button
-                                            type="button"
-                                            onClick={() => updateCollapsedSort('hitCoverage')}
-                                            className={`text-right transition-colors ${collapsedSort.key === 'hitCoverage' ? config.accentText : 'text-gray-400 hover:text-gray-200'}`}
-                                        >
-                                            Hits{collapsedSort.key === 'hitCoverage' ? (collapsedSort.dir === 'desc' ? ' ↓' : ' ↑') : ''}
-                                        </button>
-                                        <button
-                                            type="button"
-                                            onClick={() => updateCollapsedSort('fightTime')}
-                                            className={`text-right transition-colors ${collapsedSort.key === 'fightTime' ? config.accentText : 'text-gray-400 hover:text-gray-200'}`}
-                                        >
-                                            Fight Time{collapsedSort.key === 'fightTime' ? (collapsedSort.dir === 'desc' ? ' ↓' : ' ↑') : ''}
-                                        </button>
-                                    </div>}
-                                </>
+                                <div className="grid grid-cols-[0.3fr_1.3fr_1fr_0.8fr_0.8fr_0.8fr] text-xs uppercase tracking-wider text-gray-400 bg-white/5 px-4 py-2">
+                                    <div className="text-center">#</div>
+                                    <div>Player</div>
+                                    <button
+                                        type="button"
+                                        onClick={() => updateCollapsedSort('damageGain')}
+                                        className={`text-right transition-colors ${collapsedSort.key === 'damageGain' ? config.accentText : 'text-gray-400 hover:text-gray-200'}`}
+                                    >
+                                        Dmg Gain{collapsedSort.key === 'damageGain' ? (collapsedSort.dir === 'desc' ? ' ↓' : ' ↑') : ''}
+                                    </button>
+                                    <button
+                                        type="button"
+                                        onClick={() => updateCollapsedSort('pctTotal')}
+                                        className={`text-right transition-colors ${collapsedSort.key === 'pctTotal' ? config.accentText : 'text-gray-400 hover:text-gray-200'}`}
+                                    >
+                                        % Total{collapsedSort.key === 'pctTotal' ? (collapsedSort.dir === 'desc' ? ' ↓' : ' ↑') : ''}
+                                    </button>
+                                    <button
+                                        type="button"
+                                        onClick={() => updateCollapsedSort('hitCoverage')}
+                                        className={`text-right transition-colors ${collapsedSort.key === 'hitCoverage' ? config.accentText : 'text-gray-400 hover:text-gray-200'}`}
+                                    >
+                                        Hits{collapsedSort.key === 'hitCoverage' ? (collapsedSort.dir === 'desc' ? ' ↓' : ' ↑') : ''}
+                                    </button>
+                                    <button
+                                        type="button"
+                                        onClick={() => updateCollapsedSort('fightTime')}
+                                        className={`text-right transition-colors ${collapsedSort.key === 'fightTime' ? config.accentText : 'text-gray-400 hover:text-gray-200'}`}
+                                    >
+                                        Fight Time{collapsedSort.key === 'fightTime' ? (collapsedSort.dir === 'desc' ? ' ↓' : ' ↑') : ''}
+                                    </button>
+                                </div>
                             }
                             rows={
                                 <>
-                                    {contentViewMode !== 'table' ? null : sortedPlayerData.length === 0 ? (
+                                    {sortedPlayerData.length === 0 ? (
                                         <div className="px-4 py-8 text-center text-gray-500 italic text-sm">No player data for this modifier</div>
                                     ) : (
                                         sortedPlayerData.map((row, idx) => {
@@ -564,24 +468,41 @@ const CollapsedView = ({
                                             const hitCoverage = row.totalHitCount > 0
                                                 ? `${row.hitCount}/${row.totalHitCount}`
                                                 : '—';
+                                            const barWidthPct = maxAbsGain > 0
+                                                ? (Math.abs(row.damageGain) / maxAbsGain) * 100
+                                                : 0;
+                                            const isReduction = incoming && row.damageGain < 0;
+                                            const barStyle = incoming
+                                                ? (isReduction
+                                                    ? 'linear-gradient(to left, rgba(20,184,166,0.2), rgba(20,184,166,0.05))'
+                                                    : 'linear-gradient(to right, rgba(239,68,68,0.2), rgba(239,68,68,0.05))')
+                                                : config.barGradientStyle;
                                             return (
-                                                <div key={`${row.account}-${idx}`} className="grid grid-cols-[0.3fr_1.3fr_1fr_0.8fr_0.8fr_0.8fr] px-4 py-2 text-sm text-gray-200 border-t border-white/5">
-                                                    <div className="text-center text-gray-500 font-mono">{idx + 1}</div>
-                                                    <div className="flex items-center gap-2 min-w-0">
-                                                        {renderProfessionIcon(row.profession, row.professionList, 'w-4 h-4')}
-                                                        <span className="truncate">{row.account}</span>
-                                                    </div>
-                                                    <div className="text-right font-mono text-gray-300">
-                                                        {row.damageGain >= 0 ? '+' : ''}{formatWithCommas(row.damageGain, 0)}
-                                                    </div>
-                                                    <div className="text-right font-mono text-gray-400">
-                                                        {pctOfTotal}%
-                                                    </div>
-                                                    <div className="text-right font-mono text-gray-400">
-                                                        {hitCoverage}
-                                                    </div>
-                                                    <div className="text-right font-mono text-gray-400">
-                                                        {row.totalFightMs ? `${(row.totalFightMs / 1000).toFixed(1)}s` : '—'}
+                                                <div key={`${row.account}-${idx}`} className="relative border-t border-white/5">
+                                                    {/* Bar overlay — mitigation grows from right, damage from left */}
+                                                    <div
+                                                        className={`absolute inset-y-0 pointer-events-none ${isReduction ? 'right-0' : 'left-0'}`}
+                                                        style={{ width: `${barWidthPct}%`, background: barStyle }}
+                                                    />
+                                                    {/* Row content */}
+                                                    <div className="relative grid grid-cols-[0.3fr_1.3fr_1fr_0.8fr_0.8fr_0.8fr] px-4 py-2 text-sm text-gray-200">
+                                                        <div className="text-center text-gray-500 font-mono">{idx + 1}</div>
+                                                        <div className="flex items-center gap-2 min-w-0">
+                                                            {renderProfessionIcon(row.profession, row.professionList, 'w-4 h-4')}
+                                                            <span className="truncate">{row.account}</span>
+                                                        </div>
+                                                        <div className="text-right font-mono text-gray-300">
+                                                            {row.damageGain >= 0 ? '+' : ''}{formatWithCommas(row.damageGain, 0)}
+                                                        </div>
+                                                        <div className="text-right font-mono text-gray-400">
+                                                            {pctOfTotal}%
+                                                        </div>
+                                                        <div className="text-right font-mono text-gray-400">
+                                                            {hitCoverage}
+                                                        </div>
+                                                        <div className="text-right font-mono text-gray-400">
+                                                            {row.totalFightMs ? `${(row.totalFightMs / 1000).toFixed(1)}s` : '—'}
+                                                        </div>
                                                     </div>
                                                 </div>
                                             );

--- a/src/renderer/stats/sections/DamageModifiersSection.tsx
+++ b/src/renderer/stats/sections/DamageModifiersSection.tsx
@@ -1,7 +1,8 @@
 import { useMemo, useState } from 'react';
-import { Maximize2, X, Columns, Users } from 'lucide-react';
+import { Maximize2, X, Columns, Users, BarChart3, Table2 } from 'lucide-react';
 import { ColumnFilterDropdown } from '../ui/ColumnFilterDropdown';
 import { DenseStatsTable } from '../ui/DenseStatsTable';
+import { PillToggleGroup } from '../ui/PillToggleGroup';
 import { SearchSelectDropdown, SearchSelectOption } from '../ui/SearchSelectDropdown';
 import { StatsTableLayout } from '../ui/StatsTableLayout';
 import { StatsTableShell } from '../ui/StatsTableShell';
@@ -109,6 +110,9 @@ export const DamageModifiersSection = ({
     const effectiveActiveMod = filteredMods.find((m) => m.id === activeMod)
         ? activeMod
         : filteredMods[0]?.id ?? '';
+
+    // --- View mode state ---
+    const [contentViewMode, setContentViewMode] = useState<'chart' | 'table'>('chart');
 
     // --- Expanded view state ---
     const [selectedColumnIds, setSelectedColumnIds] = useState<string[]>([]);
@@ -243,6 +247,8 @@ export const DamageModifiersSection = ({
                     renderProfessionIcon={renderProfessionIcon}
                     sidebarListClass={sidebarListClass}
                     expandedSection={expandedSection}
+                    contentViewMode={contentViewMode}
+                    setContentViewMode={setContentViewMode}
                 />
             )}
         </div>
@@ -271,12 +277,15 @@ type CollapsedViewProps = {
     renderProfessionIcon: (profession: string | undefined, professionList?: string[], className?: string) => React.JSX.Element | null;
     sidebarListClass: string;
     expandedSection: string | null;
+    contentViewMode: 'chart' | 'table';
+    setContentViewMode: (v: 'chart' | 'table') => void;
 };
 
 const CollapsedView = ({
     config, incoming, search, setSearch, filteredMods, effectiveActiveMod, setActiveMod,
     playerRows, totalsKey, modMap, collapsedSort, updateCollapsedSort,
     isExpanded, formatWithCommas, renderProfessionIcon, sidebarListClass, expandedSection,
+    contentViewMode, setContentViewMode,
 }: CollapsedViewProps) => {
     const activeModInfo = modMap[effectiveActiveMod];
 
@@ -403,7 +412,7 @@ const CollapsedView = ({
                                     {activeModInfo.icon && (
                                         <img src={activeModInfo.icon} alt="" className="w-6 h-6 object-contain flex-shrink-0" />
                                     )}
-                                    <div className="flex flex-col min-w-0">
+                                    <div className="flex flex-col min-w-0 flex-1">
                                         <div className="text-sm font-semibold text-gray-200">{activeModInfo.name}</div>
                                         {activeModInfo.description && (
                                             <div className="text-[11px] text-gray-400 leading-tight mt-0.5">
@@ -413,12 +422,22 @@ const CollapsedView = ({
                                             </div>
                                         )}
                                     </div>
+                                    <PillToggleGroup
+                                        value={contentViewMode}
+                                        onChange={setContentViewMode}
+                                        options={[
+                                            { value: 'chart' as const, label: <BarChart3 className="w-3 h-3" /> },
+                                            { value: 'table' as const, label: <Table2 className="w-3 h-3" /> },
+                                        ]}
+                                        activeClassName={`${config.accentBg} ${config.accentText} border ${config.accentBorder}`}
+                                        inactiveClassName="border border-transparent text-gray-400 hover:text-white"
+                                    />
                                 </div>
                             }
                             columns={
                                 <>
                                     {/* Bar chart */}
-                                    {barChartData.length > 0 && (
+                                    {contentViewMode === 'chart' && barChartData.length > 0 && (
                                         <div className="px-4 py-3 bg-white/[0.02] border-b border-white/5">
                                             <div className="flex flex-col gap-1.5">
                                                 {incoming ? (
@@ -492,7 +511,7 @@ const CollapsedView = ({
                                         </div>
                                     )}
                                     {/* Detail table column headers */}
-                                    <div className="grid grid-cols-[0.3fr_1.3fr_1fr_0.8fr_0.8fr_0.8fr] text-xs uppercase tracking-wider text-gray-400 bg-white/5 px-4 py-2">
+                                    {contentViewMode === 'table' && <div className="grid grid-cols-[0.3fr_1.3fr_1fr_0.8fr_0.8fr_0.8fr] text-xs uppercase tracking-wider text-gray-400 bg-white/5 px-4 py-2">
                                         <div className="text-center">#</div>
                                         <div>Player</div>
                                         <button
@@ -523,12 +542,12 @@ const CollapsedView = ({
                                         >
                                             Fight Time{collapsedSort.key === 'fightTime' ? (collapsedSort.dir === 'desc' ? ' ↓' : ' ↑') : ''}
                                         </button>
-                                    </div>
+                                    </div>}
                                 </>
                             }
                             rows={
                                 <>
-                                    {sortedPlayerData.length === 0 ? (
+                                    {contentViewMode !== 'table' ? null : sortedPlayerData.length === 0 ? (
                                         <div className="px-4 py-8 text-center text-gray-500 italic text-sm">No player data for this modifier</div>
                                     ) : (
                                         sortedPlayerData.map((row, idx) => {

--- a/src/renderer/stats/sections/DamageModifiersSection.tsx
+++ b/src/renderer/stats/sections/DamageModifiersSection.tsx
@@ -1,5 +1,8 @@
 import { useMemo, useState } from 'react';
-import { Maximize2, X } from 'lucide-react';
+import { Maximize2, X, Columns, Users } from 'lucide-react';
+import { ColumnFilterDropdown } from '../ui/ColumnFilterDropdown';
+import { DenseStatsTable } from '../ui/DenseStatsTable';
+import { SearchSelectDropdown, SearchSelectOption } from '../ui/SearchSelectDropdown';
 import { StatsTableLayout } from '../ui/StatsTableLayout';
 import { StatsTableShell } from '../ui/StatsTableShell';
 import { useStatsSharedContext } from '../StatsViewContext';
@@ -107,6 +110,10 @@ export const DamageModifiersSection = ({
         ? activeMod
         : filteredMods[0]?.id ?? '';
 
+    // --- Expanded view state ---
+    const [selectedColumnIds, setSelectedColumnIds] = useState<string[]>([]);
+    const [selectedPlayers, setSelectedPlayers] = useState<string[]>([]);
+    const [denseSort, setDenseSort] = useState<{ columnId: string; dir: 'asc' | 'desc' }>({ columnId: '', dir: 'desc' });
     const [collapsedSort, setCollapsedSort] = useState<{ key: 'damageGain' | 'pctTotal' | 'hitCoverage' | 'fightTime'; dir: 'asc' | 'desc' }>({
         key: 'damageGain', dir: 'desc',
     });
@@ -117,6 +124,43 @@ export const DamageModifiersSection = ({
             dir: prev.key === key ? (prev.dir === 'desc' ? 'asc' : 'desc') : 'desc',
         }));
     };
+
+    // --- Expanded view helpers ---
+    const allColumnOptions = useMemo(() =>
+        modSummaries.map((m) => ({
+            id: m.id,
+            label: m.name,
+            icon: m.icon ? <img src={m.icon} alt="" className="h-4 w-4 object-contain" /> : undefined,
+        })),
+        [modSummaries]
+    );
+    const columnOptionsFiltered = useMemo(() =>
+        filteredMods.map((m) => ({
+            id: m.id,
+            label: m.name,
+            icon: m.icon ? <img src={m.icon} alt="" className="h-4 w-4 object-contain" /> : undefined,
+        })),
+        [filteredMods]
+    );
+    const visibleMods = selectedColumnIds.length > 0
+        ? modSummaries.filter((m) => selectedColumnIds.includes(m.id))
+        : modSummaries;
+
+    const playerOptions = useMemo(() =>
+        Array.from(new Map(
+            playerRows.map((row: any) => [row.account, row])
+        ).values()).map((row: any) => ({
+            id: row.account,
+            label: row.account,
+            icon: renderProfessionIcon(row.profession, row.professionList, 'w-3 h-3'),
+        })),
+        [playerRows, renderProfessionIcon]
+    );
+
+    const searchSelectedIds = useMemo(() => new Set([
+        ...selectedColumnIds.map((id) => `column:${id}`),
+        ...selectedPlayers.map((id) => `player:${id}`),
+    ]), [selectedColumnIds, selectedPlayers]);
 
     return (
         <div
@@ -158,7 +202,29 @@ export const DamageModifiersSection = ({
 
             {modSummaries.length === 0 ? (
                 <div className="text-center text-gray-500 italic py-8">No {incoming ? 'incoming ' : ''}damage modifier data available</div>
+            ) : isExpanded ? (
+                /* ===== EXPANDED / FULLSCREEN VIEW ===== */
+                <ExpandedView
+                    config={config}
+                    incoming={incoming}
+                    visibleMods={visibleMods}
+                    playerRows={playerRows}
+                    totalsKey={totalsKey}
+                    allColumnOptions={allColumnOptions}
+                    columnOptionsFiltered={columnOptionsFiltered}
+                    playerOptions={playerOptions}
+                    selectedColumnIds={selectedColumnIds}
+                    setSelectedColumnIds={setSelectedColumnIds}
+                    selectedPlayers={selectedPlayers}
+                    setSelectedPlayers={setSelectedPlayers}
+                    searchSelectedIds={searchSelectedIds}
+                    denseSort={denseSort}
+                    setDenseSort={setDenseSort}
+                    formatWithCommas={formatWithCommas}
+                    renderProfessionIcon={renderProfessionIcon}
+                />
             ) : (
+                /* ===== COLLAPSED VIEW ===== */
                 <CollapsedView
                     config={config}
                     incoming={incoming}
@@ -503,5 +569,201 @@ const CollapsedView = ({
                 </>
             }
         />
+    );
+};
+
+/* ─────────────────────────────────────────────
+ * EXPANDED / FULLSCREEN VIEW (dense table)
+ * ───────────────────────────────────────────── */
+
+type ExpandedViewProps = {
+    config: typeof SECTION_CONFIG.outgoing;
+    incoming: boolean;
+    visibleMods: ModSummary[];
+    playerRows: any[];
+    totalsKey: string;
+    allColumnOptions: Array<{ id: string; label: string; icon?: React.JSX.Element }>;
+    columnOptionsFiltered: Array<{ id: string; label: string; icon?: React.JSX.Element }>;
+    playerOptions: Array<{ id: string; label: string; icon: React.JSX.Element | null }>;
+    selectedColumnIds: string[];
+    setSelectedColumnIds: React.Dispatch<React.SetStateAction<string[]>>;
+    selectedPlayers: string[];
+    setSelectedPlayers: React.Dispatch<React.SetStateAction<string[]>>;
+    searchSelectedIds: Set<string>;
+    denseSort: { columnId: string; dir: 'asc' | 'desc' };
+    setDenseSort: React.Dispatch<React.SetStateAction<{ columnId: string; dir: 'asc' | 'desc' }>>;
+    formatWithCommas: (v: number, d: number) => string;
+    renderProfessionIcon: (profession: string | undefined, professionList?: string[], className?: string) => React.JSX.Element | null;
+};
+
+const ExpandedView = ({
+    config, incoming, visibleMods,
+    playerRows, totalsKey, allColumnOptions, columnOptionsFiltered, playerOptions,
+    selectedColumnIds, setSelectedColumnIds,
+    selectedPlayers, setSelectedPlayers,
+    searchSelectedIds, denseSort, setDenseSort,
+    formatWithCommas, renderProfessionIcon,
+}: ExpandedViewProps) => {
+    const resolvedSortColumnId = visibleMods.find((m) => m.id === denseSort.columnId)?.id
+        || visibleMods[0]?.id
+        || '';
+
+    const rows = useMemo(() => {
+        return [...playerRows]
+            .filter((row: any) => selectedPlayers.length === 0 || selectedPlayers.includes(row.account))
+            .map((row: any) => {
+                const modTotals: Record<string, ModTotals> = row[totalsKey] ?? {};
+                const values: Record<string, string> = {};
+                const numericValues: Record<string, number> = {};
+                visibleMods.forEach((mod) => {
+                    const modData = modTotals[mod.id];
+                    if (modData) {
+                        const gain = modData.damageGain;
+                        numericValues[mod.id] = incoming ? Math.abs(gain) : gain;
+                        values[mod.id] = `${gain >= 0 ? '+' : ''}${formatWithCommas(gain, 0)}`;
+                    } else {
+                        numericValues[mod.id] = 0;
+                        values[mod.id] = '—';
+                    }
+                });
+                return { row, values, numericValues };
+            })
+            .sort((a, b) => {
+                const resolvedA = a.numericValues[resolvedSortColumnId] ?? 0;
+                const resolvedB = b.numericValues[resolvedSortColumnId] ?? 0;
+                const primary = denseSort.dir === 'desc' ? resolvedB - resolvedA : resolvedA - resolvedB;
+                return primary || String(a.row.account || '').localeCompare(String(b.row.account || ''));
+            });
+    }, [playerRows, selectedPlayers, totalsKey, visibleMods, resolvedSortColumnId, denseSort.dir, incoming, formatWithCommas]);
+
+    return (
+        <div className="flex flex-col gap-4">
+            <div className="bg-black/20 border border-white/5 rounded-xl px-4 py-3">
+                <div className="text-xs uppercase tracking-widest text-gray-500 mb-2">Modifier Columns</div>
+                <div className="flex flex-wrap items-center gap-2">
+                    <SearchSelectDropdown
+                        options={[
+                            ...allColumnOptions.map((option) => ({ ...option, type: 'column' as const })),
+                            ...playerOptions.map((option) => ({ ...option, type: 'player' as const })),
+                        ]}
+                        onSelect={(option: SearchSelectOption) => {
+                            if (option.type === 'column') {
+                                setSelectedColumnIds((prev) =>
+                                    prev.includes(option.id) ? prev.filter((e) => e !== option.id) : [...prev, option.id]
+                                );
+                            } else {
+                                setSelectedPlayers((prev) =>
+                                    prev.includes(option.id) ? prev.filter((e) => e !== option.id) : [...prev, option.id]
+                                );
+                            }
+                        }}
+                        selectedIds={searchSelectedIds}
+                        className="w-full sm:w-64"
+                    />
+                    <ColumnFilterDropdown
+                        options={columnOptionsFiltered}
+                        selectedIds={selectedColumnIds}
+                        onToggle={(id) => {
+                            setSelectedColumnIds((prev) =>
+                                prev.includes(id) ? prev.filter((e) => e !== id) : [...prev, id]
+                            );
+                        }}
+                        onClear={() => setSelectedColumnIds([])}
+                        buttonIcon={<Columns className="h-3.5 w-3.5" />}
+                    />
+                    <ColumnFilterDropdown
+                        options={playerOptions}
+                        selectedIds={selectedPlayers}
+                        onToggle={(id) => {
+                            setSelectedPlayers((prev) =>
+                                prev.includes(id) ? prev.filter((e) => e !== id) : [...prev, id]
+                            );
+                        }}
+                        onClear={() => setSelectedPlayers([])}
+                        buttonLabel="Players"
+                        buttonIcon={<Users className="h-3.5 w-3.5" />}
+                    />
+                </div>
+                {(selectedColumnIds.length > 0 || selectedPlayers.length > 0) && (
+                    <div className="mt-2 flex flex-wrap items-center gap-2">
+                        <button
+                            type="button"
+                            onClick={() => {
+                                setSelectedColumnIds([]);
+                                setSelectedPlayers([]);
+                            }}
+                            className="inline-flex items-center gap-1 rounded-full border border-white/10 bg-white/10 px-2 py-1 text-[11px] text-gray-200 hover:text-white"
+                        >
+                            Clear All
+                        </button>
+                        {selectedColumnIds.map((id) => {
+                            const label = allColumnOptions.find((o) => o.id === id)?.label || id;
+                            return (
+                                <button
+                                    key={id}
+                                    type="button"
+                                    onClick={() => setSelectedColumnIds((prev) => prev.filter((e) => e !== id))}
+                                    className="inline-flex items-center gap-1 rounded-full border border-white/10 bg-white/5 px-2 py-1 text-[11px] text-gray-200 hover:text-white"
+                                >
+                                    <span>{label}</span>
+                                    <span className="text-gray-400">&times;</span>
+                                </button>
+                            );
+                        })}
+                        {selectedPlayers.map((id) => (
+                            <button
+                                key={id}
+                                type="button"
+                                onClick={() => setSelectedPlayers((prev) => prev.filter((e) => e !== id))}
+                                className="inline-flex items-center gap-1 rounded-full border border-white/10 bg-white/5 px-2 py-1 text-[11px] text-gray-200 hover:text-white"
+                            >
+                                <span>{id}</span>
+                                <span className="text-gray-400">&times;</span>
+                            </button>
+                        ))}
+                    </div>
+                )}
+            </div>
+            <div className="bg-black/30 border border-white/5 rounded-xl overflow-hidden">
+                {visibleMods.length === 0 ? (
+                    <div className="px-4 py-10 text-center text-gray-500 italic text-sm">No modifiers match this filter</div>
+                ) : (
+                    <DenseStatsTable
+                        title={`${config.title} - Dense View`}
+                        subtitle={incoming ? 'Incoming' : 'Outgoing'}
+                        sortColumnId={resolvedSortColumnId}
+                        sortDirection={denseSort.dir}
+                        onSortColumn={(columnId) => {
+                            setDenseSort((prev) => ({
+                                columnId,
+                                dir: prev.columnId === columnId ? (prev.dir === 'desc' ? 'asc' : 'desc') : 'desc',
+                            }));
+                        }}
+                        columns={visibleMods.map((mod) => ({
+                            id: mod.id,
+                            label: (
+                                <span className="flex items-center gap-1">
+                                    {mod.icon && <img src={mod.icon} alt="" className="w-3.5 h-3.5 object-contain" />}
+                                    <span className="truncate">{mod.name}</span>
+                                </span>
+                            ),
+                            align: 'right' as const,
+                            minWidth: 100,
+                        }))}
+                        rows={rows.map((entry, idx) => ({
+                            id: `${entry.row.account}-${idx}`,
+                            label: (
+                                <>
+                                    <span className="text-gray-500 font-mono">{idx + 1}</span>
+                                    {renderProfessionIcon(entry.row.profession, entry.row.professionList, 'w-4 h-4')}
+                                    <span className="truncate">{entry.row.account}</span>
+                                </>
+                            ),
+                            values: entry.values,
+                        }))}
+                    />
+                )}
+            </div>
+        </div>
     );
 };

--- a/src/renderer/stats/sections/DamageModifiersSection.tsx
+++ b/src/renderer/stats/sections/DamageModifiersSection.tsx
@@ -23,7 +23,7 @@ const SECTION_CONFIG = {
         accentBg: 'bg-rose-500/20',
         accentText: 'text-rose-200',
         accentBorder: 'border-rose-500/40',
-        barGradient: 'from-rose-500/40 to-rose-500/15',
+        barGradientStyle: 'linear-gradient(to right, rgba(244,63,94,0.4), rgba(244,63,94,0.15))',
     },
     incoming: {
         sectionId: 'incoming-damage-modifiers',
@@ -31,7 +31,7 @@ const SECTION_CONFIG = {
         accentBg: 'bg-blue-500/20',
         accentText: 'text-blue-200',
         accentBorder: 'border-blue-500/40',
-        barGradient: 'from-blue-500/40 to-blue-500/15',
+        barGradientStyle: 'linear-gradient(to right, rgba(59,130,246,0.4), rgba(59,130,246,0.15))',
     },
 };
 
@@ -289,35 +289,42 @@ const CollapsedView = ({
 }: CollapsedViewProps) => {
     const activeModInfo = modMap[effectiveActiveMod];
 
-    // Build player data for the active modifier
+    // Build player data for the active modifier (merged by account to handle splitPlayersByClass)
     const activeModPlayerData = useMemo(() => {
         if (!effectiveActiveMod) return [];
-        return playerRows
-            .map((row: any) => {
-                const modTotals: Record<string, ModTotals> = row[totalsKey] ?? {};
-                const modData = modTotals[effectiveActiveMod];
-                if (!modData) return null;
-                return {
+        const byAccount = new Map<string, {
+            account: string; profession: string; professionList: string[];
+            totalFightMs: number; damageGain: number; hitCount: number; totalHitCount: number; totalDamage: number;
+        }>();
+        for (const row of playerRows) {
+            const modTotals: Record<string, ModTotals> = row[totalsKey] ?? {};
+            const modData = modTotals[effectiveActiveMod];
+            if (!modData) continue;
+            const existing = byAccount.get(row.account);
+            if (existing) {
+                existing.damageGain += modData.damageGain;
+                existing.hitCount += modData.hitCount;
+                existing.totalHitCount += modData.totalHitCount;
+                existing.totalDamage += modData.totalDamage;
+                existing.totalFightMs += row.totalFightMs || 0;
+                if (row.professionList) {
+                    const seen = new Set(existing.professionList);
+                    for (const p of row.professionList) { if (!seen.has(p)) existing.professionList.push(p); }
+                }
+            } else {
+                byAccount.set(row.account, {
                     account: row.account,
                     profession: row.profession,
-                    professionList: row.professionList,
+                    professionList: row.professionList ? [...row.professionList] : [],
                     totalFightMs: row.totalFightMs || 0,
                     damageGain: modData.damageGain,
                     hitCount: modData.hitCount,
                     totalHitCount: modData.totalHitCount,
                     totalDamage: modData.totalDamage,
-                };
-            })
-            .filter(Boolean) as Array<{
-                account: string;
-                profession: string;
-                professionList: string[];
-                totalFightMs: number;
-                damageGain: number;
-                hitCount: number;
-                totalHitCount: number;
-                totalDamage: number;
-            }>;
+                });
+            }
+        }
+        return Array.from(byAccount.values());
     }, [playerRows, effectiveActiveMod, totalsKey]);
 
     // Sort the player data for the detail table
@@ -438,7 +445,7 @@ const CollapsedView = ({
                                 <>
                                     {/* Bar chart */}
                                     {contentViewMode === 'chart' && barChartData.length > 0 && (
-                                        <div className="px-4 py-3 bg-white/[0.02] border-b border-white/5">
+                                        <div className="px-4 py-3 bg-black/30 border-b border-white/5">
                                             <div className="flex flex-col gap-1.5">
                                                 {incoming ? (
                                                     /* Bidirectional bars for incoming */
@@ -461,12 +468,12 @@ const CollapsedView = ({
                                                                     {isReduction ? (
                                                                         /* Green bar extending left from center */
                                                                         <div className="absolute right-1/2 top-0 bottom-0 flex items-center justify-start" style={{ width: `${widthPct}%` }}>
-                                                                            <div className="w-full h-full rounded-l bg-gradient-to-l from-teal-500/40 to-teal-500/15" />
+                                                                            <div className="w-full h-full rounded-l" style={{ background: 'linear-gradient(to left, rgba(20,184,166,0.4), rgba(20,184,166,0.15))' }} />
                                                                         </div>
                                                                     ) : (
                                                                         /* Red bar extending right from center */
                                                                         <div className="absolute left-1/2 top-0 bottom-0 flex items-center justify-end" style={{ width: `${widthPct}%` }}>
-                                                                            <div className="w-full h-full rounded-r bg-gradient-to-r from-red-500/40 to-red-500/15" />
+                                                                            <div className="w-full h-full rounded-r" style={{ background: 'linear-gradient(to right, rgba(239,68,68,0.4), rgba(239,68,68,0.15))' }} />
                                                                         </div>
                                                                     )}
                                                                     {/* Label */}
@@ -496,8 +503,8 @@ const CollapsedView = ({
                                                                 </div>
                                                                 <div className="flex-1 relative h-5">
                                                                     <div
-                                                                        className={`absolute inset-y-0 left-0 rounded bg-gradient-to-r ${config.barGradient}`}
-                                                                        style={{ width: `${Math.max(widthPct, 0)}%` }}
+                                                                        className="absolute inset-y-0 left-0 rounded"
+                                                                        style={{ width: `${Math.max(widthPct, 0)}%`, background: config.barGradientStyle }}
                                                                     />
                                                                     <div className={`relative h-full flex items-center px-2 text-[10px] font-mono ${config.accentText}`}>
                                                                         +{formatWithCommas(row.damageGain, 0)} ({pctOfTotal}%)

--- a/src/renderer/stats/sections/DamageModifiersSection.tsx
+++ b/src/renderer/stats/sections/DamageModifiersSection.tsx
@@ -43,6 +43,7 @@ type ModSummary = {
     icon: string;
     description: string;
     squadDamageGain: number;
+    isPersonal: boolean;
 };
 
 export const DamageModifiersSection = ({
@@ -70,6 +71,10 @@ export const DamageModifiersSection = ({
         : ((stats as any).damageModPlayers ?? []);
 
     const totalsKey = incoming ? 'incomingDamageModTotals' : 'damageModTotals';
+    const personalModKeys = useMemo(() => new Set<string>((stats as any).personalDamageModKeys ?? []), [stats]);
+
+    // --- Hypothetical toggle ---
+    const [showHypothetical, setShowHypothetical] = useState(false);
 
     // --- Build sorted modifier list ---
     const modSummaries = useMemo<ModSummary[]>(() => {
@@ -81,6 +86,9 @@ export const DamageModifiersSection = ({
                 if (!info) continue;
                 // Filter: only show modifiers matching the incoming flag
                 if (info.incoming !== incoming) continue;
+                // Filter: hide hypothetical (shared) modifiers unless toggled
+                const isPersonal = personalModKeys.has(modId);
+                if (!isPersonal && !showHypothetical) continue;
                 if (!summaryMap[modId]) {
                     summaryMap[modId] = {
                         id: modId,
@@ -88,6 +96,7 @@ export const DamageModifiersSection = ({
                         icon: info.icon,
                         description: info.description,
                         squadDamageGain: 0,
+                        isPersonal,
                     };
                 }
                 summaryMap[modId].squadDamageGain += vals.damageGain;
@@ -96,7 +105,7 @@ export const DamageModifiersSection = ({
         return Object.values(summaryMap).sort(
             (a, b) => Math.abs(b.squadDamageGain) - Math.abs(a.squadDamageGain)
         );
-    }, [playerRows, modMap, incoming, totalsKey]);
+    }, [playerRows, modMap, incoming, totalsKey, personalModKeys, showHypothetical]);
 
     // --- Filtered modifiers by search ---
     const filteredMods = useMemo(() => {
@@ -189,15 +198,29 @@ export const DamageModifiersSection = ({
                     )}
                     {config.title}
                 </h3>
-                <button
-                    type="button"
-                    onClick={() => (isExpanded ? closeExpandedSection() : openExpandedSection(config.sectionId))}
-                    className="p-2 rounded-lg border border-white/10 bg-white/5 text-gray-300 hover:text-white hover:border-white/30 transition-colors"
-                    aria-label={isExpanded ? `Close ${config.title}` : `Expand ${config.title}`}
-                    title={isExpanded ? 'Close' : 'Expand'}
-                >
-                    {isExpanded ? <X className="w-4 h-4" /> : <Maximize2 className="w-4 h-4" />}
-                </button>
+                <div className="flex items-center gap-2">
+                    <button
+                        type="button"
+                        onClick={() => setShowHypothetical((v) => !v)}
+                        className={`px-2.5 py-1.5 rounded-lg border text-[10px] uppercase tracking-widest transition-colors ${
+                            showHypothetical
+                                ? `${config.accentBg} ${config.accentText} ${config.accentBorder}`
+                                : 'border-white/10 bg-white/5 text-gray-400 hover:text-white hover:border-white/30'
+                        }`}
+                        title={showHypothetical ? 'Showing all modifiers (including hypothetical)' : 'Show hypothetical shared modifiers'}
+                    >
+                        Hypothetical
+                    </button>
+                    <button
+                        type="button"
+                        onClick={() => (isExpanded ? closeExpandedSection() : openExpandedSection(config.sectionId))}
+                        className="p-2 rounded-lg border border-white/10 bg-white/5 text-gray-300 hover:text-white hover:border-white/30 transition-colors"
+                        aria-label={isExpanded ? `Close ${config.title}` : `Expand ${config.title}`}
+                        title={isExpanded ? 'Close' : 'Expand'}
+                    >
+                        {isExpanded ? <X className="w-4 h-4" /> : <Maximize2 className="w-4 h-4" />}
+                    </button>
+                </div>
             </div>
 
             {modSummaries.length === 0 ? (
@@ -279,6 +302,7 @@ const CollapsedView = ({
     isExpanded, formatWithCommas, renderProfessionIcon, sidebarListClass, expandedSection,
 }: CollapsedViewProps) => {
     const activeModInfo = modMap[effectiveActiveMod];
+    const activeModIsHypothetical = !filteredMods.find((m) => m.id === effectiveActiveMod)?.isPersonal;
 
     // Build player data for the active modifier (merged by account to handle splitPlayersByClass)
     const activeModPlayerData = useMemo(() => {
@@ -383,7 +407,7 @@ const CollapsedView = ({
                                         effectiveActiveMod === mod.id
                                             ? `${config.accentBg} ${config.accentText} ${config.accentBorder}`
                                             : 'bg-white/5 text-gray-300 border-white/10 hover:text-white'
-                                    }`}
+                                    } ${!mod.isPersonal ? 'opacity-50' : ''}`}
                                 >
                                     {mod.icon && (
                                         <img src={mod.icon} alt="" className="w-4 h-4 object-contain flex-shrink-0" />
@@ -478,7 +502,7 @@ const CollapsedView = ({
                                                     ? 'linear-gradient(to right, rgba(239,68,68,0.2), rgba(239,68,68,0.05))'
                                                     : config.barGradientStyle;
                                             return (
-                                                <div key={`${row.account}-${idx}`} className="relative border-t border-white/5">
+                                                <div key={`${row.account}-${idx}`} className={`relative border-t border-white/5 ${activeModIsHypothetical ? 'opacity-50' : ''}`}>
                                                     {/* Bar overlay — negative grows from right, positive from left */}
                                                     <div
                                                         className={`absolute inset-y-0 pointer-events-none ${isNegative ? 'right-0' : 'left-0'}`}

--- a/src/renderer/stats/sections/DamageModifiersSection.tsx
+++ b/src/renderer/stats/sections/DamageModifiersSection.tsx
@@ -390,7 +390,7 @@ const CollapsedView = ({
                                     )}
                                     <span className="flex flex-col min-w-0">
                                         <span className="truncate">{mod.name}</span>
-                                        <span className="text-[10px] text-gray-500 font-normal">
+                                        <span className={`text-[10px] font-normal ${mod.squadDamageGain < 0 ? 'text-teal-500' : 'text-gray-500'}`}>
                                             {mod.squadDamageGain >= 0 ? '+' : ''}{formatWithCommas(mod.squadDamageGain, 0)} squad total
                                         </span>
                                     </span>
@@ -471,17 +471,17 @@ const CollapsedView = ({
                                             const barWidthPct = maxAbsGain > 0
                                                 ? (Math.abs(row.damageGain) / maxAbsGain) * 100
                                                 : 0;
-                                            const isReduction = incoming && row.damageGain < 0;
-                                            const barStyle = incoming
-                                                ? (isReduction
-                                                    ? 'linear-gradient(to left, rgba(20,184,166,0.2), rgba(20,184,166,0.05))'
-                                                    : 'linear-gradient(to right, rgba(239,68,68,0.2), rgba(239,68,68,0.05))')
-                                                : config.barGradientStyle;
+                                            const isNegative = row.damageGain < 0;
+                                            const barStyle = isNegative
+                                                ? 'linear-gradient(to left, rgba(20,184,166,0.2), rgba(20,184,166,0.05))'
+                                                : incoming
+                                                    ? 'linear-gradient(to right, rgba(239,68,68,0.2), rgba(239,68,68,0.05))'
+                                                    : config.barGradientStyle;
                                             return (
                                                 <div key={`${row.account}-${idx}`} className="relative border-t border-white/5">
-                                                    {/* Bar overlay — mitigation grows from right, damage from left */}
+                                                    {/* Bar overlay — negative grows from right, positive from left */}
                                                     <div
-                                                        className={`absolute inset-y-0 pointer-events-none ${isReduction ? 'right-0' : 'left-0'}`}
+                                                        className={`absolute inset-y-0 pointer-events-none ${isNegative ? 'right-0' : 'left-0'}`}
                                                         style={{ width: `${barWidthPct}%`, background: barStyle }}
                                                     />
                                                     {/* Row content */}
@@ -491,7 +491,7 @@ const CollapsedView = ({
                                                             {renderProfessionIcon(row.profession, row.professionList, 'w-4 h-4')}
                                                             <span className="truncate">{row.account}</span>
                                                         </div>
-                                                        <div className="text-right font-mono text-gray-300">
+                                                        <div className={`text-right font-mono ${isNegative ? 'text-teal-400' : incoming ? 'text-red-400' : config.accentText}`}>
                                                             {row.damageGain >= 0 ? '+' : ''}{formatWithCommas(row.damageGain, 0)}
                                                         </div>
                                                         <div className="text-right font-mono text-gray-400">

--- a/src/renderer/stats/sections/DamageModifiersSection.tsx
+++ b/src/renderer/stats/sections/DamageModifiersSection.tsx
@@ -406,10 +406,11 @@ const CollapsedView = ({
                                     <div className="flex flex-col min-w-0">
                                         <div className="text-sm font-semibold text-gray-200">{activeModInfo.name}</div>
                                         {activeModInfo.description && (
-                                            <div
-                                                className="text-[11px] text-gray-400 leading-tight mt-0.5"
-                                                dangerouslySetInnerHTML={{ __html: activeModInfo.description }}
-                                            />
+                                            <div className="text-[11px] text-gray-400 leading-tight mt-0.5">
+                                                {activeModInfo.description.split(/<br\s*\/?>/).map((part, i, arr) => (
+                                                    <span key={i}>{part}{i < arr.length - 1 && <br />}</span>
+                                                ))}
+                                            </div>
                                         )}
                                     </div>
                                 </div>

--- a/src/renderer/stats/sections/DamageModifiersSection.tsx
+++ b/src/renderer/stats/sections/DamageModifiersSection.tsx
@@ -79,6 +79,8 @@ export const DamageModifiersSection = ({
             for (const [modId, vals] of Object.entries(modTotals)) {
                 const info = modMap[modId];
                 if (!info) continue;
+                // Filter: only show modifiers matching the incoming flag
+                if (info.incoming !== incoming) continue;
                 if (!summaryMap[modId]) {
                     summaryMap[modId] = {
                         id: modId,

--- a/src/renderer/stats/utils/pruneStatsLog.ts
+++ b/src/renderer/stats/utils/pruneStatsLog.ts
@@ -88,6 +88,7 @@ export const pruneDetailsForStats = (details: any) => {
         'skillMap',
         'buffMap',
         'damageModMap',
+        'personalDamageMods',
         'encounterDuration',
         'player_damage_mitigation',
         'player_minion_damage_mitigation',

--- a/src/renderer/stats/utils/pruneStatsLog.ts
+++ b/src/renderer/stats/utils/pruneStatsLog.ts
@@ -87,6 +87,7 @@ export const pruneDetailsForStats = (details: any) => {
         'combatReplayMetaData',
         'skillMap',
         'buffMap',
+        'damageModMap',
         'encounterDuration',
         'player_damage_mitigation',
         'player_minion_damage_mitigation',
@@ -95,6 +96,20 @@ export const pruneDetailsForStats = (details: any) => {
     ]);
     pruned.skillMap = pruneMetaMap(pruned.skillMap, { includeClassification: false, includeStacking: false });
     pruned.buffMap = pruneMetaMap(pruned.buffMap, { includeClassification: true, includeStacking: true });
+    if (pruned.damageModMap && typeof pruned.damageModMap === 'object') {
+        const prunedModMap: Record<string, any> = {};
+        Object.entries(pruned.damageModMap).forEach(([key, value]) => {
+            if (!value || typeof value !== 'object') return;
+            const v = value as any;
+            prunedModMap[key] = {
+                ...(typeof v.name === 'string' ? { name: v.name } : {}),
+                ...(typeof v.icon === 'string' ? { icon: v.icon } : {}),
+                ...(typeof v.description === 'string' ? { description: v.description } : {}),
+                ...(typeof v.incoming === 'boolean' ? { incoming: v.incoming } : {}),
+            };
+        });
+        pruned.damageModMap = prunedModMap;
+    }
     if (Array.isArray(pruned.players)) {
         const sourcePlayers = details.players as any[];
         const squadPlayers = sourcePlayers.filter((player: any) => !player?.notInSquad);
@@ -142,7 +157,9 @@ export const pruneDetailsForStats = (details: any) => {
                 'teamId',
                 'team',
                 'teamColor',
-                'team_color'
+                'team_color',
+                'damageModifiers',
+                'incomingDamageModifiers'
             ]);
             const minions = Array.isArray(player?.minions) ? player.minions : [];
             out.minions = minions.map((minion: any) => pick(minion, ['name', 'totalDamageTakenDist']));

--- a/src/shared/dpsReportTypes.ts
+++ b/src/shared/dpsReportTypes.ts
@@ -1,3 +1,23 @@
+export interface DamageModifierInfo {
+    name: string;
+    icon: string;
+    description: string;
+    nonMultiplier: boolean;
+    skillBased: boolean;
+    approximate: boolean;
+    incoming: boolean;
+}
+
+export interface DamageModifierData {
+    id: number;
+    damageModifiers: Array<{
+        hitCount: number;
+        totalHitCount: number;
+        damageGain: number;
+        totalDamage: number;
+    }>;
+}
+
 export interface DPSReportJSON {
     evtc: {
         type: string;
@@ -15,6 +35,8 @@ export interface DPSReportJSON {
     skillMap?: { [key: string]: { name: string; icon: string } };
     buffMap?: { [key: string]: { name: string; stacking: boolean; icon?: string; classification?: string } };
     combatReplayMetaData?: { inchToPixel?: number; pollingRate?: number };
+    damageModMap?: Record<string, DamageModifierInfo>;
+    personalDamageMods?: Record<string, number[]>;
 }
 
 export interface Target {
@@ -71,6 +93,8 @@ export interface Player {
     account?: string;
     stabGeneration?: number; // Calculated field
     activeTimes?: number[];
+    damageModifiers?: DamageModifierData[];
+    incomingDamageModifiers?: DamageModifierData[];
 }
 
 export interface StatsAll {

--- a/src/shared/dpsReportTypes.ts
+++ b/src/shared/dpsReportTypes.ts
@@ -36,6 +36,7 @@ export interface DPSReportJSON {
     buffMap?: { [key: string]: { name: string; stacking: boolean; icon?: string; classification?: string } };
     combatReplayMetaData?: { inchToPixel?: number; pollingRate?: number };
     damageModMap?: Record<string, DamageModifierInfo>;
+    personalDamageMods?: Record<string, number[]>;
 }
 
 export interface Target {

--- a/src/shared/dpsReportTypes.ts
+++ b/src/shared/dpsReportTypes.ts
@@ -36,7 +36,6 @@ export interface DPSReportJSON {
     buffMap?: { [key: string]: { name: string; stacking: boolean; icon?: string; classification?: string } };
     combatReplayMetaData?: { inchToPixel?: number; pollingRate?: number };
     damageModMap?: Record<string, DamageModifierInfo>;
-    personalDamageMods?: Record<string, number[]>;
 }
 
 export interface Target {

--- a/src/shared/dpsReportTypes.ts
+++ b/src/shared/dpsReportTypes.ts
@@ -2,9 +2,9 @@ export interface DamageModifierInfo {
     name: string;
     icon: string;
     description: string;
-    nonMultiplier: boolean;
-    skillBased: boolean;
-    approximate: boolean;
+    nonMultiplier?: boolean;
+    skillBased?: boolean;
+    approximate?: boolean;
     incoming: boolean;
 }
 


### PR DESCRIPTION
## Summary

- **Two new stats sections** showing per-buff/trait/relic damage contribution from EI's damage modifier data
  - **Damage Modifiers** (Offensive Stats) — outgoing damage buffs with bar-overlay table rows
  - **Incoming Damage Modifiers** (Defensive Stats) — incoming damage reduction/increase modifiers
- Bar chart overlays behind each table row showing relative damage gain
- Negative modifiers (damage reduced by enemy buffs) shown with teal right-to-left bars
- Expanded/fullscreen dense table view with modifiers as columns, players as rows
- **Hypothetical toggle** — by default only shows personal/profession-specific modifiers; toggle reveals shared modifiers (relics, food) that EI calculates for all players at 50% opacity
- Stale cache invalidation: auto re-fetches details missing `damageModMap`

## Files changed

- `src/shared/dpsReportTypes.ts` / `src/main/dpsReportTypes.ts` — new types
- `src/main/detailsProcessing.ts` — main process pruning preservation
- `src/renderer/stats/utils/pruneStatsLog.ts` — renderer pruning preservation
- `src/renderer/stats/computePlayerAggregation.ts` — per-player modifier aggregation
- `src/renderer/stats/computeStatsAggregation.ts` — merged modMap, personalDamageModKeys
- `src/renderer/stats/sections/DamageModifiersSection.tsx` — **new** shared component
- `src/renderer/StatsView.tsx` — section integration
- `src/renderer/stats/hooks/useStatsNavigation.ts` — nav group registration
- `src/main/index.ts` / `src/main/handlers/uploadHandlers.ts` — cache invalidation
- `src/renderer/app/hooks/useDetailsHydration.ts` — stale details re-hydration

## Test plan

- [x] Unit tests for damage modifier aggregation (3 tests)
- [x] All 421 existing tests pass
- [x] Typecheck + lint clean
- [ ] Manual: verify sections appear in Offensive/Defensive nav groups
- [ ] Manual: verify bar overlays render on all themes
- [ ] Manual: verify hypothetical toggle filters correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)