### PR TITLE
feat: add Casts, Hits, and Hits/Cast to player skill drill-down

### DIFF
--- a/src/renderer/__tests__/computeStatsAggregation.skillDamage.test.ts
+++ b/src/renderer/__tests__/computeStatsAggregation.skillDamage.test.ts
@@ -406,4 +406,141 @@ describe('computeStatsAggregation (skill damage source reconciliation)', () => {
         expect(topWhirlwind).toBeTruthy();
         expect(Number(topWhirlwind.damage || 0)).toBe(355);
     });
+
+    it('aggregates casts from rotation data into player skill breakdown', () => {
+        const arcDividerId = 29852;
+        const playerKey = 'TestPlayer.1234';
+        const log = {
+            status: 'success',
+            filePath: 'skill-casts-test',
+            details: {
+                durationMS: 10000,
+                skillMap: {
+                    [`s${arcDividerId}`]: { name: 'Arc Divider', icon: 'https://example.invalid/arc.png' }
+                },
+                buffMap: {},
+                players: [
+                    {
+                        account: 'TestPlayer.1234',
+                        profession: 'Berserker',
+                        notInSquad: false,
+                        dpsAll: [{ damage: 50000, dps: 5000 }],
+                        statsAll: [{ connectedDamageCount: 20 }],
+                        support: [{ resurrects: 0 }],
+                        damage1S: [[0, 10000, 20000, 30000, 40000, 50000]],
+                        targetDamage1S: [[[0, 10000, 20000, 30000, 40000, 50000]]],
+                        targetDamageDist: [[[
+                            { id: arcDividerId, totalDamage: 50000, connectedHits: 20, hits: 20, min: 1000, max: 5000, downContribution: 10000 }
+                        ]]],
+                        totalDamageDist: [[
+                            { id: arcDividerId, totalDamage: 50000, connectedHits: 20, hits: 20, min: 1000, max: 5000, downContribution: 10000 }
+                        ]],
+                        rotation: [
+                            { id: arcDividerId, skills: [0, 1500, 3000, 4500, 6000] }
+                        ]
+                    }
+                ],
+                targets: []
+            }
+        };
+
+        const { stats } = computeStatsAggregation({ logs: [log as any] });
+        const playerBreakdown = (stats.playerSkillBreakdowns || []).find((entry: any) => entry.key === playerKey);
+        expect(playerBreakdown).toBeTruthy();
+        const skill = (playerBreakdown.skills || []).find((s: any) => s.name === 'Arc Divider');
+        expect(skill).toBeTruthy();
+        expect(skill.casts).toBe(5);
+        expect(skill.hits).toBe(20);
+    });
+
+    it('sets casts to 0 for skills without rotation data (conditions/procs)', () => {
+        const vampAuraId = 30285;
+        const playerKey = 'TestPlayer.1234';
+        const log = {
+            status: 'success',
+            filePath: 'skill-casts-no-rotation-test',
+            details: {
+                durationMS: 10000,
+                skillMap: {},
+                buffMap: {
+                    [`b${vampAuraId}`]: { name: 'Vampiric Aura', icon: 'https://example.invalid/vamp.png' }
+                },
+                players: [
+                    {
+                        account: 'TestPlayer.1234',
+                        profession: 'Berserker',
+                        notInSquad: false,
+                        dpsAll: [{ damage: 5000, dps: 500 }],
+                        statsAll: [{ connectedDamageCount: 3 }],
+                        support: [{ resurrects: 0 }],
+                        damage1S: [[0, 1000, 2000, 3000, 4000, 5000]],
+                        targetDamage1S: [[[0, 1000, 2000, 3000, 4000, 5000]]],
+                        targetDamageDist: [[[
+                            { id: vampAuraId, totalDamage: 5000, connectedHits: 3, hits: 3, min: 1000, max: 2000 }
+                        ]]],
+                        totalDamageDist: [[
+                            { id: vampAuraId, totalDamage: 5000, connectedHits: 3, hits: 3, min: 1000, max: 2000 }
+                        ]],
+                        rotation: []
+                    }
+                ],
+                targets: []
+            }
+        };
+
+        const { stats } = computeStatsAggregation({ logs: [log as any] });
+        const playerBreakdown = (stats.playerSkillBreakdowns || []).find((entry: any) => entry.key === playerKey);
+        expect(playerBreakdown).toBeTruthy();
+        const skill = (playerBreakdown.skills || []).find((s: any) => s.name === 'Vampiric Aura');
+        expect(skill).toBeTruthy();
+        expect(skill.casts).toBe(0);
+    });
+
+    it('aggregates casts across multiple logs', () => {
+        const arcDividerId = 29852;
+        const playerKey = 'TestPlayer.1234';
+        const makeLog = (casts: number[], hits: number, damage: number) => ({
+            status: 'success',
+            filePath: `skill-casts-multi-${casts.length}`,
+            details: {
+                durationMS: 5000,
+                skillMap: {
+                    [`s${arcDividerId}`]: { name: 'Arc Divider' }
+                },
+                buffMap: {},
+                players: [
+                    {
+                        account: 'TestPlayer.1234',
+                        profession: 'Berserker',
+                        notInSquad: false,
+                        dpsAll: [{ damage, dps: damage / 5 }],
+                        statsAll: [{ connectedDamageCount: hits }],
+                        support: [{ resurrects: 0 }],
+                        damage1S: [[0, damage]],
+                        targetDamage1S: [[[0, damage]]],
+                        targetDamageDist: [[[
+                            { id: arcDividerId, totalDamage: damage, connectedHits: hits, hits, min: 500, max: 3000 }
+                        ]]],
+                        totalDamageDist: [[
+                            { id: arcDividerId, totalDamage: damage, connectedHits: hits, hits, min: 500, max: 3000 }
+                        ]],
+                        rotation: [
+                            { id: arcDividerId, skills: casts }
+                        ]
+                    }
+                ],
+                targets: []
+            }
+        });
+
+        const { stats } = computeStatsAggregation({
+            logs: [makeLog([0, 1000, 2000], 10, 20000) as any, makeLog([0, 1000], 8, 15000) as any]
+        });
+        const playerBreakdown = (stats.playerSkillBreakdowns || []).find((entry: any) => entry.key === playerKey);
+        expect(playerBreakdown).toBeTruthy();
+        const skill = (playerBreakdown.skills || []).find((s: any) => s.name === 'Arc Divider');
+        expect(skill).toBeTruthy();
+        expect(skill.casts).toBe(5);
+        expect(skill.hits).toBe(18);
+    });
 });

