### PR TITLE
feat(bridge-metrics): positional analysis (computePositioning) v0.2.0

### DIFF
--- a/packages/bridge-metrics/package.json
+++ b/packages/bridge-metrics/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@axiapps/bridge-metrics",
-    "version": "0.1.0",
+    "version": "0.2.0",
     "type": "module",
     "description": "AxiBridge report aggregation core: player aggregation, rollup builder, metric extractors",
     "license": "GPL-3.0-only",

--- a/packages/bridge-metrics/src/__tests__/positioning.test.ts
+++ b/packages/bridge-metrics/src/__tests__/positioning.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest'
+import { classifyDegree } from '../positioning'
+
+const player = (over: Record<string, unknown>) => ({ notInSquad: false, statsAll: [{}], ...over })
+
+describe('classifyDegree', () => {
+  it('returns "full" when a commander has replay positions', () => {
+    const report = { details: { combatReplayMetaData: { pollingRate: 150, inchToPixel: 0.01 }, players: [
+      player({ hasCommanderTag: true, combatReplayData: { positions: [[0,0],[1,1]] } }),
+      player({ combatReplayData: { positions: [[2,2]] } }),
+    ] } }
+    expect(classifyDegree(report)).toBe('full')
+  })
+  it('returns "coarse" when only distToCom aggregates exist (no positions)', () => {
+    const report = { details: { players: [ player({ statsAll: [{ distToCom: 420 }] }) ] } }
+    expect(classifyDegree(report)).toBe('coarse')
+  })
+  it('returns "none" when neither positions nor distToCom exist', () => {
+    const report = { details: { players: [ player({}) ] } }
+    expect(classifyDegree(report)).toBe('none')
+  })
+})

