### PR TITLE
feat: add Stab Performance section with party overlay drilldowns

### DIFF
--- a/src/renderer/StatsView.tsx
+++ b/src/renderer/StatsView.tsx
@@ -53,6 +53,7 @@ import { SquadCompositionSection } from './stats/sections/SquadCompositionSectio
 import { TimelineSection } from './stats/sections/TimelineSection';
 import { MapDistributionSection } from './stats/sections/MapDistributionSection';
 import { SpikeDamageSection } from './stats/sections/SpikeDamageSection';
+import { StabPerformanceSection } from './stats/sections/StabPerformanceSection';
 import { AllDamageSection } from './stats/sections/AllDamageSection';
 import { AllBoonsSection } from './stats/sections/AllBoonsSection';
 import type { AllBoonsBoon } from './stats/sections/AllBoonsSection';
@@ -129,6 +130,7 @@ const ORDERED_SECTION_IDS = [
     'all-boons',
     'boon-timeline',
     'boon-uptime',
+    'stab-performance',
     'offense-detailed',
     'damage-modifiers',
     'player-breakdown',
@@ -793,6 +795,12 @@ export const StatsView = memo(function StatsView({ logs, onBack: _onBack, mvpWei
     const [selectedBoonTimelinePlayerKey, setSelectedBoonTimelinePlayerKey] = useState<string | null>(null);
     const [selectedBoonTimelineFightIndex, setSelectedBoonTimelineFightIndex] = useState<number | null>(null);
     const [showBoonTimelineIncomingHeatmap, setShowBoonTimelineIncomingHeatmap] = useState(false);
+    const [stabPerfPlayerFilter, setStabPerfPlayerFilter] = useState('');
+    const [selectedStabPerfPlayerKey, setSelectedStabPerfPlayerKey] = useState<string | null>(null);
+    const [selectedStabPerfFightIndex, setSelectedStabPerfFightIndex] = useState<number | null>(null);
+    const [showStabPerfHeatmap, setShowStabPerfHeatmap] = useState(false);
+    const [showStabPerfDeaths, setShowStabPerfDeaths] = useState(true);
+    const [showStabPerfDistance, setShowStabPerfDistance] = useState(true);
     const [allBoonsActiveBoonId, setAllBoonsActiveBoonId] = useState<string | null>(null);
     const [allBoonsScope, setAllBoonsScope] = useState<'selfBuffs' | 'groupBuffs' | 'squadBuffs' | 'totalBuffs'>('squadBuffs');
     const [allBoonsSelectedFightIndex, setAllBoonsSelectedFightIndex] = useState<number | null>(null);
@@ -3237,6 +3245,315 @@ type SpikeFight = {
             data: dataWithIncoming
         };
     }, [selectedBoonTimelineFightIndex, boonTimelineChartData, activeBoonTimeline, selectedBoonTimelinePlayerKey, boonTimelineScope, boonTimelineScopeLabel, squadIncomingDamageBucketsByFightId, fallbackIncomingDamageBucketsByFightId, squadIncomingDamageTotalByFightId]);
+
+    // ── Stab Performance (stability boon b1122) ──────────────────────────
+    const stabBoon = useMemo(() =>
+        boonTimelineBoons.find((b: any) => String(b?.id || '') === 'b1122') || null,
+        [boonTimelineBoons]
+    );
+    const stabPerfPlayersWithScope = useMemo(() => {
+        if (!stabBoon) return [];
+        const players = Array.isArray(stabBoon?.players) ? stabBoon.players : [];
+        return [...players]
+            .map((player: any) => ({
+                ...player,
+                total: getBoonTimelineScopeTotal(player, 'squadBuffs')
+            }))
+            .sort((a: any, b: any) => Number(b.total || 0) - Number(a.total || 0)
+                || String(a.displayName || '').localeCompare(String(b.displayName || '')));
+    }, [stabBoon]);
+    const stabPerfFilteredPlayers = useMemo(() => {
+        const term = stabPerfPlayerFilter.trim().toLowerCase();
+        if (!term) return stabPerfPlayersWithScope;
+        return stabPerfPlayersWithScope.filter((p: any) =>
+            String(p?.displayName || '').toLowerCase().includes(term)
+            || String(p?.account || '').toLowerCase().includes(term)
+            || String(p?.profession || '').toLowerCase().includes(term)
+        );
+    }, [stabPerfPlayersWithScope, stabPerfPlayerFilter]);
+    const stabPerfPlayerMap = useMemo(() => {
+        const map = new Map<string, any>();
+        stabPerfPlayersWithScope.forEach((p: any) => map.set(String(p?.key || ''), p));
+        return map;
+    }, [stabPerfPlayersWithScope]);
+    const selectedStabPerfPlayer = selectedStabPerfPlayerKey
+        ? stabPerfPlayerMap.get(selectedStabPerfPlayerKey) || null
+        : null;
+    const stabPerfChartData = useMemo<Array<{
+        index: number;
+        fightId: string;
+        shortLabel: string;
+        fullLabel: string;
+        timestamp: number;
+        total: number;
+        maxTotal: number;
+    }>>(() => {
+        if (!stabBoon || !selectedStabPerfPlayerKey) return [];
+        return (stabBoon.fights || []).map((fight: any, index: number) => {
+            const playerValue = fight?.values?.[selectedStabPerfPlayerKey];
+            const computedFightMax = Object.entries((fight?.values && typeof fight.values === 'object') ? fight.values : {})
+                .filter(([key]) => String(key || '') !== '__all__')
+                .reduce((best: number, [, value]: [string, any]) => Math.max(best, getBoonTimelineScopeTotal(value, 'squadBuffs')), 0);
+            return {
+                index,
+                fightId: String(fight?.id || ''),
+                shortLabel: String(fight?.shortLabel || `F${index + 1}`),
+                fullLabel: String(fight?.fullLabel || `Fight ${index + 1}`),
+                timestamp: Number(fight?.timestamp || 0),
+                total: getBoonTimelineScopeTotal(playerValue, 'squadBuffs'),
+                maxTotal: computedFightMax > 0 ? computedFightMax : Number(fight?.maxTotal || 0)
+            };
+        });
+    }, [stabBoon, selectedStabPerfPlayerKey]);
+    const stabPerfChartMaxY = useMemo(() => {
+        const selectedPeak = stabPerfChartData.reduce((best, e) => Math.max(best, Number(e?.total || 0)), 0);
+        const fightPeak = stabPerfChartData.reduce((best, e) => Math.max(best, Number(e?.maxTotal || 0)), 0);
+        return Math.max(1, selectedPeak, fightPeak);
+    }, [stabPerfChartData]);
+    const stabPerfDrilldown = useMemo(() => {
+        const emptyResult = {
+            title: 'Fight Breakdown (5s Squad Stab Generation Buckets)',
+            data: [] as Array<{ label: string; value: number; incomingDamage: number; incomingIntensity: number; partyDeaths: number; partyDeathNames: string[]; partyAvgDistance: number; partyFarNames: string[]; [key: string]: any }>,
+            partyMembers: [] as Array<{ key: string; displayName: string }>
+        };
+        const selectedPoint = selectedStabPerfFightIndex === null
+            ? null
+            : stabPerfChartData.find((e) => e.index === selectedStabPerfFightIndex) || null;
+        if (!selectedPoint || !stabBoon || !selectedStabPerfPlayerKey) {
+            return emptyResult;
+        }
+        const selectedFight = stabBoon.fights[selectedPoint.index];
+        if (!selectedFight) return emptyResult;
+        const playerValue = selectedFight?.values?.[selectedStabPerfPlayerKey] || {
+            total: 0,
+            totals: { selfBuffs: 0, groupBuffs: 0, squadBuffs: 0, totalBuffs: 0 },
+            bucketWeights5s: [],
+            buckets5s: []
+        };
+        const rawBuckets5s = Array.isArray(playerValue?.buckets5s) ? playerValue.buckets5s : [];
+        const rawWeights5s = Array.isArray(playerValue?.bucketWeights5s) ? playerValue.bucketWeights5s : [];
+        const durationMS = Number(selectedFight?.durationMs || selectedFight?.durationMS || 0);
+        const durationBuckets = durationMS > 0 ? Math.ceil(durationMS / 5000) : rawBuckets5s.length;
+        const bucketCount = Math.max(1, durationBuckets, rawBuckets5s.length);
+        const data: Array<{ label: string; value: number; partyDeaths: number; partyDeathNames: string[]; partyAvgDistance: number; partyFarNames: string[] }> = Array.from({ length: bucketCount }, (_, i) => {
+            const rawVal = rawBuckets5s[i];
+            const weight = Number(rawWeights5s[i] || 0);
+            let value: number;
+            if (rawVal !== undefined && rawVal !== null) {
+                value = Number(rawVal);
+            } else {
+                value = 0;
+            }
+            if (weight > 0 && weight < 1) {
+                value = value / weight;
+            }
+            return {
+                label: `${i * 5}s-${(i + 1) * 5}s`,
+                value: Math.max(0, value),
+                partyDeaths: 0,
+                partyDeathNames: [],
+                partyAvgDistance: 0,
+                partyFarNames: []
+            };
+        });
+        const selectedFightId = String(selectedFight?.id || '');
+        const pointFightId = String(selectedPoint?.fightId || '');
+        const sortedLogs = [...logs]
+            .map((log: any) => ({ log, ts: parseTimestamp(log?.details?.uploadTime ?? log?.uploadTime ?? log?.details?.timeStartStd ?? log?.details?.timeStart) }))
+            .sort((a, b) => a.ts - b.ts);
+        const logAtIndex = sortedLogs[selectedPoint.index]?.log;
+        const selectedLog = logs.find((log: any) =>
+            String(log?.filePath || '') === selectedFightId
+            || String(log?.id || '') === selectedFightId
+        ) || logAtIndex;
+        const selectedLogDetails = getDetails(selectedLog);
+        const normPath = (p: string) => p.replace(/\\/g, '/').toLowerCase();
+        const normFightId = normPath(selectedFightId);
+        const normPointId = normPath(pointFightId);
+        const findInDmgMap = <T,>(m: Map<string, T>): T | undefined => {
+            const direct = m.get(selectedFightId) ?? m.get(pointFightId);
+            if (direct !== undefined) return direct;
+            for (const [k, v] of m) {
+                if (normPath(k) === normFightId || normPath(k) === normPointId) return v;
+            }
+            return undefined;
+        };
+        const primaryIncoming: number[] = (findInDmgMap(squadIncomingDamageBucketsByFightId) as any)?.buckets ?? [];
+        const fallbackIncoming: number[] = findInDmgMap(fallbackIncomingDamageBucketsByFightId) ?? [];
+        const primaryTotal = primaryIncoming.reduce((s: number, v: number) => s + Number(v || 0), 0);
+        const fallbackTotal = fallbackIncoming.reduce((s: number, v: number) => s + Number(v || 0), 0);
+        const incomingShape = primaryTotal > 0 ? primaryIncoming : fallbackIncoming;
+        const incomingShapeTotal = primaryTotal > 0 ? primaryTotal : fallbackTotal;
+        const incomingTotal = Math.max(0, Number(findInDmgMap(squadIncomingDamageTotalByFightId) ?? 0));
+        let stabIncomingBuckets = Array.from({ length: bucketCount }, (_, i) => Number(incomingShape[i] || 0));
+        if (incomingTotal > 0 && incomingShapeTotal > 0) {
+            const scale = incomingTotal / incomingShapeTotal;
+            stabIncomingBuckets = stabIncomingBuckets.map((v: number) => Number(v || 0) * scale);
+        }
+        if (!stabIncomingBuckets.some(v => v > 0) && selectedLogDetails?.players) {
+            const normCum = (val: any): number[] => {
+                if (!Array.isArray(val) || val.length === 0) return [];
+                const f = val[0];
+                if (typeof f === 'number') return val.map((e: any) => Number(e || 0));
+                if (Array.isArray(f) && f.length > 0) {
+                    if (typeof f[0] === 'number') return f.map((e: any) => Number(e || 0));
+                    if (Array.isArray(f[0]) && Array.isArray((f[0] as any)[0])) {
+                        const targets = f
+                            .map((s: any) => Array.isArray(s) ? s.map((e: any) => Number(e || 0)) : null)
+                            .filter((s: number[] | null): s is number[] => Array.isArray(s) && s.length > 0);
+                        const len = targets.reduce((m: number, s: number[]) => Math.max(m, s.length), 0);
+                        if (len <= 0) return [];
+                        const out = new Array<number>(len).fill(0);
+                        targets.forEach((s: number[]) => { for (let i = 0; i < len; i++) out[i] += Number(s[i] || 0); });
+                        return out;
+                    }
+                }
+                return [];
+            };
+            const toDeltas = (s: number[]): number[] => s.map((v, i) => Math.max(0, Number(v || 0) - Number(s[i - 1] || 0)));
+            const toBkt = (s: number[]): number[] => {
+                const out: number[] = [];
+                for (let i = 0; i < s.length; i += 5) out.push(s.slice(i, Math.min(i + 5, s.length)).reduce((a, b) => a + b, 0));
+                return out;
+            };
+            const allPlayers = ((selectedLogDetails?.players || []) as any[]).filter((p: any) => !p?.notInSquad);
+            const trySource = (field: string) => {
+                const arrays = allPlayers.map((p: any) => toDeltas(normCum(p?.[field]))).filter((a: number[]) => a.length > 0);
+                if (arrays.length === 0) return false;
+                const maxLen = arrays.reduce((m: number, a: number[]) => Math.max(m, a.length), 0);
+                const summed = new Array<number>(maxLen).fill(0);
+                arrays.forEach((a: number[]) => a.forEach((v: number, i: number) => { summed[i] += v; }));
+                const raw = toBkt(summed);
+                const candidate = Array.from({ length: bucketCount }, (_, i) => Number(raw[i] || 0));
+                if (!candidate.some(v => v > 0)) return false;
+                stabIncomingBuckets = candidate;
+                const bktSum = candidate.reduce((s: number, v: number) => s + v, 0);
+                if (bktSum > 0 && incomingTotal > 0) {
+                    const sc = incomingTotal / bktSum;
+                    stabIncomingBuckets = stabIncomingBuckets.map((v: number) => v * sc);
+                }
+                return true;
+            };
+            trySource('damageTaken1S') || trySource('powerDamageTaken1S');
+        }
+        if (!stabIncomingBuckets.some(v => v > 0) && incomingTotal > 0) {
+            stabIncomingBuckets = Array.from({ length: bucketCount }, () => incomingTotal / bucketCount);
+        }
+        const selectedPlayerDetails = selectedLogDetails?.players?.find((p: any) =>
+            String(p?.account || p?.name || 'Unknown') === selectedStabPerfPlayerKey
+        );
+        const selectedPlayerGroup = Number(selectedPlayerDetails?.group ?? 0);
+        const playerDeathsPerBucket = new Map<string, number[]>();
+        const playerDistancesPerBucket = new Map<string, number[]>();
+        const partyMembersMap = new Map<string, { displayName: string; stacksPerBucket: number[] }>();
+        if (selectedLogDetails?.players && selectedPlayerGroup > 0) {
+            const squadPlayers = (selectedLogDetails.players as any[]).filter((p: any) => !p?.notInSquad);
+            const replayMeta = (selectedLogDetails as any)?.combatReplayMetaData || {};
+            const inchesToPixel = Number(replayMeta?.inchToPixel || 0) > 0 ? Number(replayMeta.inchToPixel) : 1;
+            const pollingRate = Number(replayMeta?.pollingRate || 0) > 0 ? Number(replayMeta.pollingRate) : 500;
+            const getFirstSeg = (replayData: any) => Array.isArray(replayData) ? replayData[0] : replayData;
+            const commanderPlayer = squadPlayers.find((p: any) => p?.hasCommanderTag);
+            const cmdSeg = getFirstSeg(commanderPlayer?.combatReplayData);
+            const cmdPositions: Array<[number, number]> = Array.isArray(cmdSeg?.positions) ? cmdSeg.positions : [];
+            const cmdOffset = Math.floor(Number(cmdSeg?.start || 0) / pollingRate);
+            squadPlayers.forEach((player: any) => {
+                if (Number(player?.group || 0) !== selectedPlayerGroup) return;
+                const playerAccount = String(player?.account || player?.name || 'Unknown');
+                const fallbackDist = Number((player as any)?.statsAll?.[0]?.distToCom || (player as any)?.statsAll?.[0]?.stackDist || 0);
+                const deathSkill = (Array.isArray(player?.rotation) ? player.rotation : []).find((r: any) => Number(r?.id) === -28);
+                const deathsPerBucket = Array.from({ length: bucketCount }, () => 0);
+                if (deathSkill && Array.isArray(deathSkill.skills)) {
+                    deathSkill.skills.forEach((skill: any) => {
+                        const bucketIdx = Math.min(bucketCount - 1, Math.floor(Number(skill?.castTime || 0) / 5000));
+                        if (bucketIdx >= 0) {
+                            deathsPerBucket[bucketIdx]++;
+                        }
+                    });
+                }
+                playerDeathsPerBucket.set(playerAccount, deathsPerBucket);
+                const playerSeg = getFirstSeg(player?.combatReplayData);
+                const playerPositions: Array<[number, number]> = Array.isArray(playerSeg?.positions) ? playerSeg.positions : [];
+                const playerOffset = Math.floor(Number(playerSeg?.start || 0) / pollingRate);
+                const distancesPerBucket: number[] = Array.from({ length: bucketCount }, (_, b) => {
+                    if (cmdPositions.length === 0 || playerPositions.length === 0) return fallbackDist;
+                    const bucketStartMs = b * 5000;
+                    const bucketEndMs = (b + 1) * 5000;
+                    let sum = 0, count = 0;
+                    for (let t = bucketStartMs; t < bucketEndMs; t += pollingRate) {
+                        const tick = Math.floor(t / pollingRate);
+                        const cmdIdx = tick - cmdOffset;
+                        const playerIdx = tick - playerOffset;
+                        if (cmdIdx < 0 || cmdIdx >= cmdPositions.length) continue;
+                        if (playerIdx < 0 || playerIdx >= playerPositions.length) continue;
+                        const [cx, cy] = cmdPositions[cmdIdx];
+                        const [px, py] = playerPositions[playerIdx];
+                        const d = Math.hypot(px - cx, py - cy) / inchesToPixel;
+                        if (Number.isFinite(d)) { sum += d; count++; }
+                    }
+                    return count > 0 ? sum / count : fallbackDist;
+                });
+                playerDistancesPerBucket.set(playerAccount, distancesPerBucket);
+                const buffUptime = Array.isArray(player?.buffUptimes)
+                    ? player.buffUptimes.find((b: any) => Number(b?.id) === 1122)
+                    : null;
+                const stacksPerBucket = Array.from({ length: bucketCount }, () => 0);
+                if (buffUptime?.states && Array.isArray(buffUptime.states)) {
+                    const states: Array<[number, number]> = (buffUptime.states as any[])
+                        .map((s: any) => Array.isArray(s) ? [Number(s[0]), Number(s[1])] : null)
+                        .filter(Boolean) as Array<[number, number]>;
+                    for (let b = 0; b < bucketCount; b++) {
+                        const bucketStart = b * 5000;
+                        const bucketEnd = (b + 1) * 5000;
+                        let curStacks = 0;
+                        for (let i = states.length - 1; i >= 0; i--) {
+                            if (states[i][0] <= bucketStart) { curStacks = states[i][1]; break; }
+                        }
+                        let weightedSum = 0;
+                        let prevTime = bucketStart;
+                        for (let i = 0; i < states.length; i++) {
+                            if (states[i][0] <= bucketStart) continue;
+                            if (states[i][0] >= bucketEnd) break;
+                            weightedSum += curStacks * (states[i][0] - prevTime);
+                            prevTime = states[i][0];
+                            curStacks = states[i][1];
+                        }
+                        weightedSum += curStacks * (bucketEnd - prevTime);
+                        stacksPerBucket[b] = weightedSum / 5000;
+                    }
+                }
+                partyMembersMap.set(playerAccount, { displayName: playerAccount.split('.')[0], stacksPerBucket });
+            });
+        }
+        const incomingMax = stabIncomingBuckets.reduce((best: number, v: number) => Math.max(best, Number(v || 0)), 0);
+        const partyMembers = Array.from(partyMembersMap.entries()).map(([key, val]) => ({
+            key,
+            displayName: val.displayName
+        }));
+        const dataWithOverlays = data.map((entry, i) => {
+            const partyIncomingDamage = Number(stabIncomingBuckets[i] || 0);
+            const intensity = incomingMax > 0 ? Math.max(0, Math.min(1, partyIncomingDamage / incomingMax)) : 0;
+            const playerData: Record<string, any> = {};
+            partyMembersMap.forEach((_, playerAccount) => {
+                const deaths = playerDeathsPerBucket.get(playerAccount)?.[i] || 0;
+                const distance = playerDistancesPerBucket.get(playerAccount)?.[i] || 0;
+                playerData[`playerDeaths_${playerAccount}`] = deaths;
+                playerData[`playerDistance_${playerAccount}`] = distance;
+            });
+            return {
+                ...entry,
+                incomingDamage: partyIncomingDamage,
+                incomingIntensity: intensity,
+                ...playerData,
+                ...Object.fromEntries(Array.from(partyMembersMap.entries()).map(([key, val]) => [`pm_${key}`, val.stacksPerBucket[i] || 0]))
+            };
+        });
+        return {
+            title: `Fight Breakdown - ${selectedPoint.shortLabel || 'Fight'} (5s Squad Stab Generation Buckets)`,
+            data: dataWithOverlays,
+            partyMembers
+        };
+    }, [stabBoon, stabPerfChartData, selectedStabPerfFightIndex, selectedStabPerfPlayerKey, logs, squadIncomingDamageBucketsByFightId, fallbackIncomingDamageBucketsByFightId, squadIncomingDamageTotalByFightId]);
+
     const boonUptimeSubgroupKeyPrefix = '__subgroup__:';
     const boonUptimeBoons = useMemo(() => {
         const source = Array.isArray((safeStats as any)?.boonUptimeTimeline) ? (safeStats as any).boonUptimeTimeline : [];
@@ -4180,6 +4497,27 @@ type SpikeFight = {
                                 showIncomingHeatmap={showBoonUptimeIncomingHeatmap}
                                 setShowIncomingHeatmap={setShowBoonUptimeIncomingHeatmap}
                             />)}
+                            {renderSectionWrap(<StabPerformanceSection
+                                playerFilter={stabPerfPlayerFilter}
+                                setPlayerFilter={setStabPerfPlayerFilter}
+                                players={stabPerfFilteredPlayers}
+                                selectedPlayerKey={selectedStabPerfPlayerKey}
+                                setSelectedPlayerKey={setSelectedStabPerfPlayerKey}
+                                selectedPlayer={selectedStabPerfPlayer}
+                                chartData={stabPerfChartData}
+                                chartMaxY={stabPerfChartMaxY}
+                                selectedFightIndex={selectedStabPerfFightIndex}
+                                setSelectedFightIndex={setSelectedStabPerfFightIndex}
+                                drilldownTitle={stabPerfDrilldown.title}
+                                drilldownData={stabPerfDrilldown.data}
+                                partyMembers={stabPerfDrilldown.partyMembers}
+                                showIncomingHeatmap={showStabPerfHeatmap}
+                                setShowIncomingHeatmap={setShowStabPerfHeatmap}
+                                showPartyDeaths={showStabPerfDeaths}
+                                setShowPartyDeaths={setShowStabPerfDeaths}
+                                showPartyDistance={showStabPerfDistance}
+                                setShowPartyDistance={setShowStabPerfDistance}
+                            />)}
 
                             {renderSectionWrap(<OffenseSection
                                 offenseSearch={offenseSearch}
@@ -4823,6 +5161,27 @@ type SpikeFight = {
                                 subgroupMembers={boonUptimeSubgroupMembers}
                                 showIncomingHeatmap={showBoonUptimeIncomingHeatmap}
                                 setShowIncomingHeatmap={setShowBoonUptimeIncomingHeatmap}
+                            /> },
+                            { id: 'stab-performance', element: <StabPerformanceSection
+                                playerFilter={stabPerfPlayerFilter}
+                                setPlayerFilter={setStabPerfPlayerFilter}
+                                players={stabPerfFilteredPlayers}
+                                selectedPlayerKey={selectedStabPerfPlayerKey}
+                                setSelectedPlayerKey={setSelectedStabPerfPlayerKey}
+                                selectedPlayer={selectedStabPerfPlayer}
+                                chartData={stabPerfChartData}
+                                chartMaxY={stabPerfChartMaxY}
+                                selectedFightIndex={selectedStabPerfFightIndex}
+                                setSelectedFightIndex={setSelectedStabPerfFightIndex}
+                                drilldownTitle={stabPerfDrilldown.title}
+                                drilldownData={stabPerfDrilldown.data}
+                                partyMembers={stabPerfDrilldown.partyMembers}
+                                showIncomingHeatmap={showStabPerfHeatmap}
+                                setShowIncomingHeatmap={setShowStabPerfHeatmap}
+                                showPartyDeaths={showStabPerfDeaths}
+                                setShowPartyDeaths={setShowStabPerfDeaths}
+                                showPartyDistance={showStabPerfDistance}
+                                setShowPartyDistance={setShowStabPerfDistance}
                             /> },
                             { id: 'support-detailed', element: <SupportSection
                                 supportSearch={supportSearch}

--- a/src/renderer/stats/hooks/useStatsNavigation.ts
+++ b/src/renderer/stats/hooks/useStatsNavigation.ts
@@ -107,7 +107,7 @@ export const STATS_TOC_GROUPS: readonly StatsTocGroup[] = [
         id: 'defense',
         label: 'Defensive Stats',
         icon: Shield,
-        sectionIds: ['defense-detailed', 'incoming-damage-modifiers', 'incoming-strike-damage', 'defense-mitigation', 'boon-output', 'all-boons', 'boon-timeline', 'boon-uptime', 'support-detailed', 'healing-stats', 'healing-breakdown'],
+        sectionIds: ['defense-detailed', 'incoming-damage-modifiers', 'incoming-strike-damage', 'defense-mitigation', 'boon-output', 'all-boons', 'boon-timeline', 'boon-uptime', 'stab-performance', 'support-detailed', 'healing-stats', 'healing-breakdown'],
         items: [
             { id: 'defense-detailed', label: 'Defense Detailed', icon: Shield },
             { id: 'incoming-damage-modifiers', label: 'Incoming Modifiers', icon: ShieldOff },
@@ -117,6 +117,7 @@ export const STATS_TOC_GROUPS: readonly StatsTocGroup[] = [
             { id: 'all-boons', label: 'All Boons', icon: Gw2BoonIcon },
             { id: 'boon-timeline', label: 'Boon Timeline', icon: Gw2AegisIcon },
             { id: 'boon-uptime', label: 'Boon Uptime', icon: Gw2FuryIcon },
+            { id: 'stab-performance', label: 'Stab Performance', icon: Shield },
             { id: 'support-detailed', label: 'Support Detailed', icon: SupportPlusIcon },
             { id: 'healing-stats', label: 'Healing Stats', icon: HeartPulse },
             { id: 'healing-breakdown', label: 'Healing Breakdown', icon: ListTree },

--- a/src/renderer/stats/sectionColors.ts
+++ b/src/renderer/stats/sectionColors.ts
@@ -57,6 +57,7 @@ export const SECTION_ACCENT_COLORS: Record<string, string> = {
     'all-boons': 'var(--section-boon)',
     'boon-timeline': 'var(--section-boon)',
     'boon-uptime': 'var(--section-boon)',
+    'stab-performance': 'var(--section-boon)',
     'support-detailed': 'var(--section-support)',
     'healing-stats': 'var(--section-healing)',
     'healing-breakdown': 'var(--section-healing)',

--- a/src/renderer/stats/sections/StabPerformanceSection.tsx
+++ b/src/renderer/stats/sections/StabPerformanceSection.tsx
@@ -1,0 +1,343 @@
+import { Bar, Brush, CartesianGrid, Cell, ComposedChart, Line, Tooltip, XAxis, YAxis } from 'recharts';
+import { ChartContainer } from '../ui/ChartContainer';
+import { MapPin, Shield, Skull } from 'lucide-react';
+import { useStatsSharedContext } from '../StatsViewContext';
+import { FightMetricSection } from './FightMetricSection';
+import type { FightMetricPlayer, FightMetricPoint } from './FightMetricSection';
+
+const PARTY_MEMBER_COLORS = [
+    '#a78bfa', '#34d399', '#f59e0b', '#60a5fa', '#f472b6',
+    '#fb923c', '#4ade80', '#e879f9', '#38bdf8', '#fbbf24'
+];
+
+type StabPerfPlayer = {
+    key: string;
+    account: string;
+    displayName: string;
+    profession: string;
+    professionList: string[];
+    logs: number;
+    total: number;
+};
+
+type StabPerfFightPoint = {
+    index: number;
+    fightId: string;
+    shortLabel: string;
+    fullLabel: string;
+    timestamp: number;
+    total: number;
+    maxTotal: number;
+};
+
+type StabPerfPartyMember = {
+    key: string;
+    displayName: string;
+};
+
+type StabPerfDrilldownEntry = {
+    label: string;
+    value: number;
+    incomingDamage?: number;
+    incomingIntensity?: number;
+    partyDeaths?: number;
+    partyDeathNames?: string[];
+    partyAvgDistance?: number;
+    partyFarNames?: string[];
+    [key: string]: any;
+};
+
+type StabPerformanceSectionProps = {
+    playerFilter: string;
+    setPlayerFilter: (v: string) => void;
+    players: StabPerfPlayer[];
+    selectedPlayerKey: string | null;
+    setSelectedPlayerKey: (key: string | null) => void;
+    selectedPlayer: StabPerfPlayer | null;
+    chartData: StabPerfFightPoint[];
+    chartMaxY: number;
+    selectedFightIndex: number | null;
+    setSelectedFightIndex: (index: number | null) => void;
+    drilldownTitle: string;
+    drilldownData: StabPerfDrilldownEntry[];
+    partyMembers: StabPerfPartyMember[];
+    showIncomingHeatmap: boolean;
+    setShowIncomingHeatmap: (v: boolean) => void;
+    showPartyDeaths: boolean;
+    setShowPartyDeaths: (v: boolean) => void;
+    showPartyDistance: boolean;
+    setShowPartyDistance: (v: boolean) => void;
+};
+
+export const StabPerformanceSection = ({
+    playerFilter,
+    setPlayerFilter,
+    players,
+    selectedPlayerKey,
+    setSelectedPlayerKey,
+    selectedPlayer,
+    chartData,
+    chartMaxY,
+    selectedFightIndex,
+    setSelectedFightIndex,
+    drilldownTitle,
+    drilldownData,
+    partyMembers,
+    showIncomingHeatmap,
+    setShowIncomingHeatmap,
+    showPartyDeaths,
+    setShowPartyDeaths,
+    showPartyDistance,
+    setShowPartyDistance,
+}: StabPerformanceSectionProps) => {
+    const { formatWithCommas, renderProfessionIcon } = useStatsSharedContext();
+
+    const hasIncomingHeatData = drilldownData.some((entry) => Number(entry?.incomingDamage || 0) > 0);
+
+    const drilldownHeatData = drilldownData.map((entry) => ({
+        ...entry,
+        incomingHeatBand: 1
+    }));
+
+    // Map StabPerfPlayer[] -> FightMetricPlayer[]
+    const mappedGroups = [{
+        profession: '',
+        players: players.map((p): FightMetricPlayer => ({
+            key: p.key,
+            account: p.account,
+            displayName: p.displayName,
+            characterName: p.displayName,
+            profession: p.profession,
+            professionList: p.professionList,
+            logs: p.logs,
+            value: p.total,
+            peakFightLabel: '',
+        })),
+    }];
+
+    // Map StabPerfFightPoint[] -> FightMetricPoint[]
+    const mappedChartData: FightMetricPoint[] = chartData.map((p) => ({
+        index: p.index,
+        fightId: p.fightId,
+        shortLabel: p.shortLabel,
+        fullLabel: p.fullLabel,
+        timestamp: p.timestamp,
+        value: p.total,
+        maxValue: p.maxTotal,
+    }));
+
+    // Map selected player
+    const mappedPlayer: FightMetricPlayer | null = selectedPlayer ? {
+        key: selectedPlayer.key,
+        account: selectedPlayer.account,
+        displayName: selectedPlayer.displayName,
+        characterName: selectedPlayer.displayName,
+        profession: selectedPlayer.profession,
+        professionList: selectedPlayer.professionList,
+        logs: selectedPlayer.logs,
+        value: selectedPlayer.total,
+        peakFightLabel: '',
+    } : null;
+
+    return (
+        <FightMetricSection
+            sectionId="stab-performance"
+            title="Stab Performance"
+            titleIcon={Shield}
+            titleIconClassName="text-violet-300"
+            listTitle="Stability Sources"
+            searchPlaceholder="Search player or account"
+            modes={[]}
+            activeMode=""
+            setActiveMode={() => {}}
+            playerFilter={playerFilter}
+            setPlayerFilter={setPlayerFilter}
+            groupedPlayers={mappedGroups}
+            selectedPlayerKey={selectedPlayerKey}
+            setSelectedPlayerKey={setSelectedPlayerKey}
+            selectedPlayer={mappedPlayer}
+            chartData={mappedChartData}
+            chartMaxY={chartMaxY}
+            formatValue={(v) => formatWithCommas(v / 1000, 0)}
+            selectedFightIndex={selectedFightIndex}
+            setSelectedFightIndex={setSelectedFightIndex}
+            headerExtras={selectedFightIndex !== null ? <>
+                <button
+                    onClick={() => setShowIncomingHeatmap(!showIncomingHeatmap)}
+                    className={`text-[10px] uppercase tracking-wider transition-colors ${
+                        showIncomingHeatmap ? 'text-red-300 hover:text-red-200' : 'text-slate-500 hover:text-slate-300'
+                    }`}
+                >
+                    Party Damage
+                </button>
+                <button
+                    onClick={() => setShowPartyDeaths(!showPartyDeaths)}
+                    className={`text-[10px] uppercase tracking-wider transition-colors ${
+                        showPartyDeaths ? 'text-red-400 hover:text-red-300' : 'text-slate-500 hover:text-slate-300'
+                    }`}
+                >
+                    Deaths
+                </button>
+                <button
+                    onClick={() => setShowPartyDistance(!showPartyDistance)}
+                    title="Flags party members who averaged more than 600 units from the commander during this fight"
+                    className={`text-[10px] uppercase tracking-wider transition-colors ${
+                        showPartyDistance ? 'text-yellow-300 hover:text-yellow-200' : 'text-slate-500 hover:text-slate-300'
+                    }`}
+                >
+                    Distance
+                </button>
+            </> : undefined}
+            renderPlayerItem={(player, isSelected) => (
+                <>
+                    {renderProfessionIcon(player.profession, player.professionList, 'w-4 h-4 flex-shrink-0')}
+                    <span className={`text-xs truncate flex-1 ${isSelected ? 'text-slate-200' : 'text-slate-400'}`}>
+                        {player.displayName}
+                    </span>
+                    <span className={`text-xs tabular-nums ${isSelected ? 'text-indigo-300 font-semibold' : 'text-slate-500'}`}>
+                        {formatWithCommas(player.value / 1000, 0)}
+                    </span>
+                </>
+            )}
+            drilldownTitle={drilldownTitle}
+            renderDrilldown={() => (
+                <div>
+                    {partyMembers.length > 0 && (
+                        <div className="flex flex-wrap gap-x-4 gap-y-1 mb-2">
+                            {partyMembers.map((m, mi) => (
+                                <div key={m.key} className="flex items-center gap-1.5">
+                                    <div className="w-5 h-0" style={{ borderTop: `2px dashed ${PARTY_MEMBER_COLORS[mi % PARTY_MEMBER_COLORS.length]}` }} />
+                                    <span className="text-[9px] text-slate-400">{m.displayName}</span>
+                                </div>
+                            ))}
+                        </div>
+                    )}
+                    <div className="h-[220px] relative">
+                        {drilldownData.length === 0 ? (
+                            <div className="h-full flex items-center justify-center text-xs text-slate-500">
+                                No detailed data available for this fight.
+                            </div>
+                        ) : (
+                            <ChartContainer width="100%" height="100%">
+                                <ComposedChart data={drilldownHeatData}>
+                                    <CartesianGrid stroke="rgba(255,255,255,0.08)" strokeDasharray="3 3" />
+                                    <XAxis dataKey="label" tick={{ fontSize: 10, fill: '#64748b' }} axisLine={{ stroke: 'rgba(255,255,255,0.08)' }} tickLine={false} />
+                                    <YAxis tick={{ fontSize: 10, fill: '#64748b' }} axisLine={{ stroke: 'rgba(255,255,255,0.08)' }} tickLine={false}
+                                        tickFormatter={(value: number) => formatWithCommas(value / 1000, 0)} width={50} />
+                                    <YAxis yAxisId="incomingHeat" hide domain={[0, 1]} />
+                                    <YAxis yAxisId="stabStacks" hide domain={[0, 'auto']} />
+                                    <Tooltip
+                                        content={({ payload, label }: any) => {
+                                            if (!payload || payload.length === 0) return null;
+                                            const point = payload[0]?.payload || {};
+                                            const gen = Number(point?.value || 0);
+                                            const damage = Number(point?.incomingDamage || 0);
+                                            return (
+                                                <div className="bg-slate-900/95 border border-white/10 rounded-lg px-3 py-2 text-xs shadow-xl">
+                                                    <div className="text-slate-200 font-medium mb-1">
+                                                        {String(label || '')}
+                                                        {gen > 0 && <span className="text-violet-300">{` · Gen: ${formatWithCommas(gen / 1000, 0)}`}</span>}
+                                                    </div>
+                                                    {showIncomingHeatmap && damage > 0 && (
+                                                        <div className="text-red-300 mb-1">
+                                                            Party Incoming Damage: {formatWithCommas(damage, 0)}
+                                                        </div>
+                                                    )}
+                                                    {[...partyMembers].sort((a, b) => a.displayName.localeCompare(b.displayName)).map((member) => {
+                                                        const mi = partyMembers.indexOf(member);
+                                                        const color = PARTY_MEMBER_COLORS[mi % PARTY_MEMBER_COLORS.length];
+                                                        const stacks = Number(point?.[`pm_${member.key}`] ?? 0);
+                                                        const deaths = Number(point?.[`playerDeaths_${member.key}`] || 0);
+                                                        const hasDeath = deaths > 0;
+                                                        const distance = Number(point?.[`playerDistance_${member.key}`] || 0);
+                                                        const hasFar = distance > 600;
+                                                        return (
+                                                            <div key={member.key} style={{ color }} className="py-px flex items-center gap-1">
+                                                                <span>{member.displayName}</span>
+                                                                {hasFar && <MapPin className="inline w-3.5 h-3.5 text-yellow-400" />}
+                                                                <span>: {stacks === 0 ? 'No stab' : stacks.toFixed(1) + ' stacks'}</span>
+                                                                {hasDeath && <Skull className={`inline w-3.5 h-3.5 ${member.key === selectedPlayerKey ? 'text-purple-400' : 'text-white'}`} />}
+                                                            </div>
+                                                        );
+                                                    })}
+                                                </div>
+                                            );
+                                        }}
+                                    />
+                                    {showIncomingHeatmap && hasIncomingHeatData && (
+                                        <Bar
+                                            yAxisId="incomingHeat"
+                                            dataKey="incomingHeatBand"
+                                            name="Party Incoming Damage Heat"
+                                            barSize={24}
+                                            fill="rgba(239,68,68,0.35)"
+                                            stroke="none"
+                                            isAnimationActive={false}
+                                        >
+                                            {drilldownData.map((entry, index) => {
+                                                const intensity = Math.max(0, Math.min(1, Number(entry?.incomingIntensity || 0)));
+                                                const alpha = 0.06 + (0.52 * intensity);
+                                                return <Cell key={`stab-heat-${index}`} fill={`rgba(239, 68, 68, ${alpha.toFixed(3)})`} />;
+                                            })}
+                                        </Bar>
+                                    )}
+                                    {partyMembers.map((member, mi) => {
+                                        const color = PARTY_MEMBER_COLORS[mi % PARTY_MEMBER_COLORS.length];
+                                        return (
+                                            <Line
+                                                key={member.key}
+                                                yAxisId="stabStacks"
+                                                type="monotone"
+                                                dataKey={`pm_${member.key}`}
+                                                name={member.displayName}
+                                                stroke={color}
+                                                strokeWidth={1.5}
+                                                strokeDasharray="4 2"
+                                                dot={(props: any) => {
+                                                    const point = props.payload;
+                                                    if (!point) return null;
+                                                    const deaths = Number(point?.[`playerDeaths_${member.key}`] || 0);
+                                                    const distance = Number(point?.[`playerDistance_${member.key}`] || 0);
+                                                    const hasDeaths = showPartyDeaths && deaths > 0;
+                                                    const hasHighDistance = showPartyDistance && distance > 600;
+                                                    if (!hasDeaths && !hasHighDistance) return null;
+                                                    const isSelectedPlayer = member.key === selectedPlayerKey;
+                                                    const size = isSelectedPlayer ? 20 : 16;
+                                                    const half = size / 2;
+                                                    return (
+                                                        <g transform={`translate(${props.cx - half}, ${props.cy - half})`}>
+                                                            {hasDeaths && (
+                                                                <Skull width={size} height={size} color={isSelectedPlayer ? '#a855f7' : '#ffffff'} strokeWidth={2} />
+                                                            )}
+                                                            {!hasDeaths && hasHighDistance && (
+                                                                <MapPin width={16} height={16} color="#fbbf24" strokeWidth={2} />
+                                                            )}
+                                                        </g>
+                                                    );
+                                                }}
+                                                activeDot={{ r: 3, fill: color }}
+                                                isAnimationActive={true}
+                                                animationDuration={600}
+                                                animationEasing="ease-out"
+                                            />
+                                        );
+                                    })}
+                                    {drilldownHeatData.length > 10 && (
+                                        <Brush
+                                            dataKey="label"
+                                            height={24}
+                                            stroke="rgba(129,140,248,0.4)"
+                                            fill="rgba(15,23,42,0.8)"
+                                            travellerWidth={8}
+                                            tickFormatter={() => ''}
+                                        />
+                                    )}
+                                </ComposedChart>
+                            </ChartContainer>
+                        )}
+                    </div>
+                </div>
+            )}
+        />
+    );
+};


### PR DESCRIPTION
## Summary
- Adds a new **Stab Performance** stats section under Defensive Stats, tracking per-player stability (boon 1122) generation across WvW fights
- Includes 5-second bucket drilldown chart with party member stab stack lines and toggleable overlays: incoming damage heatmap, death markers (skull icons), and distance-from-tag indicators (600+ units)
- Reuses `FightMetricSection` base component for consistent UX with other metric sections

Builds on the original work from #17.

## Test plan
- [ ] Load a dataset with WvW fights and verify the Stab Performance section appears under Defensive Stats
- [ ] Select a player and confirm per-fight chart renders correctly
- [ ] Click into a fight and verify the 5s bucket drilldown with party member stab stack lines
- [ ] Toggle Party Damage, Deaths, and Distance overlays and confirm each renders correctly
- [ ] Verify death skulls are white for non-selected players, purple for selected player
- [ ] Hover the Distance toggle and confirm the tooltip explains the 600-unit threshold
- [ ] Test with both small (<8 logs) and large (>8 logs, worker path) datasets

🤖 Generated with [Claude Code](https://claude.com/claude-code)