--- a/src/renderer/stats/computePlayerAggregation.ts
+++ b/src/renderer/stats/computePlayerAggregation.ts
@@ -1013,7 +1013,7 @@ export const computePlayerAggregation = ({
                 const skillId = `s${entry.id}`;
                 let skillEntry = playerBreakdown!.skills.get(skillId);
                 if (!skillEntry) {
-                    skillEntry = { id: skillId, name, icon, damage: 0, downContribution: 0, hits: 0, min: Infinity, max: 0 };
+                    skillEntry = { id: skillId, name, icon, damage: 0, downContribution: 0, hits: 0, casts: 0, min: Infinity, max: 0 };
                     playerBreakdown!.skills.set(skillId, skillEntry);
                 }
                 if (skillEntry.name.startsWith('Skill ') && !name.startsWith('Skill ')) skillEntry.name = name;
@@ -1086,6 +1086,19 @@ export const computePlayerAggregation = ({
                         });
                     });
                 }
+            }
+            // Inject cast counts from rotation data
+            if (Array.isArray(p.rotation)) {
+                p.rotation.forEach((rot: any) => {
+                    if (!rot?.id) return;
+                    const count = rot.skills?.length || 0;
+                    if (count <= 0) return;
+                    const skillId = `s${rot.id}`;
+                    const skillEntry = playerBreakdown!.skills.get(skillId);
+                    if (skillEntry) {
+                        skillEntry.casts += count;
+                    }
+                });
             }
             if (p.totalDamageTaken) {
                 p.totalDamageTaken.forEach((list: any) => {

--- a/src/renderer/stats/sections/PlayerBreakdownSection.tsx
+++ b/src/renderer/stats/sections/PlayerBreakdownSection.tsx
@@ -587,7 +587,15 @@ export const PlayerBreakdownSection = ({
                                                                     : 0
                                                             )
                                                         },
-                                                        { label: 'Max Hit', value: formatTopStatValue(activePlayerSkill?.max || 0) }
+                                                        { label: 'Max Hit', value: formatTopStatValue(activePlayerSkill?.max || 0) },
+                                                        { label: 'Casts', value: formatTopStatValue(activePlayerSkill?.casts || 0) },
+                                                        { label: 'Hits', value: formatTopStatValue(activePlayerSkill?.hits || 0) },
+                                                        {
+                                                            label: 'Hits / Cast',
+                                                            value: (activePlayerSkill?.casts || 0) > 0
+                                                                ? formatWithCommas((activePlayerSkill?.hits || 0) / (activePlayerSkill?.casts || 1), 2)
+                                                                : '—'
+                                                        }
                                                     ]).map((row) => (
                                                         <div key={row.label} className="grid grid-cols-[1.2fr_0.8fr] px-3 py-2 text-xs text-[color:var(--text-primary)] border-b border-[color:var(--border-subtle)] hover:bg-[var(--bg-hover)]">
                                                             <div className="font-semibold text-white">{row.label}</div>

--- a/src/renderer/stats/statsTypes.ts
+++ b/src/renderer/stats/statsTypes.ts
@@ -44,6 +44,7 @@ export interface PlayerSkillDamageEntry {
     damage: number;
     downContribution: number;
     hits: number;
+    casts: number;
     min: number;
     max: number;
 }


### PR DESCRIPTION
## Summary
- Adds `casts` field to `PlayerSkillDamageEntry`, populated from EI JSON rotation data during aggregation
- Displays three new metrics (Casts, Hits, Hits/Cast) in the player breakdown skill drill-down, after the existing damage metrics
- Skills without rotation data (condition ticks, procs) show 0 casts and "—" for Hits/Cast

## Test plan
- [x] 3 new unit tests: basic cast aggregation, zero casts for conditions/procs, multi-log accumulation
- [x] All 505 unit tests pass
- [x] Typecheck and lint clean (`npm run validate`)
- [ ] Manual: select a player → click a skill → verify Casts, Hits, and Hits/Cast rows appear below Max Hit
- [ ] Manual: select a condition/proc skill → verify Hits/Cast shows "—"

🤖 Generated with [Claude Code](https://claude.com/claude-code)