--- a/packages/bridge-metrics/src/__tests__/positioning.test.ts
+++ b/packages/bridge-metrics/src/__tests__/positioning.test.ts
@@ -7,7 +7,7 @@ describe('computePositioning', () => {
   it('reports per-player distance-to-tag and out-of-position deaths', () => {
     const report = { details: { durationMS: 10000, combatReplayMetaData: { pollingRate: 150, inchToPixel: 0.01, sizes: [1000,1000] as [number,number] }, players: [
       { notInSquad: false, hasCommanderTag: true, account: 'Tag.1', combatReplayData: { positions: [[0,0],[0,0]] as [number,number][] } },
-      { notInSquad: false, account: 'Stray.2', combatReplayData: { positions: [[0,0],[2000,0]] as [number,number][], down: [[2000,0]] as [number,number][], dead: [] as [number,number][] } },
+      { notInSquad: false, account: 'Stray.2', combatReplayData: { positions: [[0,0],[2000,0]] as [number,number][], down: [[150,9000]] as [number,number][], dead: [[9000,99999]] as [number,number][] } },
     ] } }
     const s = computePositioning(report)
     expect(s.degree).toBe('full')

--- a/packages/bridge-metrics/src/__tests__/positioning.test.ts
+++ b/packages/bridge-metrics/src/__tests__/positioning.test.ts
@@ -48,6 +48,22 @@ describe('squad spread, commander overextension, death clusters', () => {
   })
 })
 
+describe('figure payload', () => {
+  it('omits the figure for coarse data but still gives distances', () => {
+    const report = { details: { players: [ { notInSquad:false, account:'A.2', statsAll:[{ distToCom: 800 }] } ] } }
+    const s = computePositioning(report)
+    expect(s.degree).toBe('coarse'); expect(s.figure).toBeUndefined()
+    expect(s.perPlayer.find(p=>p.account==='A.2')!.avgDistToTag).toBe(800)
+  })
+  it('down-samples the figure tag path to <= ~1 point/sec', () => {
+    const positions = Array.from({length: 600}, (_,i)=>[i,0] as [number,number]) // 600 ticks @ 100ms = 60s
+    const report = { details:{ durationMS:60000, combatReplayMetaData:{ pollingRate:100, inchToPixel:1, sizes:[1000,1000] as [number,number] }, players:[
+      { notInSquad:false, hasCommanderTag:true, account:'Tag.1', combatReplayData:{ positions } } ] } }
+    const s = computePositioning(report)
+    expect(s.figure!.tagPath.length).toBeLessThanOrEqual(70)
+  })
+})
+
 describe('classifyDegree', () => {
   it('returns "full" when a commander has replay positions', () => {
     const report = { details: { combatReplayMetaData: { pollingRate: 150, inchToPixel: 0.01 }, players: [

--- a/packages/bridge-metrics/src/__tests__/positioning.test.ts
+++ b/packages/bridge-metrics/src/__tests__/positioning.test.ts
@@ -17,6 +17,30 @@ describe('computePositioning', () => {
   })
 })
 
+describe('squad spread, commander overextension, death clusters', () => {
+  it('computes peak spread, commander overextension, and death clusters', () => {
+    const report = { details: { durationMS: 6000, combatReplayMetaData: { pollingRate: 1000, inchToPixel: 1, sizes: [3000,3000] as [number,number] }, players: [
+      { notInSquad:false, hasCommanderTag:true, account:'Tag.1', combatReplayData:{ positions:[[0,0],[100,0],[1800,0]] as [number,number][] } },
+      { notInSquad:false, account:'A.2', combatReplayData:{ positions:[[0,0],[100,0],[0,0]] as [number,number][], dead:[[0,0]] as [number,number][] } },
+      { notInSquad:false, account:'B.3', combatReplayData:{ positions:[[0,0],[100,0],[0,0]] as [number,number][], dead:[[0,0]] as [number,number][] } },
+    ] } }
+    const s = computePositioning(report)
+    expect(s.squad!.peakSpread!.value).toBeGreaterThan(1000)      // tag bolted at the last tick
+    expect(s.commander!.peakLeadFromSquad!.value).toBeGreaterThan(1000)
+    expect(s.deathClusters[0].count).toBe(2)                      // both died at ~[0,0]
+  })
+
+  it('excludes commander from perPlayer distance ranking', () => {
+    const report = { details: { durationMS: 3000, combatReplayMetaData: { pollingRate: 1000, inchToPixel: 1, sizes: [3000,3000] as [number,number] }, players: [
+      { notInSquad:false, hasCommanderTag:true, account:'Tag.1', combatReplayData:{ positions:[[0,0],[500,0],[1000,0]] as [number,number][] } },
+      { notInSquad:false, account:'A.2', combatReplayData:{ positions:[[0,0],[100,0],[200,0]] as [number,number][] } },
+    ] } }
+    const s = computePositioning(report)
+    expect(s.perPlayer.find(p => p.account === 'Tag.1')).toBeUndefined()
+    expect(s.perPlayer.find(p => p.account === 'A.2')).toBeDefined()
+  })
+})
+
 describe('classifyDegree', () => {
   it('returns "full" when a commander has replay positions', () => {
     const report = { details: { combatReplayMetaData: { pollingRate: 150, inchToPixel: 0.01 }, players: [

--- a/packages/bridge-metrics/src/__tests__/positioning.test.ts
+++ b/packages/bridge-metrics/src/__tests__/positioning.test.ts
@@ -23,7 +23,7 @@ describe('squad spread, commander overextension, death clusters', () => {
     // Player A and B each go down at t=1000ms (tick 1 → position index 1 = [10,10])
     // down: [[1000, 2000]] means downStartMs=1000, linkedDeathMs=2000
     // dead: [[2000]] means deathMs=2000, which matches linkedDeathMs → valid death
-    // At tick floor(1000/1000)=1, position[1]=[10,10] → death location near [0,0]
+    // At tick floor(1000/1000)=1, position[1]=[10,10] → death location near [10,10]
     const report = { details: { durationMS: 6000, combatReplayMetaData: { pollingRate: 1000, inchToPixel: 1, sizes: [3000,3000] as [number,number] }, players: [
       { notInSquad:false, hasCommanderTag:true, account:'Tag.1', combatReplayData:{ positions:[[0,0],[100,0],[1800,0]] as [number,number][] } },
       { notInSquad:false, account:'A.2', combatReplayData:{ positions:[[0,0],[10,10],[0,0]] as [number,number][], down:[[1000,2000]] as [number,number][], dead:[[2000]] as [number,number][] } },

--- a/packages/bridge-metrics/src/__tests__/positioning.test.ts
+++ b/packages/bridge-metrics/src/__tests__/positioning.test.ts
@@ -1,7 +1,21 @@
 import { describe, it, expect } from 'vitest'
-import { classifyDegree } from '../positioning'
+import { classifyDegree, computePositioning, OUT_OF_POSITION } from '../positioning'
 
 const player = (over: Record<string, unknown>) => ({ notInSquad: false, statsAll: [{}], ...over })
+
+describe('computePositioning', () => {
+  it('reports per-player distance-to-tag and out-of-position deaths', () => {
+    const report = { details: { durationMS: 10000, combatReplayMetaData: { pollingRate: 150, inchToPixel: 0.01, sizes: [1000,1000] as [number,number] }, players: [
+      { notInSquad: false, hasCommanderTag: true, account: 'Tag.1', combatReplayData: { positions: [[0,0],[0,0]] as [number,number][] } },
+      { notInSquad: false, account: 'Stray.2', combatReplayData: { positions: [[0,0],[2000,0]] as [number,number][], down: [[2000,0]] as [number,number][], dead: [] as [number,number][] } },
+    ] } }
+    const s = computePositioning(report)
+    expect(s.degree).toBe('full')
+    const stray = s.perPlayer.find(p => p.account === 'Stray.2')!
+    expect(stray.peakDistToTag).toBeGreaterThan(OUT_OF_POSITION)
+    expect(s.outOfPositionDeaths.some(d => d.account === 'Stray.2')).toBe(true)
+  })
+})
 
 describe('classifyDegree', () => {
   it('returns "full" when a commander has replay positions', () => {

--- a/packages/bridge-metrics/src/__tests__/positioning.test.ts
+++ b/packages/bridge-metrics/src/__tests__/positioning.test.ts
@@ -19,15 +19,22 @@ describe('computePositioning', () => {
 
 describe('squad spread, commander overextension, death clusters', () => {
   it('computes peak spread, commander overextension, and death clusters', () => {
+    // pollingRate=1000ms; positions indexed by tick (1 tick = 1000ms)
+    // Player A and B each go down at t=1000ms (tick 1 → position index 1 = [10,10])
+    // down: [[1000, 2000]] means downStartMs=1000, linkedDeathMs=2000
+    // dead: [[2000]] means deathMs=2000, which matches linkedDeathMs → valid death
+    // At tick floor(1000/1000)=1, position[1]=[10,10] → death location near [0,0]
     const report = { details: { durationMS: 6000, combatReplayMetaData: { pollingRate: 1000, inchToPixel: 1, sizes: [3000,3000] as [number,number] }, players: [
       { notInSquad:false, hasCommanderTag:true, account:'Tag.1', combatReplayData:{ positions:[[0,0],[100,0],[1800,0]] as [number,number][] } },
-      { notInSquad:false, account:'A.2', combatReplayData:{ positions:[[0,0],[100,0],[0,0]] as [number,number][], dead:[[0,0]] as [number,number][] } },
-      { notInSquad:false, account:'B.3', combatReplayData:{ positions:[[0,0],[100,0],[0,0]] as [number,number][], dead:[[0,0]] as [number,number][] } },
+      { notInSquad:false, account:'A.2', combatReplayData:{ positions:[[0,0],[10,10],[0,0]] as [number,number][], down:[[1000,2000]] as [number,number][], dead:[[2000]] as [number,number][] } },
+      { notInSquad:false, account:'B.3', combatReplayData:{ positions:[[0,0],[10,10],[0,0]] as [number,number][], down:[[1000,2000]] as [number,number][], dead:[[2000]] as [number,number][] } },
     ] } }
     const s = computePositioning(report)
     expect(s.squad!.peakSpread!.value).toBeGreaterThan(1000)      // tag bolted at the last tick
     expect(s.commander!.peakLeadFromSquad!.value).toBeGreaterThan(1000)
-    expect(s.deathClusters[0].count).toBe(2)                      // both died at ~[0,0]
+    expect(s.deathClusters[0].count).toBe(2)                      // both died at ~[10,10]
+    expect(s.deathClusters[0].x).toBeCloseTo(10)
+    expect(s.deathClusters[0].y).toBeCloseTo(10)
   })
 
   it('excludes commander from perPlayer distance ranking', () => {

--- a/packages/bridge-metrics/src/index.ts
+++ b/packages/bridge-metrics/src/index.ts
@@ -11,3 +11,4 @@ export * from './roles';
 export { isResUtilitySkill } from './resUtility';
 export { resolveFightTimestamp, parseTimestamp as parseFightTimestamp } from './timestampUtils';
 export * from './reportMetrics';
+export * from './positioning';

--- a/packages/bridge-metrics/src/positioning.ts
+++ b/packages/bridge-metrics/src/positioning.ts
@@ -8,6 +8,32 @@ export type ParsedReport = { details?: { players?: AnyPlayer[]
   combatReplayMetaData?: { pollingRate?: number; inchToPixel?: number; sizes?: [number, number] }
   durationMS?: number } }
 
+export type PerPlayerDistance = {
+  account: string
+  avgDistToTag: number
+  peakDistToTag: number
+}
+
+export type OutOfPositionDeath = {
+  account: string
+  distAtDown: number
+  atSec: number
+}
+
+export type PositioningSummary = {
+  degree: ReplayDegree
+  perPlayer: PerPlayerDistance[]
+  outOfPositionDeaths: OutOfPositionDeath[]
+  squad: null
+  commander: null
+  deathClusters: []
+  figure: undefined
+}
+
+export const OUT_OF_POSITION = 1200
+
+const clamp = (val: number, min: number, max: number) => Math.max(min, Math.min(max, val))
+
 const squadOf = (r: ParsedReport): AnyPlayer[] => (r.details?.players ?? []).filter((p) => !p?.notInSquad)
 
 export function classifyDegree(report: ParsedReport): ReplayDegree {
@@ -18,4 +44,81 @@ export function classifyDegree(report: ParsedReport): ReplayDegree {
   if (commander && tagPositions.length > 0 && (meta.pollingRate ?? 0) > 0 && (meta.inchToPixel ?? 0) > 0) return 'full'
   if (squad.some((p) => typeof p?.statsAll?.[0]?.distToCom === 'number')) return 'coarse'
   return 'none'
+}
+
+export function computePositioning(report: ParsedReport): PositioningSummary {
+  const degree = classifyDegree(report)
+  const squad = squadOf(report)
+  const meta = report.details?.combatReplayMetaData ?? {}
+  const pollingRate = (meta.pollingRate ?? 0) > 0 ? (meta.pollingRate as number) : 0
+  const inchToPixel = (meta.inchToPixel ?? 0) > 0 ? (meta.inchToPixel as number) : 0
+
+  const commander = squad.find((p) => p?.hasCommanderTag)
+  const tagPositions: Array<[number, number]> = commander?.combatReplayData?.positions ?? []
+  const replayUsable = !!commander && tagPositions.length > 0 && pollingRate > 0 && inchToPixel > 0
+
+  const perPlayerMap = new Map<string, number[]>()
+  const outOfPositionDeaths: OutOfPositionDeath[] = []
+
+  if (replayUsable) {
+    for (const player of squad) {
+      const account = player?.account ?? 'Unknown'
+      const isCommanderPlayer = !!player?.hasCommanderTag
+      const playerPositions = player?.combatReplayData?.positions
+      if (!Array.isArray(playerPositions) || playerPositions.length === 0) continue
+
+      const playerStart = Number(player?.combatReplayData?.start ?? 0)
+      const playerOffset = Math.floor(playerStart / pollingRate)
+
+      // Per-tick distance samples
+      const samples: number[] = []
+      for (let i = 0; i < playerPositions.length; i++) {
+        const tagIdx = clamp(i + playerOffset, 0, tagPositions.length - 1)
+        const [px, py] = playerPositions[i]
+        const [tx, ty] = tagPositions[tagIdx]
+        const dist = isCommanderPlayer ? 0 : Math.hypot(px - tx, py - ty) / inchToPixel
+        samples.push(dist)
+      }
+      const existing = perPlayerMap.get(account)
+      if (existing) {
+        for (const s of samples) existing.push(s)
+      } else {
+        perPlayerMap.set(account, samples)
+      }
+
+      // Out-of-position downs/deaths
+      if (isCommanderPlayer) continue
+      const replay = player?.combatReplayData
+      if (!replay || !Array.isArray(replay.down)) continue
+
+      for (const entry of replay.down) {
+        if (!Array.isArray(entry)) continue
+        const downStartMs = Number(entry[0])
+        if (!Number.isFinite(downStartMs) || downStartMs < 0) continue
+
+        const pollIndex = Math.floor(downStartMs / pollingRate)
+        const playerIdx = clamp(pollIndex - playerOffset, 0, playerPositions.length - 1)
+        const tagIdx = clamp(pollIndex, 0, tagPositions.length - 1)
+
+        const [px, py] = playerPositions[playerIdx]
+        const [tx, ty] = tagPositions[tagIdx]
+        const distAtDown = Math.round(Math.hypot(px - tx, py - ty) / inchToPixel)
+
+        if (distAtDown > OUT_OF_POSITION) {
+          outOfPositionDeaths.push({ account, distAtDown, atSec: Math.round(downStartMs / 1000) })
+        }
+      }
+    }
+  }
+
+  const perPlayer: PerPlayerDistance[] = []
+  for (const [account, samples] of perPlayerMap) {
+    if (samples.length === 0) continue
+    const avg = samples.reduce((s, v) => s + v, 0) / samples.length
+    const peak = Math.max(...samples)
+    perPlayer.push({ account, avgDistToTag: Math.round(avg), peakDistToTag: Math.round(peak) })
+  }
+  perPlayer.sort((a, b) => b.peakDistToTag - a.peakDistToTag)
+
+  return { degree, perPlayer, outOfPositionDeaths, squad: null, commander: null, deathClusters: [], figure: undefined }
 }

--- a/packages/bridge-metrics/src/positioning.ts
+++ b/packages/bridge-metrics/src/positioning.ts
@@ -20,13 +20,32 @@ export type OutOfPositionDeath = {
   atSec: number
 }
 
+export type SquadCohesion = {
+  avgSpread: number
+  peakSpread: { value: number; atSec: number }
+  cohesionNote: string
+}
+
+export type CommanderOverextension = {
+  account: string
+  peakLeadFromSquad: { value: number; atSec: number }
+  /** v1 definition: mean per-tick distance from commander to squad centroid */
+  squadFollowLag: number
+}
+
+export type DeathCluster = {
+  x: number
+  y: number
+  count: number
+}
+
 export type PositioningSummary = {
   degree: ReplayDegree
   perPlayer: PerPlayerDistance[]
   outOfPositionDeaths: OutOfPositionDeath[]
-  squad: null
-  commander: null
-  deathClusters: []
+  squad: SquadCohesion | null
+  commander: CommanderOverextension | null
+  deathClusters: DeathCluster[]
   figure: undefined
 }
 
@@ -70,7 +89,7 @@ export function computePositioning(report: ParsedReport): PositioningSummary {
       const playerStart = Number(player?.combatReplayData?.start ?? 0)
       const playerOffset = Math.floor(playerStart / pollingRate)
 
-      // Per-tick distance samples
+      // Per-tick distance samples; commander distance is always 0 (skip adding to perPlayerMap)
       const samples: number[] = []
       for (let i = 0; i < playerPositions.length; i++) {
         const tagIdx = clamp(i + playerOffset, 0, tagPositions.length - 1)
@@ -79,14 +98,17 @@ export function computePositioning(report: ParsedReport): PositioningSummary {
         const dist = isCommanderPlayer ? 0 : Math.hypot(px - tx, py - ty) / inchToPixel
         samples.push(dist)
       }
-      const existing = perPlayerMap.get(account)
-      if (existing) {
-        for (const s of samples) existing.push(s)
-      } else {
-        perPlayerMap.set(account, samples)
+      // Omit commander from perPlayer — the tag shouldn't appear in the distance ranking
+      if (!isCommanderPlayer) {
+        const existing = perPlayerMap.get(account)
+        if (existing) {
+          for (const s of samples) existing.push(s)
+        } else {
+          perPlayerMap.set(account, samples)
+        }
       }
 
-      // Out-of-position downs/deaths
+      // Out-of-position downs/deaths (skip commander)
       if (isCommanderPlayer) continue
       const replay = player?.combatReplayData
       if (!replay || !Array.isArray(replay.dead) || !Array.isArray(replay.down)) continue
@@ -129,5 +151,131 @@ export function computePositioning(report: ParsedReport): PositioningSummary {
   }
   perPlayer.sort((a, b) => b.peakDistToTag - a.peakDistToTag)
 
-  return { degree, perPlayer, outOfPositionDeaths, squad: null, commander: null, deathClusters: [], figure: undefined }
+  // Only populate squad/commander/deathClusters for 'full' degree
+  if (degree !== 'full' || !replayUsable) {
+    return { degree, perPlayer, outOfPositionDeaths, squad: null, commander: null, deathClusters: [], figure: undefined }
+  }
+
+  // --- Squad cohesion (spread timeline) ---
+  // squad members = non-commander players with positions
+  const squadNonCmdr = squad.filter((p) => !p?.hasCommanderTag && Array.isArray(p?.combatReplayData?.positions) && (p.combatReplayData!.positions!.length ?? 0) > 0)
+  const numTicks = tagPositions.length
+  let spreadSum = 0
+  let peakSpreadValue = 0
+  let peakSpreadAtSec = 0
+
+  // For commander overextension: track distance from tag to centroid per tick
+  let tagToCentroidSum = 0
+  let peakLeadValue = 0
+  let peakLeadAtSec = 0
+
+  // Collect dead/down coords for death clusters (raw map coords, no inchToPixel)
+  const deathCoords: Array<[number, number]> = []
+
+  for (const player of squad) {
+    const replay = player?.combatReplayData
+    if (!replay) continue
+    // Collect dead coords
+    if (Array.isArray(replay.dead)) {
+      for (const entry of replay.dead) {
+        if (Array.isArray(entry) && entry.length >= 2) {
+          deathCoords.push([entry[0] as number, entry[1] as number])
+        }
+      }
+    }
+    // Collect down coords
+    if (Array.isArray(replay.down)) {
+      for (const entry of replay.down) {
+        if (Array.isArray(entry) && entry.length >= 2) {
+          deathCoords.push([entry[0] as number, entry[1] as number])
+        }
+      }
+    }
+  }
+
+  for (let i = 0; i < numTicks; i++) {
+    const atSec = (i * pollingRate) / 1000
+    const [tx, ty] = tagPositions[i]
+
+    // Compute spread = mean player distance to tag at this tick
+    if (squadNonCmdr.length > 0) {
+      let spreadAtTick = 0
+      let centroidX = 0
+      let centroidY = 0
+      for (const player of squadNonCmdr) {
+        const positions = player.combatReplayData!.positions!
+        const playerStart = Number(player.combatReplayData?.start ?? 0)
+        const playerOffset = Math.floor(playerStart / pollingRate)
+        const pIdx = clamp(i - playerOffset, 0, positions.length - 1)
+        const [px, py] = positions[pIdx]
+        // spread = distance to tag / inchToPixel
+        spreadAtTick += Math.hypot(px - tx, py - ty) / inchToPixel
+        centroidX += px
+        centroidY += py
+      }
+      const avgSpreadAtTick = spreadAtTick / squadNonCmdr.length
+      spreadSum += avgSpreadAtTick
+      if (avgSpreadAtTick > peakSpreadValue) {
+        peakSpreadValue = avgSpreadAtTick
+        peakSpreadAtSec = atSec
+      }
+
+      // Centroid of squad (non-commander)
+      centroidX /= squadNonCmdr.length
+      centroidY /= squadNonCmdr.length
+
+      // Commander overextension: distance from tag to centroid / inchToPixel
+      const tagToCentroidDist = Math.hypot(tx - centroidX, ty - centroidY) / inchToPixel
+      tagToCentroidSum += tagToCentroidDist
+      if (tagToCentroidDist > peakLeadValue) {
+        peakLeadValue = tagToCentroidDist
+        peakLeadAtSec = atSec
+      }
+    }
+  }
+
+  const avgSpread = numTicks > 0 ? spreadSum / numTicks : 0
+  const peakAvgRatio = avgSpread > 0 ? peakSpreadValue / avgSpread : 1
+  const cohesionNote = peakAvgRatio > 2.5 ? 'tight then scattered' : 'held together'
+
+  // v1 squadFollowLag = mean over ticks of distance(tag, centroid) / inchToPixel
+  const squadFollowLag = numTicks > 0 ? tagToCentroidSum / numTicks : 0
+
+  // --- Death clusters ---
+  // Bucket dead/down coords into a 150-inch grid (raw map coords, no inchToPixel division)
+  const CLUSTER_CELL = 150
+  const cellMap = new Map<string, { x: number; y: number; count: number }>()
+  for (const [x, y] of deathCoords) {
+    const cellX = Math.floor(x / CLUSTER_CELL)
+    const cellY = Math.floor(y / CLUSTER_CELL)
+    const key = `${cellX},${cellY}`
+    const existing = cellMap.get(key)
+    if (existing) {
+      existing.count++
+    } else {
+      // Cell centroid = cell center in map coords
+      cellMap.set(key, { x: (cellX + 0.5) * CLUSTER_CELL, y: (cellY + 0.5) * CLUSTER_CELL, count: 1 })
+    }
+  }
+  const deathClusters = Array.from(cellMap.values())
+    .sort((a, b) => b.count - a.count)
+    .slice(0, 6)
+
+  return {
+    degree,
+    perPlayer,
+    outOfPositionDeaths,
+    squad: {
+      avgSpread: Math.round(avgSpread),
+      peakSpread: { value: Math.round(peakSpreadValue), atSec: peakSpreadAtSec },
+      cohesionNote,
+    },
+    commander: {
+      account: commander?.account ?? 'Unknown',
+      peakLeadFromSquad: { value: Math.round(peakLeadValue), atSec: peakLeadAtSec },
+      squadFollowLag: Math.round(squadFollowLag),
+    },
+    deathClusters,
+    figure: undefined,
+  }
 }

--- a/packages/bridge-metrics/src/positioning.ts
+++ b/packages/bridge-metrics/src/positioning.ts
@@ -1,0 +1,21 @@
+// src/positioning.ts
+export type ReplayDegree = 'full' | 'coarse' | 'none'
+
+type AnyPlayer = { notInSquad?: boolean; hasCommanderTag?: boolean; account?: string; profession?: string
+  statsAll?: Array<{ distToCom?: number; stackDist?: number }>
+  combatReplayData?: { positions?: Array<[number, number]>; dead?: Array<[number, number]>; down?: Array<[number, number]>; start?: number } }
+export type ParsedReport = { details?: { players?: AnyPlayer[]
+  combatReplayMetaData?: { pollingRate?: number; inchToPixel?: number; sizes?: [number, number] }
+  durationMS?: number } }
+
+const squadOf = (r: ParsedReport): AnyPlayer[] => (r.details?.players ?? []).filter((p) => !p?.notInSquad)
+
+export function classifyDegree(report: ParsedReport): ReplayDegree {
+  const squad = squadOf(report)
+  const meta = report.details?.combatReplayMetaData ?? {}
+  const commander = squad.find((p) => p?.hasCommanderTag)
+  const tagPositions = commander?.combatReplayData?.positions ?? []
+  if (commander && tagPositions.length > 0 && (meta.pollingRate ?? 0) > 0 && (meta.inchToPixel ?? 0) > 0) return 'full'
+  if (squad.some((p) => typeof p?.statsAll?.[0]?.distToCom === 'number')) return 'coarse'
+  return 'none'
+}

--- a/packages/bridge-metrics/src/positioning.ts
+++ b/packages/bridge-metrics/src/positioning.ts
@@ -55,6 +55,53 @@ const clamp = (val: number, min: number, max: number) => Math.max(min, Math.min(
 
 const squadOf = (r: ParsedReport): AnyPlayer[] => (r.details?.players ?? []).filter((p) => !p?.notInSquad)
 
+type LinkedDeathHit = { px: number; py: number; tx: number; ty: number; downStartMs: number }
+
+/**
+ * Walk a single player's linked-death `down` events once and return, per qualifying death,
+ * the player map position [px,py] and the tag map position [tx,ty] at the down tick.
+ * A "linked death" is a down entry whose second value (linkedDeathMs) exists in the
+ * player's dead set (built with the same `entry[0] > 0` threshold as the renderer).
+ */
+function linkedDeathHits(
+  player: AnyPlayer,
+  tagPositions: Array<[number, number]>,
+  pollingRate: number,
+): LinkedDeathHit[] {
+  const replay = player?.combatReplayData
+  if (!replay || !Array.isArray(replay.dead) || !Array.isArray(replay.down)) return []
+  const playerPositions = replay.positions
+  if (!Array.isArray(playerPositions) || playerPositions.length === 0) return []
+
+  const playerStart = Number(replay.start ?? 0)
+  const playerOffset = Math.floor(playerStart / pollingRate)
+
+  const deadSet = new Set<number>()
+  for (const entry of replay.dead) {
+    if (Array.isArray(entry) && Number.isFinite(Number(entry[0])) && Number(entry[0]) > 0) {
+      deadSet.add(Number(entry[0]))
+    }
+  }
+
+  const hits: LinkedDeathHit[] = []
+  for (const entry of replay.down) {
+    if (!Array.isArray(entry)) continue
+    const downStartMs = Number(entry[0])
+    const linkedDeathMs = Number(entry[1])
+    if (!Number.isFinite(downStartMs) || downStartMs < 0) continue
+    if (!deadSet.has(linkedDeathMs)) continue
+
+    const pollIndex = Math.floor(downStartMs / pollingRate)
+    const playerIdx = clamp(pollIndex - playerOffset, 0, playerPositions.length - 1)
+    const tagIdx = clamp(pollIndex, 0, tagPositions.length - 1)
+
+    const [px, py] = playerPositions[playerIdx]
+    const [tx, ty] = tagPositions[tagIdx]
+    hits.push({ px, py, tx, ty, downStartMs })
+  }
+  return hits
+}
+
 export function classifyDegree(report: ParsedReport): ReplayDegree {
   const squad = squadOf(report)
   const meta = report.details?.combatReplayMetaData ?? {}
@@ -110,31 +157,8 @@ export function computePositioning(report: ParsedReport): PositioningSummary {
 
       // Out-of-position downs/deaths (skip commander)
       if (isCommanderPlayer) continue
-      const replay = player?.combatReplayData
-      if (!replay || !Array.isArray(replay.dead) || !Array.isArray(replay.down)) continue
-
-      const deadSet = new Set<number>()
-      for (const entry of replay.dead) {
-        if (Array.isArray(entry) && Number.isFinite(Number(entry[0])) && Number(entry[0]) > 0) {
-          deadSet.add(Number(entry[0]))
-        }
-      }
-
-      for (const entry of replay.down) {
-        if (!Array.isArray(entry)) continue
-        const downStartMs = Number(entry[0])
-        const linkedDeathMs = Number(entry[1])
-        if (!Number.isFinite(downStartMs) || downStartMs < 0) continue
-        if (!deadSet.has(linkedDeathMs)) continue
-
-        const pollIndex = Math.floor(downStartMs / pollingRate)
-        const playerIdx = clamp(pollIndex - playerOffset, 0, playerPositions.length - 1)
-        const tagIdx = clamp(pollIndex, 0, tagPositions.length - 1)
-
-        const [px, py] = playerPositions[playerIdx]
-        const [tx, ty] = tagPositions[tagIdx]
+      for (const { px, py, tx, ty, downStartMs } of linkedDeathHits(player, tagPositions, pollingRate)) {
         const distAtDown = Math.round(Math.hypot(px - tx, py - ty) / inchToPixel)
-
         if (distAtDown > OUT_OF_POSITION) {
           outOfPositionDeaths.push({ account, distAtDown, atSec: Math.round(downStartMs / 1000) })
         }
@@ -175,32 +199,7 @@ export function computePositioning(report: ParsedReport): PositioningSummary {
   const deathCoords: Array<[number, number]> = []
 
   for (const player of squad) {
-    const replay = player?.combatReplayData
-    if (!replay) continue
-    const playerPositions = replay.positions
-    if (!Array.isArray(playerPositions) || playerPositions.length === 0) continue
-    if (!Array.isArray(replay.dead) || !Array.isArray(replay.down)) continue
-
-    const playerStart = Number(replay.start ?? 0)
-    const playerOffset = Math.floor(playerStart / pollingRate)
-
-    const deadSet = new Set<number>()
-    for (const entry of replay.dead) {
-      if (Array.isArray(entry) && Number.isFinite(Number(entry[0])) && Number(entry[0]) >= 0) {
-        deadSet.add(Number(entry[0]))
-      }
-    }
-
-    for (const entry of replay.down) {
-      if (!Array.isArray(entry)) continue
-      const downStartMs = Number(entry[0])
-      const linkedDeathMs = Number(entry[1])
-      if (!Number.isFinite(downStartMs) || downStartMs < 0) continue
-      if (!deadSet.has(linkedDeathMs)) continue
-
-      const pollIndex = Math.floor(downStartMs / pollingRate)
-      const playerIdx = clamp(pollIndex - playerOffset, 0, playerPositions.length - 1)
-      const [px, py] = playerPositions[playerIdx]
+    for (const { px, py } of linkedDeathHits(player, tagPositions, pollingRate)) {
       deathCoords.push([px, py])
     }
   }

--- a/packages/bridge-metrics/src/positioning.ts
+++ b/packages/bridge-metrics/src/positioning.ts
@@ -39,6 +39,21 @@ export type DeathCluster = {
   count: number
 }
 
+export type PositioningFigure = {
+  map: { sizes: [number, number]; inchToPixel: number }
+  /** Down-sampled tag path: ~1 point/sec (stride = Math.ceil(1000/pollingRate)) */
+  tagPath: Array<[number, number]>
+  /** Approximate bounding circle of the squad centroid over time */
+  squadMass: { x: number; y: number; r: number }
+  /** Death locations (reused from deathClusters source) */
+  deaths: Array<[number, number]>
+  /** Down positions */
+  downs: Array<[number, number]>
+  /** [[sec, spreadValue]] down-sampled to ~1 point/sec */
+  spread: Array<[number, number]>
+  peakSpread: number
+}
+
 export type PositioningSummary = {
   degree: ReplayDegree
   perPlayer: PerPlayerDistance[]
@@ -46,7 +61,7 @@ export type PositioningSummary = {
   squad: SquadCohesion | null
   commander: CommanderOverextension | null
   deathClusters: DeathCluster[]
-  figure: undefined
+  figure: PositioningFigure | undefined
 }
 
 export const OUT_OF_POSITION = 1200
@@ -167,13 +182,26 @@ export function computePositioning(report: ParsedReport): PositioningSummary {
   }
 
   const perPlayer: PerPlayerDistance[] = []
-  for (const [account, samples] of perPlayerMap) {
-    if (samples.length === 0) continue
-    const avg = samples.reduce((s, v) => s + v, 0) / samples.length
-    const peak = Math.max(...samples)
-    perPlayer.push({ account, avgDistToTag: Math.round(avg), peakDistToTag: Math.round(peak) })
+
+  if (replayUsable) {
+    for (const [account, samples] of perPlayerMap) {
+      if (samples.length === 0) continue
+      const avg = samples.reduce((s, v) => s + v, 0) / samples.length
+      const peak = Math.max(...samples)
+      perPlayer.push({ account, avgDistToTag: Math.round(avg), peakDistToTag: Math.round(peak) })
+    }
+    perPlayer.sort((a, b) => b.peakDistToTag - a.peakDistToTag)
+  } else if (degree === 'coarse') {
+    // Populate from statsAll[0].distToCom (peak = avg in coarse mode)
+    for (const p of squad) {
+      const account = p?.account
+      if (!account) continue
+      const distToCom = p?.statsAll?.[0]?.distToCom
+      if (typeof distToCom !== 'number') continue
+      perPlayer.push({ account, avgDistToTag: distToCom, peakDistToTag: distToCom })
+    }
+    perPlayer.sort((a, b) => b.peakDistToTag - a.peakDistToTag)
   }
-  perPlayer.sort((a, b) => b.peakDistToTag - a.peakDistToTag)
 
   // Only populate squad/commander/deathClusters for 'full' degree
   if (degree !== 'full' || !replayUsable) {
@@ -274,6 +302,88 @@ export function computePositioning(report: ParsedReport): PositioningSummary {
     .sort((a, b) => b.count - a.count)
     .slice(0, 6)
 
+  // --- Figure payload (down-sampled, full degree only) ---
+  // stride = 1 point/sec: e.g. pollingRate=100ms → stride=10, 600 ticks → 60 points
+  const stride = Math.ceil(1000 / pollingRate)
+
+  // Down-sample tagPath
+  const tagPath: Array<[number, number]> = []
+  for (let i = 0; i < tagPositions.length; i += stride) {
+    tagPath.push(tagPositions[i])
+  }
+
+  // Collect downs positions (first player position at down tick)
+  const downCoords: Array<[number, number]> = []
+  for (const player of squad) {
+    const replay = player?.combatReplayData
+    if (!replay || !Array.isArray(replay.down) || !Array.isArray(replay.positions)) continue
+    const playerStart = Number(replay.start ?? 0)
+    const playerOffset = Math.floor(playerStart / pollingRate)
+    for (const entry of replay.down) {
+      if (!Array.isArray(entry)) continue
+      const downStartMs = Number(entry[0])
+      if (!Number.isFinite(downStartMs) || downStartMs < 0) continue
+      const pollIndex = Math.floor(downStartMs / pollingRate)
+      const playerIdx = clamp(pollIndex - playerOffset, 0, replay.positions.length - 1)
+      const [px, py] = replay.positions[playerIdx]
+      downCoords.push([px, py])
+    }
+  }
+
+  // Build spread timeline down-sampled to ~1 point/sec
+  // Re-walk tag positions at stride intervals
+  const spreadTimeline: Array<[number, number]> = []
+  let sumMassX = 0
+  let sumMassY = 0
+  let massCount = 0
+  let minX = Infinity; let maxX = -Infinity; let minY = Infinity; let maxY = -Infinity
+
+  for (let i = 0; i < numTicks; i += stride) {
+    const atSec = (i * pollingRate) / 1000
+    const [tx, ty] = tagPositions[i]
+
+    let spreadAtTick = 0
+    let centroidX = 0
+    let centroidY = 0
+    for (const player of squadNonCmdr) {
+      const positions = player.combatReplayData!.positions!
+      const playerStart = Number(player.combatReplayData?.start ?? 0)
+      const playerOffset = Math.floor(playerStart / pollingRate)
+      const pIdx = clamp(i - playerOffset, 0, positions.length - 1)
+      const [px, py] = positions[pIdx]
+      spreadAtTick += Math.hypot(px - tx, py - ty) / inchToPixel
+      centroidX += px
+      centroidY += py
+    }
+    if (squadNonCmdr.length > 0) {
+      centroidX /= squadNonCmdr.length
+      centroidY /= squadNonCmdr.length
+      spreadTimeline.push([atSec, Math.round(spreadAtTick / squadNonCmdr.length)])
+      sumMassX += centroidX
+      sumMassY += centroidY
+      minX = Math.min(minX, centroidX); maxX = Math.max(maxX, centroidX)
+      minY = Math.min(minY, centroidY); maxY = Math.max(maxY, centroidY)
+      massCount++
+    }
+  }
+
+  // squadMass: centroid of centroids + bounding-circle radius
+  const massX = massCount > 0 ? sumMassX / massCount : 0
+  const massY = massCount > 0 ? sumMassY / massCount : 0
+  const massR = massCount > 0 ? Math.hypot(maxX - minX, maxY - minY) / 2 : 0
+
+  const sizes = (meta.sizes ?? [0, 0]) as [number, number]
+
+  const figure: PositioningFigure = {
+    map: { sizes, inchToPixel },
+    tagPath,
+    squadMass: { x: Math.round(massX), y: Math.round(massY), r: Math.round(massR) },
+    deaths: deathCoords,
+    downs: downCoords,
+    spread: spreadTimeline,
+    peakSpread: Math.round(peakSpreadValue),
+  }
+
   return {
     degree,
     perPlayer,
@@ -289,6 +399,6 @@ export function computePositioning(report: ParsedReport): PositioningSummary {
       squadFollowLag: Math.round(squadFollowLag),
     },
     deathClusters,
-    figure: undefined,
+    figure,
   }
 }

--- a/packages/bridge-metrics/src/positioning.ts
+++ b/packages/bridge-metrics/src/positioning.ts
@@ -89,12 +89,21 @@ export function computePositioning(report: ParsedReport): PositioningSummary {
       // Out-of-position downs/deaths
       if (isCommanderPlayer) continue
       const replay = player?.combatReplayData
-      if (!replay || !Array.isArray(replay.down)) continue
+      if (!replay || !Array.isArray(replay.dead) || !Array.isArray(replay.down)) continue
+
+      const deadSet = new Set<number>()
+      for (const entry of replay.dead) {
+        if (Array.isArray(entry) && Number.isFinite(Number(entry[0])) && Number(entry[0]) > 0) {
+          deadSet.add(Number(entry[0]))
+        }
+      }
 
       for (const entry of replay.down) {
         if (!Array.isArray(entry)) continue
         const downStartMs = Number(entry[0])
+        const linkedDeathMs = Number(entry[1])
         if (!Number.isFinite(downStartMs) || downStartMs < 0) continue
+        if (!deadSet.has(linkedDeathMs)) continue
 
         const pollIndex = Math.floor(downStartMs / pollingRate)
         const playerIdx = clamp(pollIndex - playerOffset, 0, playerPositions.length - 1)

--- a/packages/bridge-metrics/src/positioning.ts
+++ b/packages/bridge-metrics/src/positioning.ts
@@ -169,27 +169,39 @@ export function computePositioning(report: ParsedReport): PositioningSummary {
   let peakLeadValue = 0
   let peakLeadAtSec = 0
 
-  // Collect dead/down coords for death clusters (raw map coords, no inchToPixel)
+  // Collect death positions for death clusters (raw map coords, no inchToPixel)
+  // dead entries are timestamps: [deathMs, ...]; down entries are [downStartMs, linkedDeathMs]
+  // The death location is the player's position at the down tick.
   const deathCoords: Array<[number, number]> = []
 
   for (const player of squad) {
     const replay = player?.combatReplayData
     if (!replay) continue
-    // Collect dead coords
-    if (Array.isArray(replay.dead)) {
-      for (const entry of replay.dead) {
-        if (Array.isArray(entry) && entry.length >= 2) {
-          deathCoords.push([entry[0] as number, entry[1] as number])
-        }
+    const playerPositions = replay.positions
+    if (!Array.isArray(playerPositions) || playerPositions.length === 0) continue
+    if (!Array.isArray(replay.dead) || !Array.isArray(replay.down)) continue
+
+    const playerStart = Number(replay.start ?? 0)
+    const playerOffset = Math.floor(playerStart / pollingRate)
+
+    const deadSet = new Set<number>()
+    for (const entry of replay.dead) {
+      if (Array.isArray(entry) && Number.isFinite(Number(entry[0])) && Number(entry[0]) >= 0) {
+        deadSet.add(Number(entry[0]))
       }
     }
-    // Collect down coords
-    if (Array.isArray(replay.down)) {
-      for (const entry of replay.down) {
-        if (Array.isArray(entry) && entry.length >= 2) {
-          deathCoords.push([entry[0] as number, entry[1] as number])
-        }
-      }
+
+    for (const entry of replay.down) {
+      if (!Array.isArray(entry)) continue
+      const downStartMs = Number(entry[0])
+      const linkedDeathMs = Number(entry[1])
+      if (!Number.isFinite(downStartMs) || downStartMs < 0) continue
+      if (!deadSet.has(linkedDeathMs)) continue
+
+      const pollIndex = Math.floor(downStartMs / pollingRate)
+      const playerIdx = clamp(pollIndex - playerOffset, 0, playerPositions.length - 1)
+      const [px, py] = playerPositions[playerIdx]
+      deathCoords.push([px, py])
     }
   }
 
@@ -242,22 +254,24 @@ export function computePositioning(report: ParsedReport): PositioningSummary {
   const squadFollowLag = numTicks > 0 ? tagToCentroidSum / numTicks : 0
 
   // --- Death clusters ---
-  // Bucket dead/down coords into a 150-inch grid (raw map coords, no inchToPixel division)
+  // Bucket death positions into a 150-map-unit grid; centroid = mean of points in cell
   const CLUSTER_CELL = 150
-  const cellMap = new Map<string, { x: number; y: number; count: number }>()
+  const cellMap = new Map<string, { sumX: number; sumY: number; count: number }>()
   for (const [x, y] of deathCoords) {
     const cellX = Math.floor(x / CLUSTER_CELL)
     const cellY = Math.floor(y / CLUSTER_CELL)
     const key = `${cellX},${cellY}`
     const existing = cellMap.get(key)
     if (existing) {
+      existing.sumX += x
+      existing.sumY += y
       existing.count++
     } else {
-      // Cell centroid = cell center in map coords
-      cellMap.set(key, { x: (cellX + 0.5) * CLUSTER_CELL, y: (cellY + 0.5) * CLUSTER_CELL, count: 1 })
+      cellMap.set(key, { sumX: x, sumY: y, count: 1 })
     }
   }
   const deathClusters = Array.from(cellMap.values())
+    .map(({ sumX, sumY, count }) => ({ x: sumX / count, y: sumY / count, count }))
     .sort((a, b) => b.count - a.count)
     .slice(0, 6)
 


### PR DESCRIPTION
Adds a pure positional-analysis module to `@axiapps/bridge-metrics`, consumed by AxiVale (darkharasho/axivale#7) to analyze WvW fights by **where people were**.

## What's here
- **`packages/bridge-metrics/src/positioning.ts`** — `computePositioning(report)` + `classifyDegree(report)`:
  - squad **cohesion** (spread-from-tag timeline + peak), per-player **distance-to-tag**, **out-of-position deaths** (linked-death filtered, matching the renderer's `computeTagDistanceDeaths` semantics), **commander overextension**, **death clusters** (from death-tick positions — `dead`/`down` are timestamps, location = player position at the tick).
  - a **down-sampled `figure`** payload (~1 pt/sec; raw per-tick `positions` never leak) for full-replay runs.
  - graceful degradation: `full` / `coarse` (distances only) / `none`.
- Bumps the package to **`0.2.0`**.

Built TDD via subagent-driven development in an isolated worktree; per-task + whole-branch reviewed (**Ready to merge**, no critical/important findings). Distance math validated against the renderer source of truth.

## Notes for the maintainer
- Pure addition — **no renderer changes**, so it shouldn't conflict with in-flight branches.
- Follow-up (deferred): refactor `src/renderer/stats/compute{DistanceToTag,TagDistanceDeaths,CommanderStats}.ts` to consume these shared functions so the two apps don't drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)