### PR TITLE
No Ego mode (with role-aware comparisons)

### DIFF
--- a/docs/superpowers/plans/2026-06-22-no-ego-mode.md
+++ b/docs/superpowers/plans/2026-06-22-no-ego-mode.md
@@ -1,0 +1,946 @@
+# No Ego Mode Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a single master "No Ego mode" toggle that, when on, removes all competitive/ranking framing across the desktop app and web report and replaces it with squad-level distribution readouts (average, deviation, needs-improvement outliers).
+
+**Architecture:** A pure shared util (`src/shared/squadStats.ts`) summarizes any list of per-player values into `{mean, stdDev, min, max, players, needsImprovementOutliers}`, choosing the outlier end via the metric's `higherIsBetter` flag. A shared presentation component (`MetricDistributionCard`) renders one metric as a dot-plot + hard numbers + neutral low/needs-improvement callouts. A new `noEgoMode` boolean on `IStatsViewSettings` gates section behavior; when on it overrides `showMvp`/`showTopStats`, swaps Top Players and the Offense/Defense/Support sections to metric-card layouts, and hides Top Skills and Player Comparison. The web report reuses the same components and reads the baked flag from `report.json`.
+
+**Tech Stack:** TypeScript, React 18, Vite (three targets), Vitest + jsdom, Tailwind CSS variables, lucide-react.
+
+## Global Constraints
+
+- Run vitest with limited parallelism: `npx vitest run --maxWorkers=2` (per global instructions; the project config may already cap this — respect it if ≤2).
+- `npm run validate` (typecheck + ESLint with `--max-warnings 0`) must pass before any commit that touches `.ts`/`.tsx`.
+- The leaderboard/per-player row shape used throughout is `{ account: string; value: number; profession?: string; professionList?: string[]; count?: number; rank?: number }`.
+- The metric catalog is `TOP_STATS_CATALOG` in `src/renderer/stats/topStatsCatalog.ts`; each def carries `higherIsBetter: boolean`. Outlier direction MUST be derived from this flag, never hard-coded.
+- Outlier threshold is fixed at **1.5σ** (population standard deviation). Do not add it to settings.
+- `src/shared/` modules must NOT import lucide-react or other renderer-only deps (the audit TS sandbox breaks on them). `squadStats.ts` must stay dependency-free.
+- High-end values are NEVER styled as "good"/celebrated. Only the needs-improvement end gets named callouts.
+- New `noEgoMode` defaults to `false`. When off, behavior is byte-for-byte the existing behavior.
+
+---
+
+### Task 1: Squad-stat math util
+
+**Files:**
+- Create: `src/shared/squadStats.ts`
+- Test: `src/shared/__tests__/squadStats.test.ts`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces:
+  ```ts
+  export interface SquadStatPlayer {
+    account: string;
+    value: number;
+    profession?: string;
+    professionList?: string[];
+  }
+  export interface SquadStatSummary {
+    mean: number;
+    stdDev: number;        // population standard deviation
+    min: number;
+    max: number;
+    count: number;
+    players: SquadStatPlayer[];               // sorted by value ascending (for the dot-plot)
+    needsImprovementOutliers: SquadStatPlayer[]; // players beyond threshold*stdDev on the bad end
+  }
+  export function computeSquadStat(
+    players: SquadStatPlayer[],
+    higherIsBetter: boolean,
+    sigmaThreshold?: number, // default 1.5
+  ): SquadStatSummary;
+  ```
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// src/shared/__tests__/squadStats.test.ts
+import { describe, it, expect } from 'vitest';
+import { computeSquadStat } from '../squadStats';
+
+const players = (vals: number[]) =>
+  vals.map((value, i) => ({ account: `P${i}`, value, profession: 'Guardian' }));
+
+describe('computeSquadStat', () => {
+  it('computes mean, population stdDev, min, max, count', () => {
+    const s = computeSquadStat(players([2, 4, 4, 4, 5, 5, 7, 9]), true);
+    expect(s.mean).toBe(5);
+    expect(s.stdDev).toBeCloseTo(2, 5);
+    expect(s.min).toBe(2);
+    expect(s.max).toBe(9);
+    expect(s.count).toBe(8);
+  });
+
+  it('sorts players ascending for the dot-plot', () => {
+    const s = computeSquadStat(players([9, 1, 5]), true);
+    expect(s.players.map((p) => p.value)).toEqual([1, 5, 9]);
+  });
+
+  it('flags LOW outliers when higherIsBetter (low end needs improvement)', () => {
+    // mean 100, one player far below
+    const s = computeSquadStat(players([100, 100, 100, 100, 0]), true, 1.5);
+    expect(s.needsImprovementOutliers.map((p) => p.value)).toEqual([0]);
+  });
+
+  it('flags HIGH outliers when NOT higherIsBetter (e.g. deaths/damage taken)', () => {
+    const s = computeSquadStat(players([0, 0, 0, 0, 100]), false, 1.5);
+    expect(s.needsImprovementOutliers.map((p) => p.value)).toEqual([100]);
+  });
+
+  it('never flags the celebrated end as needs-improvement', () => {
+    // higherIsBetter: a single very HIGH player must NOT be an outlier
+    const s = computeSquadStat(players([0, 0, 0, 0, 100]), true, 1.5);
+    expect(s.needsImprovementOutliers).toEqual([]);
+  });
+
+  it('returns no outliers when stdDev is 0 (all equal)', () => {
+    const s = computeSquadStat(players([3, 3, 3]), true);
+    expect(s.stdDev).toBe(0);
+    expect(s.needsImprovementOutliers).toEqual([]);
+  });
+
+  it('handles single player and empty input safely', () => {
+    const single = computeSquadStat(players([42]), true);
+    expect(single.mean).toBe(42);
+    expect(single.stdDev).toBe(0);
+    expect(single.needsImprovementOutliers).toEqual([]);
+
+    const empty = computeSquadStat([], true);
+    expect(empty.count).toBe(0);
+    expect(empty.mean).toBe(0);
+    expect(empty.players).toEqual([]);
+    expect(empty.needsImprovementOutliers).toEqual([]);
+  });
+
+  it('ignores non-finite values', () => {
+    const s = computeSquadStat(
+      [{ account: 'A', value: 10 }, { account: 'B', value: NaN }, { account: 'C', value: 20 }],
+      true,
+    );
+    expect(s.count).toBe(2);
+    expect(s.mean).toBe(15);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/shared/__tests__/squadStats.test.ts --maxWorkers=2`
+Expected: FAIL — `Failed to resolve import "../squadStats"` / `computeSquadStat is not a function`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```ts
+// src/shared/squadStats.ts
+export interface SquadStatPlayer {
+  account: string;
+  value: number;
+  profession?: string;
+  professionList?: string[];
+}
+
+export interface SquadStatSummary {
+  mean: number;
+  stdDev: number;
+  min: number;
+  max: number;
+  count: number;
+  players: SquadStatPlayer[];
+  needsImprovementOutliers: SquadStatPlayer[];
+}
+
+export function computeSquadStat(
+  players: SquadStatPlayer[],
+  higherIsBetter: boolean,
+  sigmaThreshold = 1.5,
+): SquadStatSummary {
+  const valid = (Array.isArray(players) ? players : [])
+    .map((p) => ({ ...p, value: Number(p?.value) }))
+    .filter((p) => Number.isFinite(p.value));
+
+  const count = valid.length;
+  if (count === 0) {
+    return { mean: 0, stdDev: 0, min: 0, max: 0, count: 0, players: [], needsImprovementOutliers: [] };
+  }
+
+  const sorted = [...valid].sort((a, b) => a.value - b.value);
+  const values = sorted.map((p) => p.value);
+  const mean = values.reduce((sum, v) => sum + v, 0) / count;
+  const variance = values.reduce((sum, v) => sum + (v - mean) ** 2, 0) / count;
+  const stdDev = Math.sqrt(variance);
+  const min = values[0];
+  const max = values[values.length - 1];
+
+  let needsImprovementOutliers: SquadStatPlayer[] = [];
+  if (stdDev > 0) {
+    const cutoff = sigmaThreshold * stdDev;
+    needsImprovementOutliers = sorted.filter((p) =>
+      higherIsBetter ? p.value < mean - cutoff : p.value > mean + cutoff,
+    );
+  }
+
+  return { mean, stdDev, min, max, count, players: sorted, needsImprovementOutliers };
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run src/shared/__tests__/squadStats.test.ts --maxWorkers=2`
+Expected: PASS (8 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/shared/squadStats.ts src/shared/__tests__/squadStats.test.ts
+git commit -m "feat: add squadStats util for No Ego distribution math"
+```
+
+---
+
+### Task 2: Add `noEgoMode` setting + override plumbing
+
+**Files:**
+- Modify: `src/renderer/global.d.ts:76-91` (interface) and `:223-244` (defaults)
+- Modify: `src/renderer/StatsView.tsx:230-236` (read + override)
+- Test: `src/renderer/__tests__/noEgoSettings.test.ts` (new)
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `IStatsViewSettings.noEgoMode: boolean`; `DEFAULT_STATS_VIEW_SETTINGS.noEgoMode = false`. In `StatsView`, a derived `const noEgoMode = activeStatsViewSettings.noEgoMode === true;` and overridden `showTopStats`/`showMvp` (see Step 4).
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// src/renderer/__tests__/noEgoSettings.test.ts
+import { describe, it, expect } from 'vitest';
+import { DEFAULT_STATS_VIEW_SETTINGS } from '../global';
+
+describe('noEgoMode setting', () => {
+  it('defaults to false', () => {
+    expect(DEFAULT_STATS_VIEW_SETTINGS.noEgoMode).toBe(false);
+  });
+});
+```
+
+Note: `global.d.ts` is imported via `../global` (no extension) — confirm an existing test imports the same path; if the project re-exports defaults from `global.d.ts` directly, mirror whatever path neighboring tests already use (`grep -rn "from '../global'" src/renderer/__tests__`).
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/renderer/__tests__/noEgoSettings.test.ts --maxWorkers=2`
+Expected: FAIL — `expected undefined to be false`.
+
+- [ ] **Step 3: Add the field and default**
+
+In `src/renderer/global.d.ts`, inside `interface IStatsViewSettings` (after `mvpBoonMetric` on line ~90), add:
+
+```ts
+    // No Ego mode: removes ranking/MVP framing everywhere; shows squad
+    // average/deviation/needs-improvement outliers instead. Overrides
+    // showTopStats/showMvp when true.
+    noEgoMode: boolean;
+```
+
+In `DEFAULT_STATS_VIEW_SETTINGS` (after `mvpBoonMetric: 'uptime',` on line ~235), add:
+
+```ts
+    noEgoMode: false,
+```
+
+- [ ] **Step 4: Wire the override in StatsView**
+
+In `src/renderer/StatsView.tsx`, replace lines 232-233:
+
+```ts
+    const showTopStats = activeStatsViewSettings.showTopStats;
+    const showMvp = activeStatsViewSettings.showMvp;
+```
+
+with:
+
+```ts
+    const noEgoMode = activeStatsViewSettings.noEgoMode === true;
+    // No Ego mode forces the squad-summary layout on and the MVP podium off.
+    const showTopStats = noEgoMode ? true : activeStatsViewSettings.showTopStats;
+    const showMvp = noEgoMode ? false : activeStatsViewSettings.showMvp;
+```
+
+(`noEgoMode` is now available to pass into sections in later tasks.)
+
+- [ ] **Step 5: Run test + typecheck**
+
+Run: `npx vitest run src/renderer/__tests__/noEgoSettings.test.ts --maxWorkers=2`
+Expected: PASS.
+Run: `npm run typecheck`
+Expected: no errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/renderer/global.d.ts src/renderer/StatsView.tsx src/renderer/__tests__/noEgoSettings.test.ts
+git commit -m "feat: add noEgoMode setting and StatsView override plumbing"
+```
+
+---
+
+### Task 3: Settings UI toggle
+
+**Files:**
+- Modify: `src/renderer/SettingsView.tsx` (near the `showTopStats`/`showMvp` toggles, ~lines 2188-2195)
+
+**Interfaces:**
+- Consumes: `IStatsViewSettings.noEgoMode` (Task 2).
+- Produces: a user-visible toggle that sets `noEgoMode`.
+
+- [ ] **Step 1: Read the existing toggle markup**
+
+Run: `sed -n '2180,2200p' src/renderer/SettingsView.tsx` to see how `showTopStats`/`showMvp` toggles are wired (the `onChange` handler that updates stats-view settings, and the toggle component used).
+
+- [ ] **Step 2: Add the No Ego toggle**
+
+Immediately before the `showTopStats` toggle, add a toggle following the exact same pattern the file already uses (same toggle component, same settings-update handler), bound to `noEgoMode`. Label: **"No Ego mode"**. Description: **"Hide MVP, rankings, and leaderboards. Show squad averages, spread, and areas to improve instead — across the app and web reports."**
+
+When `noEgoMode` is on, render the `showTopStats` and `showMvp` toggles as disabled (greyed) since they have no effect — match however the file disables dependent toggles elsewhere (look for an existing `disabled=` usage to copy the idiom). If no such idiom exists, leave them enabled but unaffected; do not invent new styling.
+
+- [ ] **Step 3: Verify in the running app**
+
+Run: `npm run dev`
+Manually: open Settings → stats section, confirm the "No Ego mode" toggle appears, flips, and persists across an app reload (it writes through the same handler the neighbors use, so persistence is automatic). Stop the dev server.
+
+- [ ] **Step 4: Validate + commit**
+
+Run: `npm run validate`
+Expected: pass.
+
+```bash
+git add src/renderer/SettingsView.tsx
+git commit -m "feat: add No Ego mode toggle to settings"
+```
+
+---
+
+### Task 4: `MetricDistributionCard` shared component
+
+**Files:**
+- Create: `src/renderer/stats/components/MetricDistributionCard.tsx`
+- Test: `src/renderer/stats/components/__tests__/MetricDistributionCard.test.tsx`
+
+**Interfaces:**
+- Consumes: `computeSquadStat`, `SquadStatSummary`, `SquadStatPlayer` from `src/shared/squadStats` (Task 1).
+- Produces:
+  ```ts
+  export interface MetricDistributionCardProps {
+    title: string;
+    accentColor: string;                 // hex, from catalog def.color
+    higherIsBetter: boolean;
+    players: SquadStatPlayer[];           // per-player values for this metric
+    formatValue: (n: number) => string;  // caller supplies metric-aware formatting
+    unit?: string;
+    renderProfessionIcon?: (profession: string, professionList: string[] | undefined, className: string) => React.ReactNode;
+  }
+  export const MetricDistributionCard: React.FC<MetricDistributionCardProps>;
+  ```
+
+- [ ] **Step 1: Write the failing test**
+
+```tsx
+// src/renderer/stats/components/__tests__/MetricDistributionCard.test.tsx
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MetricDistributionCard } from '../MetricDistributionCard';
+
+const players = (vals: number[]) =>
+  vals.map((value, i) => ({ account: `Player${i}`, value, profession: 'Guardian' }));
+
+describe('MetricDistributionCard', () => {
+  it('renders title, average and deviation hard numbers', () => {
+    render(
+      <MetricDistributionCard
+        title="Cleanses"
+        accentColor="#60a5fa"
+        higherIsBetter
+        players={players([2, 4, 4, 4, 5, 5, 7, 9])}
+        formatValue={(n) => String(Math.round(n))}
+      />,
+    );
+    expect(screen.getByText('Cleanses')).toBeInTheDocument();
+    expect(screen.getByTestId('metric-card-mean')).toHaveTextContent('5');
+    expect(screen.getByTestId('metric-card-stddev')).toHaveTextContent('2');
+  });
+
+  it('names needs-improvement outliers and never celebrates the high end', () => {
+    render(
+      <MetricDistributionCard
+        title="Cleanses"
+        accentColor="#60a5fa"
+        higherIsBetter
+        players={players([100, 100, 100, 100, 0]).map((p, i) => ({ ...p, account: i === 4 ? 'LowGuy' : p.account }))}
+        formatValue={(n) => String(Math.round(n))}
+      />,
+    );
+    const callouts = screen.getByTestId('metric-card-outliers');
+    expect(callouts).toHaveTextContent('LowGuy');
+    // No "MVP"/"top"/crown language anywhere
+    expect(screen.queryByText(/MVP|top performer|#1/i)).toBeNull();
+  });
+
+  it('shows a quiet consistent-squad note when there are no outliers', () => {
+    render(
+      <MetricDistributionCard
+        title="Cleanses"
+        accentColor="#60a5fa"
+        higherIsBetter
+        players={players([5, 5, 5])}
+        formatValue={(n) => String(Math.round(n))}
+      />,
+    );
+    expect(screen.getByTestId('metric-card-outliers')).toHaveTextContent(/consistent/i);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/renderer/stats/components/__tests__/MetricDistributionCard.test.tsx --maxWorkers=2`
+Expected: FAIL — cannot resolve `../MetricDistributionCard`.
+
+- [ ] **Step 3: Implement the component**
+
+```tsx
+// src/renderer/stats/components/MetricDistributionCard.tsx
+import React from 'react';
+import { computeSquadStat, type SquadStatPlayer } from '../../../shared/squadStats';
+
+export interface MetricDistributionCardProps {
+  title: string;
+  accentColor: string;
+  higherIsBetter: boolean;
+  players: SquadStatPlayer[];
+  formatValue: (n: number) => string;
+  unit?: string;
+  renderProfessionIcon?: (
+    profession: string,
+    professionList: string[] | undefined,
+    className: string,
+  ) => React.ReactNode;
+}
+
+export const MetricDistributionCard: React.FC<MetricDistributionCardProps> = ({
+  title,
+  accentColor,
+  higherIsBetter,
+  players,
+  formatValue,
+  unit = '',
+  renderProfessionIcon,
+}) => {
+  const s = computeSquadStat(players, higherIsBetter);
+  const range = s.max - s.min;
+  const pos = (v: number) => (range > 0 ? ((v - s.min) / range) * 100 : 50);
+  const outlierKeys = new Set(s.needsImprovementOutliers.map((p) => p.account));
+
+  // σ band as a fraction of the plotted range, centered on the mean
+  const bandLeft = range > 0 ? Math.max(0, ((s.mean - s.stdDev - s.min) / range) * 100) : 0;
+  const bandRight = range > 0 ? Math.min(100, ((s.mean + s.stdDev - s.min) / range) * 100) : 100;
+
+  return (
+    <div
+      className="border rounded-[var(--radius-md)] p-4 flex flex-col gap-3"
+      style={{ borderColor: 'var(--border-default)' }}
+    >
+      <div className="flex items-baseline justify-between gap-2">
+        <div
+          className="text-xs font-bold uppercase tracking-wider truncate"
+          style={{ color: 'var(--text-secondary)' }}
+        >
+          {title}
+        </div>
+        <div className="text-xs text-[color:var(--text-muted)]">{s.count} players</div>
+      </div>
+
+      {/* Hard numbers */}
+      <div className="flex items-end gap-4">
+        <div>
+          <div className="text-[10px] uppercase tracking-wide text-[color:var(--text-muted)]">Avg</div>
+          <div data-testid="metric-card-mean" className="text-2xl font-bold text-white">
+            {formatValue(s.mean)} <span className="text-sm font-normal text-[color:var(--text-secondary)]">{unit}</span>
+          </div>
+        </div>
+        <div>
+          <div className="text-[10px] uppercase tracking-wide text-[color:var(--text-muted)]">σ Deviation</div>
+          <div data-testid="metric-card-stddev" className="text-lg font-semibold text-[color:var(--text-secondary)]">
+            {formatValue(s.stdDev)}
+          </div>
+        </div>
+        <div>
+          <div className="text-[10px] uppercase tracking-wide text-[color:var(--text-muted)]">Range</div>
+          <div className="text-sm text-[color:var(--text-secondary)]">
+            {formatValue(s.min)}–{formatValue(s.max)}
+          </div>
+        </div>
+      </div>
+
+      {/* Dot-plot: every player a neutral dot; σ band shaded; mean line. */}
+      <div className="relative h-8 mt-1">
+        <div
+          className="absolute top-1/2 -translate-y-1/2 h-2 rounded-full"
+          style={{ left: `${bandLeft}%`, width: `${Math.max(0, bandRight - bandLeft)}%`, background: `${accentColor}22` }}
+        />
+        <div
+          className="absolute top-0 bottom-0 w-px"
+          style={{ left: `${pos(s.mean)}%`, background: 'var(--border-hover)' }}
+        />
+        {s.players.map((p) => (
+          <div
+            key={p.account}
+            title={`${p.account}: ${formatValue(p.value)}`}
+            className="absolute top-1/2 -translate-y-1/2 -translate-x-1/2 w-2 h-2 rounded-full"
+            style={{
+              left: `${pos(p.value)}%`,
+              background: outlierKeys.has(p.account) ? accentColor : 'var(--text-muted)',
+              outline: outlierKeys.has(p.account) ? `1px solid ${accentColor}` : 'none',
+            }}
+          />
+        ))}
+      </div>
+
+      {/* Needs-improvement callouts (neutral language, low/bad end only) */}
+      <div
+        data-testid="metric-card-outliers"
+        className="border-t border-[color:var(--border-subtle)] pt-2 text-xs text-[color:var(--text-secondary)]"
+      >
+        {s.needsImprovementOutliers.length ? (
+          <div className="flex flex-col gap-1">
+            <div className="text-[10px] uppercase tracking-wide text-[color:var(--text-muted)]">
+              Most room to improve
+            </div>
+            {s.needsImprovementOutliers.map((p) => (
+              <div key={p.account} className="flex items-center gap-2 min-w-0">
+                {renderProfessionIcon?.(p.profession || 'Unknown', p.professionList, 'w-4 h-4')}
+                <span className="truncate flex-1">{p.account}</span>
+                <span className="font-mono text-[color:var(--text-secondary)]">{formatValue(p.value)}</span>
+              </div>
+            ))}
+          </div>
+        ) : (
+          <span className="text-[color:var(--text-muted)]">Squad is consistent here.</span>
+        )}
+      </div>
+    </div>
+  );
+};
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run src/renderer/stats/components/__tests__/MetricDistributionCard.test.tsx --maxWorkers=2`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/renderer/stats/components/MetricDistributionCard.tsx src/renderer/stats/components/__tests__/MetricDistributionCard.test.tsx
+git commit -m "feat: add MetricDistributionCard for No Ego squad readouts"
+```
+
+---
+
+### Task 5: Top Players → Squad Summary in No Ego mode
+
+**Files:**
+- Modify: `src/renderer/stats/sections/TopPlayersSection.tsx`
+- Modify: `src/renderer/StatsView.tsx` (both `TopPlayersSection` render sites: ~4264 and ~4709 — pass the new prop)
+- Test: `src/renderer/stats/sections/__tests__/TopPlayersSection.noego.test.tsx` (new)
+
+**Interfaces:**
+- Consumes: `noEgoMode` (Task 2), `MetricDistributionCard` (Task 4), `computeSquadStat` (Task 1), `TOP_STATS_CATALOG` + `enabledTopStats`, and the leaderboard maps already read in this file (`stats.leaderboards`, `stats.topStatsLeaderboardsPerSecond`, `stats.topStatsLeaderboardsPerMinute`).
+- Produces: `TopPlayersSectionProps.noEgoMode?: boolean`.
+
+- [ ] **Step 1: Write the failing test**
+
+```tsx
+// src/renderer/stats/sections/__tests__/TopPlayersSection.noego.test.tsx
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { TopPlayersSection } from '../TopPlayersSection';
+import { StatsSharedContext } from '../../StatsViewContext';
+
+// Minimal context value; fill required fields per StatsSharedContextValue.
+const ctx: any = {
+  stats: {
+    leaderboards: {
+      cleanses: [
+        { account: 'A', value: 100, profession: 'Guardian' },
+        { account: 'B', value: 100, profession: 'Guardian' },
+        { account: 'C', value: 100, profession: 'Guardian' },
+        { account: 'LowGuy', value: 0, profession: 'Guardian' },
+      ],
+    },
+  },
+  formatWithCommas: (n: number) => String(n),
+  renderProfessionIcon: () => null,
+};
+
+const renderWith = (props: any) =>
+  render(
+    <StatsSharedContext.Provider value={ctx}>
+      <TopPlayersSection {...props} />
+    </StatsSharedContext.Provider>,
+  );
+
+const base = {
+  showTopStats: true,
+  showMvp: false,
+  topStatsMode: 'total' as const,
+  expandedLeader: null,
+  setExpandedLeader: () => {},
+  formatTopStatValue: (n: number) => String(Math.round(n)),
+  isMvpStatEnabled: () => true,
+  enabledTopStats: ['cleanses'],
+};
+
+describe('TopPlayersSection — No Ego', () => {
+  it('shows squad-summary cards and no podium when noEgoMode', () => {
+    renderWith({ ...base, noEgoMode: true });
+    expect(screen.getByTestId('squad-summary')).toBeInTheDocument();
+    expect(screen.queryByText('Offensive MVP')).toBeNull();
+    expect(screen.getByTestId('metric-card-outliers')).toHaveTextContent('LowGuy');
+  });
+
+  it('shows the normal leaderboard layout when noEgoMode is off', () => {
+    renderWith({ ...base, noEgoMode: false });
+    expect(screen.queryByTestId('squad-summary')).toBeNull();
+  });
+});
+```
+
+Before implementing, confirm `StatsSharedContext` is exported from `src/renderer/stats/StatsViewContext.tsx`. If only the hook `useStatsSharedContext` is exported, export the raw context too (add `export const StatsSharedContext = ...` if needed) so the test can wrap it.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/renderer/stats/sections/__tests__/TopPlayersSection.noego.test.tsx --maxWorkers=2`
+Expected: FAIL — `noEgoMode` not handled / no `squad-summary` testid.
+
+- [ ] **Step 3: Add the prop and the No Ego branch**
+
+In `TopPlayersSectionProps` add:
+
+```ts
+    noEgoMode?: boolean;
+```
+
+In the component destructuring add `noEgoMode = false,`. Then, right after computing `topStatsLeaderboards`, `enabledSet`, `enabledDefs`, and `formatValue` (the existing code around lines 156-179), insert a No Ego early return that reuses the same leaderboard source and per-def formatting:
+
+```tsx
+  if (noEgoMode) {
+    return (
+      <div data-testid="squad-summary">
+        <div className="flex items-center gap-2 mb-3.5">
+          <Trophy className="w-4 h-4 shrink-0" style={{ color: 'var(--brand-primary)' }} />
+          <h3 className="text-[11px] font-semibold uppercase tracking-[0.05em]" style={{ color: 'var(--text-primary)' }}>
+            Squad Summary
+          </h3>
+        </div>
+        <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4">
+          {enabledDefs.map((def) => {
+            const rows =
+              def.source.kind === 'boon'
+                ? (stats.boonLeaderboards?.[def.id] ?? [])
+                : (topStatsLeaderboards?.[def.source.key] ?? []);
+            const players = (Array.isArray(rows) ? rows : []).map((r: any) => ({
+              account: r.account,
+              value: Number(r.value ?? 0),
+              profession: r.profession,
+              professionList: r.professionList,
+            }));
+            return (
+              <MetricDistributionCard
+                key={def.id}
+                title={getCardTitle(def, isPerSecond, isPerMinute)}
+                accentColor={def.color}
+                higherIsBetter={def.higherIsBetter}
+                players={players}
+                unit={def.unit ?? ''}
+                formatValue={(n) => formatValue(def, n)}
+                renderProfessionIcon={renderProfessionIcon}
+              />
+            );
+          })}
+        </div>
+      </div>
+    );
+  }
+```
+
+Add the import at the top: `import { MetricDistributionCard } from '../components/MetricDistributionCard';`
+
+Note on boon source: confirm the boon leaderboard map name by reading how the existing non-No-Ego code resolves boon cards in this file (search for `boon` / `boonLeaderboards` / `def.source.kind === 'boon'`). Use whatever map/getter the existing leader cards use for boons; the placeholder `stats.boonLeaderboards?.[def.id]` above must be replaced with the real accessor if it differs.
+
+- [ ] **Step 4: Pass the prop from StatsView**
+
+At BOTH `TopPlayersSection` render sites in `src/renderer/StatsView.tsx` (~line 4264 and ~line 4709), add the prop `noEgoMode={noEgoMode}` alongside the existing `showTopStats`/`showMvp` props.
+
+- [ ] **Step 5: Run test + typecheck**
+
+Run: `npx vitest run src/renderer/stats/sections/__tests__/TopPlayersSection.noego.test.tsx --maxWorkers=2`
+Expected: PASS.
+Run: `npm run typecheck`
+Expected: no errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/renderer/stats/sections/TopPlayersSection.tsx src/renderer/StatsView.tsx src/renderer/stats/sections/__tests__/TopPlayersSection.noego.test.tsx
+git commit -m "feat: Top Players becomes Squad Summary in No Ego mode"
+```
+
+---
+
+### Task 6: Offense / Defense / Support → metric cards + collapsed grid
+
+**Files:**
+- Modify: `src/renderer/stats/sections/OffenseSection.tsx`
+- Modify: `src/renderer/stats/sections/DefenseSection.tsx`
+- Modify: `src/renderer/stats/sections/SupportSection.tsx`
+- Modify: `src/renderer/StatsView.tsx` (all six render sites: ~4363, ~4471, ~4532, ~4796, ~4909, ~5057 — pass `noEgoMode`)
+- Test: `src/renderer/stats/sections/__tests__/OffenseSection.noego.test.tsx` (new)
+
+**Interfaces:**
+- Consumes: `noEgoMode` (Task 2), `MetricDistributionCard` (Task 4).
+- Produces: a `noEgoMode?: boolean` prop on each of the three section prop types.
+
+Each section currently renders a player×metric grid. In No Ego mode it must render a **list of `MetricDistributionCard`s (one per metric column the table shows)** with the **full grid collapsed behind an expander** (default collapsed).
+
+- [ ] **Step 1: Read one section to learn its metric set + row data**
+
+Run: `sed -n '1,120p' src/renderer/stats/sections/OffenseSection.tsx`
+Identify (a) the array of metric column definitions the table iterates (id, label, higherIsBetter or a lookup into `TOP_STATS_CATALOG`, accent color, value formatter) and (b) the per-player row array and how each player's value for a metric is read. You will reuse exactly those to build `players` arrays per metric.
+
+- [ ] **Step 2: Write the failing test (Offense as the representative)**
+
+```tsx
+// src/renderer/stats/sections/__tests__/OffenseSection.noego.test.tsx
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { OffenseSection } from '../OffenseSection';
+import { StatsSharedContext } from '../../StatsViewContext';
+
+// Build a context + props matching OffenseSection's real shape (read the file
+// in Step 1 and fill these to match). The assertions below are the contract.
+const ctx: any = { /* minimal stats with >=4 players having offense metrics */ };
+
+describe('OffenseSection — No Ego', () => {
+  it('renders metric distribution cards and hides rank numbers', () => {
+    render(
+      <StatsSharedContext.Provider value={ctx}>
+        {/* spread the section's required props; add noEgoMode */}
+        <OffenseSection {...({} as any)} noEgoMode />
+      </StatsSharedContext.Provider>,
+    );
+    // At least one distribution card present
+    expect(screen.getAllByTestId('metric-card-mean').length).toBeGreaterThan(0);
+    // Full grid is collapsed by default behind an expander
+    expect(screen.getByRole('button', { name: /per-player detail|show detail|detailed/i })).toBeInTheDocument();
+  });
+});
+```
+
+Note: this test's context/props MUST be completed against the real `OffenseSection` signature found in Step 1. Do not leave `{}` — populate with a 4+ player fixture so `computeSquadStat` produces a card. Treat the two assertions (cards present, expander present) as the fixed contract.
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `npx vitest run src/renderer/stats/sections/__tests__/OffenseSection.noego.test.tsx --maxWorkers=2`
+Expected: FAIL.
+
+- [ ] **Step 4: Implement the No Ego branch in each section**
+
+For each of `OffenseSection`, `DefenseSection`, `SupportSection`:
+1. Add `noEgoMode?: boolean` to the props type and destructure with default `false`.
+2. Add `import { MetricDistributionCard } from '../components/MetricDistributionCard';`.
+3. When `noEgoMode` is true, render:
+   - A responsive grid of `MetricDistributionCard`, one per metric column the table shows. Build each card's `players` array from the same per-player rows the grid uses: `{ account, value: <that player's value for this metric>, profession, professionList }`. Use the metric's `higherIsBetter` (from `TOP_STATS_CATALOG` lookup by id, or the column def if it already carries the flag), `color`, `unit`, and the section's existing value formatter for that metric.
+   - Below the cards, an expander button (default collapsed) labeled "Per-player detail" that, when expanded, renders the **existing grid unchanged** (no rank numbers/best-value highlight needed inside — but if the existing grid adds a `{idx + 1}` rank marker or best-value highlight, suppress those when `noEgoMode` by guarding that markup with `!noEgoMode`).
+   - Use a local `useState(false)` for the expander. Match the expander idiom already used elsewhere in the codebase if one exists (search for `aria-expanded` / existing collapsible sections); otherwise a plain button toggling the state is fine.
+
+- [ ] **Step 5: Pass `noEgoMode` from StatsView**
+
+Add `noEgoMode={noEgoMode}` to all six section render sites listed in **Files**.
+
+- [ ] **Step 6: Run test + validate**
+
+Run: `npx vitest run src/renderer/stats/sections/__tests__/OffenseSection.noego.test.tsx --maxWorkers=2`
+Expected: PASS.
+Run: `npm run validate`
+Expected: pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/renderer/stats/sections/OffenseSection.tsx src/renderer/stats/sections/DefenseSection.tsx src/renderer/stats/sections/SupportSection.tsx src/renderer/StatsView.tsx src/renderer/stats/sections/__tests__/OffenseSection.noego.test.tsx
+git commit -m "feat: Offense/Defense/Support show metric cards in No Ego mode"
+```
+
+---
+
+### Task 7: Hide Top Skills and Player Comparison in No Ego mode
+
+**Files:**
+- Modify: `src/renderer/StatsView.tsx` (TopSkills sites ~4276, ~4719; PlayerComparison site ~5155)
+- Test: extend `src/renderer/stats/sections/__tests__/` via the integration test in Task 8 (no separate test here — covered by Task 8 assertions).
+
+**Interfaces:**
+- Consumes: `noEgoMode` (Task 2).
+
+- [ ] **Step 1: Gate the render sites**
+
+In `src/renderer/StatsView.tsx`, wrap each `TopSkillsSection` and the `PlayerComparisonSection` render so it is omitted when `noEgoMode` is true. Two patterns appear in the file:
+- Direct render via `renderSectionWrap(<TopSkillsSection .../>)` (~4276): change to `{!noEgoMode && renderSectionWrap(<TopSkillsSection .../>)}`.
+- Section-list entries `{ id: 'top-skills-outgoing', element: <TopSkillsSection .../> }` (~4719) and `{ id: 'player-comparison', element: <PlayerComparisonSection .../> }` (~5155): these are array items. After the array is built, filter them out when `noEgoMode`, OR guard each with a conditional spread. Concretely, find where this array is defined and add a `.filter(...)` that drops `top-skills-outgoing`, `top-skills-incoming` (if present), and `player-comparison` ids when `noEgoMode`. Read the surrounding code to choose the cleaner of the two; prefer the post-build `.filter` so all skill/comparison variants are caught.
+
+- [ ] **Step 2: Typecheck**
+
+Run: `npm run typecheck`
+Expected: no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/renderer/StatsView.tsx
+git commit -m "feat: hide Top Skills and Player Comparison in No Ego mode"
+```
+
+---
+
+### Task 8: StatsView integration test for No Ego mode
+
+**Files:**
+- Create: `src/renderer/__tests__/StatsView.noego.integration.test.tsx` (mirror the setup of the existing `StatsView.integration.test.tsx`)
+
+**Interfaces:**
+- Consumes: everything above.
+
+- [ ] **Step 1: Read the existing integration test for setup conventions**
+
+Run: `sed -n '1,80p' src/renderer/__tests__/StatsView.integration.test.tsx`
+Reuse its data fixture/builder and the way it passes `statsViewSettings`.
+
+- [ ] **Step 2: Write the test**
+
+Using the same fixture, render `StatsView` twice via its `statsViewSettings` prop:
+
+```tsx
+// Assertions for noEgoMode: true
+expect(screen.getByTestId('squad-summary')).toBeInTheDocument();
+expect(screen.queryByText('Offensive MVP')).toBeNull();
+expect(screen.queryByText('Defensive MVP')).toBeNull();
+// Top Skills section header absent
+expect(screen.queryByText(/Top Skills/i)).toBeNull();
+// Player comparison absent
+expect(screen.queryByText(/Player Comparison|head-to-head/i)).toBeNull();
+
+// Assertions for noEgoMode: false (control)
+expect(screen.queryByTestId('squad-summary')).toBeNull();
+```
+
+Match the exact section header strings to what the components render (grep the section files for their `<h3>`/title text and use those literals).
+
+- [ ] **Step 3: Run + validate**
+
+Run: `npx vitest run src/renderer/__tests__/StatsView.noego.integration.test.tsx --maxWorkers=2`
+Expected: PASS.
+Run: `npm run validate`
+Expected: pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/renderer/__tests__/StatsView.noego.integration.test.tsx
+git commit -m "test: StatsView No Ego mode integration coverage"
+```
+
+---
+
+### Task 9: Web report + rollup honor the baked flag
+
+**Files:**
+- Inspect/Modify: `src/web/reportApp.tsx`, `src/web/rollup.ts`
+- Inspect: the main-process web-report builder that writes `report.json` (search for where `statsViewSettings` / settings are serialized into the report payload)
+- Test: `src/web/__tests__/rollup.noego.test.ts` (new, only if rollup display logic is extracted as testable functions; otherwise a reportApp render test)
+
+**Interfaces:**
+- Consumes: `noEgoMode` baked in `report.json` (already part of `IStatsViewSettings`), `MetricDistributionCard`, `computeSquadStat`.
+
+- [ ] **Step 1: Confirm the flag bakes into report.json automatically**
+
+Run: `grep -rn "statsViewSettings\|noEgoMode\|StatsViewSettings" src/main src/web | grep -iv test`
+Confirm `report.json` carries the full `IStatsViewSettings` (so `noEgoMode` rides along with no extra work). If the builder cherry-picks individual settings fields rather than spreading the whole object, add `noEgoMode` to that projection. Document which case applies in the commit message.
+
+- [ ] **Step 2: Verify StatsView path already covers the web report**
+
+Because `reportApp.tsx` renders the same `StatsView` with settings from `report.json`, Tasks 5–7 already apply to the web report. Confirm by reading `reportApp.tsx` to ensure it passes `statsViewSettings` straight from the payload into `StatsView` (it should). No change needed if so.
+
+- [ ] **Step 3: Reframe the rollup display (cross-report aggregates only)**
+
+In `src/web/rollup.ts` + its renderer in `reportApp.tsx`: the rollup builder must **keep computing all aggregates unconditionally** (do NOT gate any computation on `noEgoMode`). Only the **display** changes: when the report's `noEgoMode` is true, render the cross-report "top commanders / top players" leaderboards as `MetricDistributionCard`s (per aggregated metric, building `players` arrays from the rollup's per-player aggregates and the metric's `higherIsBetter`) instead of ranked lists. Read `rollup.ts` to find the per-player aggregate arrays and reuse them as the card `players`.
+
+- [ ] **Step 4: Test**
+
+If rollup exposes pure builder functions, add `src/web/__tests__/rollup.noego.test.ts` asserting the builder still returns full aggregates regardless of `noEgoMode` (computation is never gated). If display logic is inline in `reportApp.tsx`, add a render test asserting that with `noEgoMode: true` the rollup shows distribution cards and no rank numbers, and with it false shows the existing leaderboard.
+
+Run: `npx vitest run src/web/__tests__/rollup.noego.test.ts --maxWorkers=2`
+Expected: PASS.
+
+- [ ] **Step 5: Build the web report to confirm it compiles**
+
+Run: `npm run build:web`
+Expected: build succeeds.
+
+- [ ] **Step 6: Validate + commit**
+
+Run: `npm run validate`
+Expected: pass.
+
+```bash
+git add src/web/reportApp.tsx src/web/rollup.ts src/web/__tests__/rollup.noego.test.ts
+git commit -m "feat: web report + rollup honor baked No Ego flag (compute always, reframe display)"
+```
+
+---
+
+### Task 10: Full validation sweep
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Run the whole unit suite**
+
+Run: `npm run test:unit -- --maxWorkers=2` (if the script doesn't forward args, use `npx vitest run --maxWorkers=2`)
+Expected: all pass, including the new No Ego tests and the pre-existing suite (catches any regression in the default-off path).
+
+- [ ] **Step 2: Validate**
+
+Run: `npm run validate`
+Expected: typecheck + lint clean (0 warnings).
+
+- [ ] **Step 3: Manual smoke in the app**
+
+Run: `npm run dev`
+- Toggle No Ego on: Top Players → "Squad Summary" cards; Offense/Defense/Support show metric cards with a collapsed "Per-player detail" expander; Top Skills and Player Comparison gone; no crown/medals/rank numbers anywhere.
+- Toggle off: everything returns to the original layout.
+Stop the dev server.
+
+- [ ] **Step 4: Final commit (if any smoke fixes were needed)**
+
+```bash
+git add -A
+git commit -m "chore: No Ego mode smoke-test fixes"
+```
+
+---
+
+## Notes for the implementer
+
+- The leaderboard maps (`stats.leaderboards`, `...PerSecond`, `...PerMinute`) already contain one row per player per metric — these ARE the per-player value arrays `computeSquadStat` needs. You rarely need to recompute from raw player stats.
+- Keep the default-off path untouched: every change is additive behind `noEgoMode`. The pre-existing test suite is your regression guard.
+- Never style the high end as good. The dot-plot colors only needs-improvement outliers with the accent; everyone else is neutral `--text-muted`.
+- Boon metrics live in a separate leaderboard map than the numeric `leaderboards`; confirm the exact accessor in `TopPlayersSection.tsx` before relying on the placeholder in Task 5 Step 3.

--- a/docs/superpowers/plans/2026-06-22-no-ego-role-aware.md
+++ b/docs/superpowers/plans/2026-06-22-no-ego-role-aware.md
@@ -1,0 +1,690 @@
+# No Ego Role-Aware Comparisons Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make No Ego "needs-improvement" outliers role-aware — judge each player against their own role cohort (support vs damage) instead of one squad-wide average, so e.g. a healer is not flagged for low down-contribution.
+
+**Architecture:** A new pure `computeCohortStat` in `src/shared/squadStats.ts` partitions players by role, builds per-cohort and squad summaries via the existing `computeSquadStat`, and flags each player against the correct baseline (cohort if that cohort has ≥3 players, else squad), returning a signed σ-gap. `MetricDistributionCard` gains an opt-in `roleAware` mode that uses it: role-colored dots, per-cohort headline averages, and outlier rows showing `value · −Xσ`. The Squad Summary and Offense/Defense/Support No Ego card lists attach each player's `role` (from the aggregation's `roleClassifications`) and pass `roleAware={noEgoMode}`.
+
+**Tech Stack:** TypeScript, React 18, Vitest + jsdom, Tailwind CSS variables.
+
+## Global Constraints
+
+- Run vitest with limited parallelism: `npx vitest run <file> --maxWorkers=2`.
+- `npm run validate` (typecheck + ESLint, max-warnings 0) must pass before each commit that touches `.ts`/`.tsx`.
+- `src/shared/squadStats.ts` must stay dependency-free (no imports). Reuse the existing `computeSquadStat` already in that file.
+- Role values are the binary `'support' | 'damage'` from the existing classifier. A player with no/unknown role is always compared squad-wide.
+- Outlier σ threshold stays **1.5**; minimum cohort size for a valid cohort baseline is **3**.
+- Role-awareness is intrinsic to No Ego mode (gate on `noEgoMode`); there is no separate setting. When `roleAware` is false, `MetricDistributionCard` must behave byte-for-byte as it does today (default-off safety).
+- The cross-report rollup is NOT changed by this work.
+- The aggregation already emits `stats.roleClassifications`: an array of `{ account, profession, professionList, role, supportScore, confidenceScore, threshold, factors }` (see `incrementalAggregation.ts:1474-1483`). `role` is `'support' | 'damage'`.
+
+---
+
+### Task 1: `computeCohortStat` — role-aware squad stats
+
+**Files:**
+- Modify: `src/shared/squadStats.ts` (append new types + function; do not change `computeSquadStat`)
+- Test: `src/shared/__tests__/squadStats.cohort.test.ts` (new)
+
+**Interfaces:**
+- Consumes: existing `computeSquadStat`, `SquadStatPlayer`, `SquadStatSummary` from the same file.
+- Produces:
+  ```ts
+  export type PlayerRole = 'support' | 'damage';
+  export interface CohortStatPlayer extends SquadStatPlayer { role?: PlayerRole; }
+  export interface CohortOutlier extends SquadStatPlayer {
+    role?: PlayerRole;
+    baseline: 'support' | 'damage' | 'squad';
+    sigmaGap: number; // >= sigmaThreshold, distance past the mean on the needs-improvement side
+  }
+  export interface CohortStatSummary {
+    support?: SquadStatSummary;
+    damage?: SquadStatSummary;
+    squad: SquadStatSummary;
+    needsImprovementOutliers: CohortOutlier[];
+  }
+  export function computeCohortStat(
+    players: CohortStatPlayer[],
+    higherIsBetter: boolean,
+    sigmaThreshold?: number, // default 1.5
+    minCohortSize?: number,  // default 3
+  ): CohortStatSummary;
+  ```
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// src/shared/__tests__/squadStats.cohort.test.ts
+import { describe, it, expect } from 'vitest';
+import { computeCohortStat, type CohortStatPlayer } from '../squadStats';
+
+// 5 damage players with high down-contrib, 4 support players with low down-contrib.
+const downContribSquad: CohortStatPlayer[] = [
+  { account: 'D1', value: 40, role: 'damage' },
+  { account: 'D2', value: 42, role: 'damage' },
+  { account: 'D3', value: 44, role: 'damage' },
+  { account: 'D4', value: 46, role: 'damage' },
+  { account: 'D5', value: 48, role: 'damage' },
+  { account: 'Healer1', value: 3, role: 'support' },
+  { account: 'Healer2', value: 4, role: 'support' },
+  { account: 'Healer3', value: 5, role: 'support' },
+  { account: 'Healer4', value: 4, role: 'support' },
+];
+
+describe('computeCohortStat', () => {
+  it('does NOT flag a support player on a damage-metric just for being below the squad', () => {
+    const s = computeCohortStat(downContribSquad, true);
+    const flagged = s.needsImprovementOutliers.map((o) => o.account);
+    // None of the healers should be flagged: their low down-contrib is normal AMONG supports.
+    expect(flagged).not.toContain('Healer1');
+    expect(flagged).not.toContain('Healer2');
+    expect(flagged).not.toContain('Healer3');
+    expect(flagged).not.toContain('Healer4');
+  });
+
+  it('flags a support player who is genuinely low among supports', () => {
+    const squad: CohortStatPlayer[] = [
+      { account: 'S1', value: 100, role: 'support' },
+      { account: 'S2', value: 100, role: 'support' },
+      { account: 'S3', value: 100, role: 'support' },
+      { account: 'SLow', value: 0, role: 'support' },
+    ];
+    const s = computeCohortStat(squad, true);
+    const low = s.needsImprovementOutliers.find((o) => o.account === 'SLow');
+    expect(low).toBeTruthy();
+    expect(low!.baseline).toBe('support');
+    expect(low!.sigmaGap).toBeGreaterThanOrEqual(1.5);
+  });
+
+  it('falls back to squad baseline when a cohort has fewer than 3 players', () => {
+    const squad: CohortStatPlayer[] = [
+      { account: 'D1', value: 10, role: 'damage' },
+      { account: 'D2', value: 10, role: 'damage' },
+      { account: 'D3', value: 10, role: 'damage' },
+      { account: 'D4', value: 10, role: 'damage' },
+      { account: 'S1', value: 9, role: 'support' },   // support cohort size 2 -> fallback
+      { account: 'S2', value: 11, role: 'support' },
+    ];
+    const s = computeCohortStat(squad, true);
+    expect(s.support).toBeUndefined();          // too small to be its own baseline
+    expect(s.damage).toBeDefined();
+    // Every flagged player (if any) must be judged against 'squad' or 'damage', never 'support'.
+    for (const o of s.needsImprovementOutliers) expect(o.baseline).not.toBe('support');
+  });
+
+  it('uses squad baseline for players with no role', () => {
+    const squad: CohortStatPlayer[] = [
+      { account: 'A', value: 100 },
+      { account: 'B', value: 100 },
+      { account: 'C', value: 100 },
+      { account: 'NoRoleLow', value: 0 },
+    ];
+    const s = computeCohortStat(squad, true);
+    const low = s.needsImprovementOutliers.find((o) => o.account === 'NoRoleLow');
+    expect(low?.baseline).toBe('squad');
+  });
+
+  it('flags the HIGH end for lower-is-better metrics (deaths) within cohort', () => {
+    const squad: CohortStatPlayer[] = [
+      { account: 'D1', value: 1, role: 'damage' },
+      { account: 'D2', value: 1, role: 'damage' },
+      { account: 'D3', value: 1, role: 'damage' },
+      { account: 'DHigh', value: 9, role: 'damage' },
+    ];
+    const s = computeCohortStat(squad, false); // lower is better
+    const hi = s.needsImprovementOutliers.find((o) => o.account === 'DHigh');
+    expect(hi).toBeTruthy();
+    expect(hi!.baseline).toBe('damage');
+  });
+
+  it('populates squad always and both cohort summaries when both are large enough', () => {
+    const s = computeCohortStat(downContribSquad, true);
+    expect(s.squad.count).toBe(9);
+    expect(s.damage?.count).toBe(5);
+    expect(s.support?.count).toBe(4);
+  });
+
+  it('is safe on empty input', () => {
+    const s = computeCohortStat([], true);
+    expect(s.squad.count).toBe(0);
+    expect(s.needsImprovementOutliers).toEqual([]);
+    expect(s.support).toBeUndefined();
+    expect(s.damage).toBeUndefined();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/shared/__tests__/squadStats.cohort.test.ts --maxWorkers=2`
+Expected: FAIL — `computeCohortStat is not a function`.
+
+- [ ] **Step 3: Implement (append to `src/shared/squadStats.ts`)**
+
+```ts
+export type PlayerRole = 'support' | 'damage';
+
+export interface CohortStatPlayer extends SquadStatPlayer {
+  role?: PlayerRole;
+}
+
+export interface CohortOutlier extends SquadStatPlayer {
+  role?: PlayerRole;
+  baseline: 'support' | 'damage' | 'squad';
+  sigmaGap: number;
+}
+
+export interface CohortStatSummary {
+  support?: SquadStatSummary;
+  damage?: SquadStatSummary;
+  squad: SquadStatSummary;
+  needsImprovementOutliers: CohortOutlier[];
+}
+
+export function computeCohortStat(
+  players: CohortStatPlayer[],
+  higherIsBetter: boolean,
+  sigmaThreshold = 1.5,
+  minCohortSize = 3,
+): CohortStatSummary {
+  const valid = (Array.isArray(players) ? players : [])
+    .map((p) => ({ ...p, value: Number(p?.value) }))
+    .filter((p) => Number.isFinite(p.value));
+
+  const squad = computeSquadStat(valid, higherIsBetter, sigmaThreshold);
+  const supportPlayers = valid.filter((p) => p.role === 'support');
+  const damagePlayers = valid.filter((p) => p.role === 'damage');
+  const support = supportPlayers.length >= minCohortSize
+    ? computeSquadStat(supportPlayers, higherIsBetter, sigmaThreshold)
+    : undefined;
+  const damage = damagePlayers.length >= minCohortSize
+    ? computeSquadStat(damagePlayers, higherIsBetter, sigmaThreshold)
+    : undefined;
+
+  const baselineFor = (role?: PlayerRole): { summary: SquadStatSummary; label: 'support' | 'damage' | 'squad' } => {
+    if (role === 'support' && support) return { summary: support, label: 'support' };
+    if (role === 'damage' && damage) return { summary: damage, label: 'damage' };
+    return { summary: squad, label: 'squad' };
+  };
+
+  const needsImprovementOutliers: CohortOutlier[] = [];
+  for (const p of valid) {
+    const { summary, label } = baselineFor(p.role);
+    if (summary.stdDev <= 0) continue;
+    const diff = higherIsBetter ? summary.mean - p.value : p.value - summary.mean;
+    const sigmaGap = diff / summary.stdDev;
+    if (sigmaGap >= sigmaThreshold) {
+      needsImprovementOutliers.push({
+        account: p.account,
+        value: p.value,
+        profession: p.profession,
+        professionList: p.professionList,
+        role: p.role,
+        baseline: label,
+        sigmaGap,
+      });
+    }
+  }
+  needsImprovementOutliers.sort((a, b) => b.sigmaGap - a.sigmaGap);
+
+  return { support, damage, squad, needsImprovementOutliers };
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run src/shared/__tests__/squadStats.cohort.test.ts --maxWorkers=2`
+Expected: PASS (7 tests).
+
+- [ ] **Step 5: Run the existing squadStats test to confirm no regression**
+
+Run: `npx vitest run src/shared/__tests__/squadStats.test.ts --maxWorkers=2`
+Expected: PASS (existing 8 tests unchanged).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/shared/squadStats.ts src/shared/__tests__/squadStats.cohort.test.ts
+git commit -m "feat: add computeCohortStat for role-aware No Ego outliers"
+```
+
+---
+
+### Task 2: `MetricDistributionCard` role-aware mode
+
+**Files:**
+- Modify: `src/renderer/stats/components/MetricDistributionCard.tsx`
+- Test: `src/renderer/stats/components/__tests__/MetricDistributionCard.roleaware.test.tsx` (new)
+
+**Interfaces:**
+- Consumes: `computeCohortStat`, `CohortStatPlayer`, `PlayerRole` from `../../../shared/squadStats` (Task 1).
+- Produces: extended `MetricDistributionCardProps`:
+  ```ts
+  players: Array<SquadStatPlayer & { role?: 'support' | 'damage' }>;
+  roleAware?: boolean; // default false → existing behavior
+  ```
+
+- [ ] **Step 1: Write the failing test**
+
+```tsx
+// src/renderer/stats/components/__tests__/MetricDistributionCard.roleaware.test.tsx
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MetricDistributionCard } from '../MetricDistributionCard';
+
+const downContrib = [
+  { account: 'D1', value: 40, role: 'damage' as const },
+  { account: 'D2', value: 42, role: 'damage' as const },
+  { account: 'D3', value: 44, role: 'damage' as const },
+  { account: 'D4', value: 46, role: 'damage' as const },
+  { account: 'D5', value: 48, role: 'damage' as const },
+  { account: 'Healer1', value: 3, role: 'support' as const },
+  { account: 'Healer2', value: 4, role: 'support' as const },
+  { account: 'Healer3', value: 5, role: 'support' as const },
+  { account: 'Healer4', value: 4, role: 'support' as const },
+];
+
+describe('MetricDistributionCard — role-aware', () => {
+  it('does not flag a support player on a damage metric', () => {
+    render(
+      <MetricDistributionCard
+        title="Down Contribution"
+        accentColor="#f87171"
+        higherIsBetter
+        roleAware
+        players={downContrib}
+        formatValue={(n) => String(Math.round(n))}
+      />,
+    );
+    const outliers = screen.getByTestId('metric-card-outliers');
+    expect(outliers).not.toHaveTextContent('Healer1');
+    expect(outliers).not.toHaveTextContent('Healer2');
+  });
+
+  it('shows the σ gap on a flagged outlier row', () => {
+    const squad = [
+      { account: 'S1', value: 100, role: 'support' as const },
+      { account: 'S2', value: 100, role: 'support' as const },
+      { account: 'S3', value: 100, role: 'support' as const },
+      { account: 'SLow', value: 0, role: 'support' as const },
+    ];
+    render(
+      <MetricDistributionCard
+        title="Cleanses"
+        accentColor="#60a5fa"
+        higherIsBetter
+        roleAware
+        players={squad}
+        formatValue={(n) => String(Math.round(n))}
+      />,
+    );
+    const outliers = screen.getByTestId('metric-card-outliers');
+    expect(outliers).toHaveTextContent('SLow');
+    expect(outliers.textContent || '').toMatch(/σ/); // gap rendered with a sigma marker
+  });
+
+  it('falls back to current behavior when roleAware is false', () => {
+    // With a single squad-wide baseline, the lone low player IS flagged.
+    const squad = [
+      { account: 'A', value: 100 },
+      { account: 'B', value: 100 },
+      { account: 'C', value: 100 },
+      { account: 'Low', value: 0 },
+    ];
+    render(
+      <MetricDistributionCard
+        title="Cleanses"
+        accentColor="#60a5fa"
+        higherIsBetter
+        players={squad}
+        formatValue={(n) => String(Math.round(n))}
+      />,
+    );
+    expect(screen.getByTestId('metric-card-outliers')).toHaveTextContent('Low');
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/renderer/stats/components/__tests__/MetricDistributionCard.roleaware.test.tsx --maxWorkers=2`
+Expected: FAIL — `roleAware` not handled (Healer rows still present / no σ in outlier rows).
+
+- [ ] **Step 3: Implement the role-aware branch**
+
+In `MetricDistributionCard.tsx`:
+
+1. Update the import:
+
+```tsx
+import { computeSquadStat, computeCohortStat, type SquadStatPlayer, type PlayerRole } from '../../../shared/squadStats';
+```
+
+2. Update the props interface:
+
+```tsx
+export interface MetricDistributionCardProps {
+  title: string;
+  accentColor: string;
+  higherIsBetter: boolean;
+  players: Array<SquadStatPlayer & { role?: PlayerRole }>;
+  formatValue: (n: number) => string;
+  unit?: string;
+  roleAware?: boolean;
+  renderProfessionIcon?: (
+    profession: string,
+    professionList: string[] | undefined,
+    className: string,
+  ) => React.ReactNode;
+}
+```
+
+3. Add `roleAware = false` to the destructured props.
+
+4. Replace the single `const s = computeSquadStat(players, higherIsBetter);` with a branch that
+   keeps the squad summary for the dot-plot/headline extent and derives the outliers + role colors:
+
+```tsx
+  const cohort = roleAware ? computeCohortStat(players, higherIsBetter) : null;
+  const s = cohort ? cohort.squad : computeSquadStat(players, higherIsBetter);
+  const outliers = cohort ? cohort.needsImprovementOutliers : s.needsImprovementOutliers;
+  const outlierKeys = new Set(outliers.map((p) => p.account));
+  const roleOf = new Map(players.map((p) => [p.account, (p as { role?: PlayerRole }).role]));
+```
+
+5. Dot color: in the dot `.map`, color by role when `roleAware` (damage warm, support cool,
+   unknown neutral); keep the outlier outline. Replace the existing dot background expression:
+
+```tsx
+            style={{
+              left: `${pos(p.value)}%`,
+              background: outlierKeys.has(p.account)
+                ? accentColor
+                : roleAware
+                  ? (roleOf.get(p.account) === 'support' ? '#22d3ee'
+                     : roleOf.get(p.account) === 'damage' ? '#fb923c'
+                     : 'var(--text-muted)')
+                  : 'var(--text-muted)',
+              outline: outlierKeys.has(p.account) ? `1px solid ${accentColor}` : 'none',
+            }}
+```
+
+6. Headline averages: when `roleAware` and both cohorts exist, render two compact averages
+   instead of the single Avg block. Keep the single-Avg block for the non-role-aware path and
+   for the case where only one cohort exists. Concretely, replace the existing Avg `<div>` with:
+
+```tsx
+        {cohort && cohort.support && cohort.damage ? (
+          <div>
+            <div className="text-[10px] uppercase tracking-wide text-[color:var(--text-muted)]">Avg by role</div>
+            <div data-testid="metric-card-mean" className="text-lg font-bold text-white">
+              <span style={{ color: '#fb923c' }}>DPS {formatValue(cohort.damage.mean)}</span>
+              {' · '}
+              <span style={{ color: '#22d3ee' }}>Sup {formatValue(cohort.support.mean)}</span>
+            </div>
+          </div>
+        ) : (
+          <div>
+            <div className="text-[10px] uppercase tracking-wide text-[color:var(--text-muted)]">Avg</div>
+            <div data-testid="metric-card-mean" className="text-2xl font-bold text-white">
+              {formatValue(s.mean)} <span className="text-sm font-normal text-[color:var(--text-secondary)]">{unit}</span>
+            </div>
+          </div>
+        )}
+```
+
+   (Leave the σ Deviation and Range blocks as they are — they describe the squad summary `s`.)
+
+7. Outlier rows: render the σ gap next to the value. Replace the value `<span>` in each
+   outlier row so it shows `value · −Xσ` when a `sigmaGap` is present:
+
+```tsx
+              <span className="font-mono text-[color:var(--text-secondary)]">
+                {formatValue(p.value)}
+                {'sigmaGap' in p && typeof (p as { sigmaGap?: number }).sigmaGap === 'number'
+                  ? ` · −${(p as { sigmaGap: number }).sigmaGap.toFixed(1)}σ`
+                  : ''}
+              </span>
+```
+
+   (In the non-role-aware path the outliers come from `s.needsImprovementOutliers` which have no
+   `sigmaGap`, so the suffix is omitted and behavior is unchanged.)
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run src/renderer/stats/components/__tests__/MetricDistributionCard.roleaware.test.tsx --maxWorkers=2`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Confirm the original card test still passes (default-off safety)**
+
+Run: `npx vitest run src/renderer/stats/components/__tests__/MetricDistributionCard.test.tsx --maxWorkers=2`
+Expected: PASS (existing 3 tests unchanged).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/renderer/stats/components/MetricDistributionCard.tsx src/renderer/stats/components/__tests__/MetricDistributionCard.roleaware.test.tsx
+git commit -m "feat: role-aware mode for MetricDistributionCard"
+```
+
+---
+
+### Task 3: Attach role + enable roleAware in the Squad Summary
+
+**Files:**
+- Modify: `src/renderer/stats/sections/TopPlayersSection.tsx` (the `if (noEgoMode)` Squad Summary branch)
+- Test: `src/renderer/stats/sections/__tests__/TopPlayersSection.noego.test.tsx` (extend)
+
+**Interfaces:**
+- Consumes: `stats.roleClassifications` (array of `{ account, role, ... }`), `MetricDistributionCard` `roleAware` + per-player `role` (Task 2).
+
+- [ ] **Step 1: Add a failing assertion to the existing No Ego test**
+
+Open `src/renderer/stats/sections/__tests__/TopPlayersSection.noego.test.tsx`. Extend the
+context fixture `ctx.stats` to include a `roleClassifications` array and a leaderboard where a
+support player has a low value, then assert the support player is NOT flagged. Add this test
+inside the existing `describe`:
+
+```tsx
+  it('does not flag a support player on a damage-style leaderboard (role-aware)', () => {
+    const ctxRole: any = {
+      stats: {
+        leaderboards: {
+          downContrib: [
+            { account: 'D1', value: 40, profession: 'Guardian' },
+            { account: 'D2', value: 42, profession: 'Guardian' },
+            { account: 'D3', value: 44, profession: 'Guardian' },
+            { account: 'D4', value: 46, profession: 'Guardian' },
+            { account: 'D5', value: 48, profession: 'Guardian' },
+            { account: 'Healer1', value: 3, profession: 'Druid' },
+            { account: 'Healer2', value: 4, profession: 'Druid' },
+            { account: 'Healer3', value: 5, profession: 'Druid' },
+            { account: 'Healer4', value: 4, profession: 'Druid' },
+          ],
+        },
+        roleClassifications: [
+          { account: 'D1', role: 'damage' }, { account: 'D2', role: 'damage' },
+          { account: 'D3', role: 'damage' }, { account: 'D4', role: 'damage' },
+          { account: 'D5', role: 'damage' },
+          { account: 'Healer1', role: 'support' }, { account: 'Healer2', role: 'support' },
+          { account: 'Healer3', role: 'support' }, { account: 'Healer4', role: 'support' },
+        ],
+      },
+      formatWithCommas: (n: number) => String(n),
+      renderProfessionIcon: () => null,
+    };
+    render(
+      <StatsSharedContext.Provider value={ctxRole}>
+        <TopPlayersSection {...base} noEgoMode enabledTopStats={['downContrib']} />
+      </StatsSharedContext.Provider>,
+    );
+    const outliers = screen.getByTestId('metric-card-outliers');
+    expect(outliers).not.toHaveTextContent('Healer1');
+  });
+```
+
+- [ ] **Step 2: Run it to confirm it fails**
+
+Run: `npx vitest run src/renderer/stats/sections/__tests__/TopPlayersSection.noego.test.tsx --maxWorkers=2`
+Expected: FAIL — a Healer is currently flagged because the card is squad-wide.
+
+- [ ] **Step 3: Implement role attachment in the Squad Summary branch**
+
+In the `if (noEgoMode)` branch of `TopPlayersSection.tsx`, before the `enabledDefs.map(...)`,
+build a role lookup from `stats.roleClassifications`:
+
+```tsx
+    const roleByAccount = new Map<string, 'support' | 'damage'>(
+      (Array.isArray((stats as any).roleClassifications) ? (stats as any).roleClassifications : [])
+        .filter((r: any) => r && (r.role === 'support' || r.role === 'damage'))
+        .map((r: any) => [String(r.account), r.role as 'support' | 'damage']),
+    );
+    const roleOf = (account: string): 'support' | 'damage' | undefined =>
+      roleByAccount.get(account) ?? roleByAccount.get(String(account).split('::')[0]);
+```
+
+(The `split('::')[0]` fallback handles `splitPlayersByClass` composite keys; harmless otherwise.)
+
+Then where each card's `players` array is built (the `rows.map((r: any) => ({ account: r.account, value: ..., profession: r.profession, professionList: r.professionList }))`), add `role: roleOf(r.account)`, and pass `roleAware` to the card:
+
+```tsx
+            const players = (Array.isArray(rows) ? rows : []).map((r: any) => ({
+              account: r.account,
+              value: Number(r.value ?? 0),
+              profession: r.profession,
+              professionList: r.professionList,
+              role: roleOf(r.account),
+            }));
+            return (
+              <MetricDistributionCard
+                key={def.id}
+                title={getCardTitle(def, isPerSecond, isPerMinute)}
+                accentColor={def.color}
+                higherIsBetter={def.higherIsBetter}
+                players={players}
+                unit={def.unit ?? ''}
+                roleAware
+                formatValue={(n) => formatValue(def, n)}
+                renderProfessionIcon={renderProfessionIcon}
+              />
+            );
+```
+
+- [ ] **Step 4: Run the test to confirm it passes**
+
+Run: `npx vitest run src/renderer/stats/sections/__tests__/TopPlayersSection.noego.test.tsx --maxWorkers=2`
+Expected: PASS (existing tests + the new role-aware test).
+
+- [ ] **Step 5: Validate + commit**
+
+Run: `npm run validate`
+Expected: pass.
+
+```bash
+git add src/renderer/stats/sections/TopPlayersSection.tsx src/renderer/stats/sections/__tests__/TopPlayersSection.noego.test.tsx
+git commit -m "feat: role-aware Squad Summary outliers in No Ego mode"
+```
+
+---
+
+### Task 4: Attach role + enable roleAware in Offense/Defense/Support cards
+
+**Files:**
+- Modify: `src/renderer/stats/sections/OffenseSection.tsx`
+- Modify: `src/renderer/stats/sections/DefenseSection.tsx`
+- Modify: `src/renderer/stats/sections/SupportSection.tsx`
+- Test: `src/renderer/stats/sections/__tests__/OffenseSection.noego.test.tsx` (extend)
+
+**Interfaces:**
+- Consumes: `stats.roleClassifications`, `MetricDistributionCard` `roleAware` + per-player `role`.
+
+- [ ] **Step 1: Add a failing assertion to the Offense No Ego test**
+
+Extend `OffenseSection.noego.test.tsx`'s context fixture to add `roleClassifications` marking
+the low-value players as `support`, and assert that on a damage metric a support player is not
+in `metric-card-outliers`. (Mirror the role data shape used in Task 3 Step 1; use the section's
+existing fixture player accounts, tagging the intended healers as `support` and the rest as
+`damage`, with at least 3 players per role so cohorts are valid.)
+
+- [ ] **Step 2: Run it to confirm it fails**
+
+Run: `npx vitest run src/renderer/stats/sections/__tests__/OffenseSection.noego.test.tsx --maxWorkers=2`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement role attachment in all three sections**
+
+For EACH of `OffenseSection.tsx`, `DefenseSection.tsx`, `SupportSection.tsx`, inside the
+`if (noEgoMode && ...)` branch, add the same role lookup helper before the metric-card map:
+
+```tsx
+        const roleByAccount = new Map<string, 'support' | 'damage'>(
+          (Array.isArray((stats as any).roleClassifications) ? (stats as any).roleClassifications : [])
+            .filter((r: any) => r && (r.role === 'support' || r.role === 'damage'))
+            .map((r: any) => [String(r.account), r.role as 'support' | 'damage']),
+        );
+        const roleOf = (account: string): 'support' | 'damage' | undefined =>
+          roleByAccount.get(account) ?? roleByAccount.get(String(account).split('::')[0]);
+```
+
+Then, where each section builds the per-metric `players` array for its `MetricDistributionCard`,
+add `role: roleOf(row.account)` to each player object and add the `roleAware` prop to the card.
+(The exact variable name for the row is whatever that section already uses — e.g. `row.account`.
+Read the section's existing No Ego branch and add the field there.)
+
+- [ ] **Step 4: Run the Offense test to confirm it passes**
+
+Run: `npx vitest run src/renderer/stats/sections/__tests__/OffenseSection.noego.test.tsx --maxWorkers=2`
+Expected: PASS.
+
+- [ ] **Step 5: Validate + commit**
+
+Run: `npm run validate`
+Expected: pass.
+
+```bash
+git add src/renderer/stats/sections/OffenseSection.tsx src/renderer/stats/sections/DefenseSection.tsx src/renderer/stats/sections/SupportSection.tsx src/renderer/stats/sections/__tests__/OffenseSection.noego.test.tsx
+git commit -m "feat: role-aware Offense/Defense/Support cards in No Ego mode"
+```
+
+---
+
+### Task 5: Full validation sweep
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Run the whole unit suite**
+
+Run: `npx vitest run --maxWorkers=2`
+Expected: all pass, including the new cohort/role-aware tests and the full pre-existing suite (regression guard for the default-off path).
+
+- [ ] **Step 2: Validate**
+
+Run: `npm run validate`
+Expected: typecheck + lint clean (0 warnings).
+
+- [ ] **Step 3: Build the web report (web report reuses these components)**
+
+Run: `npm run build:web`
+Expected: build succeeds.
+
+- [ ] **Step 4: Commit (only if a fix was needed)**
+
+```bash
+git add -A
+git commit -m "chore: role-aware No Ego validation fixes"
+```
+
+---
+
+## Notes for the implementer
+
+- `roleClassifications` is keyed by account; when `splitPlayersByClass` is on, leaderboard
+  row accounts may be `account::profession` composites — the `roleOf` helper's `split('::')[0]`
+  fallback covers that.
+- Players missing from `roleClassifications` (or with an unexpected role) get `undefined` role
+  and are compared squad-wide — that's the intended fallback, never an error.
+- Keep `computeSquadStat` untouched; all role logic lives in `computeCohortStat`.
+- Do not touch the rollup (`reportApp.tsx` / `rollup.ts`) — role-awareness is out of scope there.
+- The web report needs no separate wiring: it renders the same sections with the same
+  `noEgoMode`, so `roleAware` flows through automatically.

--- a/docs/superpowers/plans/2026-06-23-no-ego-followups.md
+++ b/docs/superpowers/plans/2026-06-23-no-ego-followups.md
@@ -1,0 +1,491 @@
+# No Ego Follow-ups Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** Clear the non-blocking follow-ups accumulated across the No Ego reviews: stronger tests, role color on outlier dots, a typed role-classification accessor, a Total/Stat-1s/Stat-60s view-mode toggle in No Ego sections, Defense/Support role-aware tests, an exact rollup card-count assertion, and a shared `NoEgoMetricSection` to de-duplicate the three section branches.
+
+**Architecture:** Mostly small, isolated changes. The one structural change (Task 7) extracts the identical No Ego section shell (header + view-mode toggle + `StatsTableLayout` sidebar + large card + per-player detail expander) into a single reusable `NoEgoMetricSection` component; each section passes its data/behavior (metrics, active-stat state, value resolver, formatter, direction, fight-time accessor, accent, icon) as props.
+
+**Tech Stack:** TypeScript, React 18, Vitest + jsdom, Tailwind CSS variables.
+
+## Global Constraints
+
+- Run vitest with `--maxWorkers=2`. `npm run validate` (typecheck + ESLint, max-warnings 0) must pass before each commit.
+- Work in the main checkout `/var/home/mstephens/Documents/GitHub/axibridge` on branch `feat/no-ego-mode`. Do NOT use git worktrees. After each commit, confirm it is the tip of `feat/no-ego-mode`.
+- Behavior-preserving except where a task explicitly adds UI (Task 4 toggle) or fixes a display nuance (Task 2 dot color). Role/σ/outlier math is unchanged throughout.
+- Default-off safety: when `noEgoMode`/`roleAware`/`large` are off, all components render exactly as before.
+- Scope: Offense/Defense/Support detailed sections + `MetricDistributionCard` + web rollup test. The Squad Summary (TopPlayersSection) view stays a grid (but Task 3's typed accessor and Task 7's role map may touch its role-lookup code — keep its behavior identical).
+- Reuse `PillToggleGroup` (already used in normal mode: `value`/`onChange`/`options=[{value:'total',label:'Total'},{value:'per1s',label:'Stat/1s'},{value:'per60s',label:'Stat/60s'}]`, `activeClassName="bg-[var(--accent-bg-strong)] text-[color:var(--brand-primary)] border border-[color:var(--accent-border)]"`, `inactiveClassName="text-[color:var(--text-secondary)]"`).
+- The role-classification runtime shape (emitted in `incrementalAggregation.ts:1474`) is `{ account: string; profession: string; professionList: string[]; role: 'support' | 'damage'; supportScore: number; confidenceScore: number; threshold: number; factors: unknown[] }`.
+
+---
+
+### Task 1: Widen the no-celebration regex
+
+**Files:**
+- Modify: `src/renderer/stats/components/__tests__/MetricDistributionCard.test.tsx:38`
+
+- [ ] **Step 1: Strengthen the assertion**
+
+Replace the existing line:
+
+```tsx
+    expect(screen.queryByText(/MVP|top performer|#1/i)).toBeNull();
+```
+
+with a wider guard that also catches crown/best/elite/winner/podium language:
+
+```tsx
+    expect(screen.queryByText(/\bMVP\b|top performer|#1|crown|\bbest\b|elite|winner|podium|champion/i)).toBeNull();
+```
+
+- [ ] **Step 2: Run the test**
+
+Run: `npx vitest run src/renderer/stats/components/__tests__/MetricDistributionCard.test.tsx --maxWorkers=2`
+Expected: PASS (the card has no such language, so the wider regex still finds nothing).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/renderer/stats/components/__tests__/MetricDistributionCard.test.tsx
+git commit -m "test: widen No Ego no-celebration guard (crown/best/elite/winner/podium)"
+```
+
+---
+
+### Task 2: Role color on outlier dots
+
+**Files:**
+- Modify: `src/renderer/stats/components/MetricDistributionCard.tsx:102-119`
+- Test: `src/renderer/stats/components/__tests__/MetricDistributionCard.roleaware.test.tsx` (add a case)
+
+**Interfaces:**
+- Consumes: existing `roleAware`, `roleOf` map, `outlierKeys`.
+
+Problem: today an outlier dot is filled with `accentColor`, so in role-aware mode you can't tell if the flagged player was support or damage. Fix: in role-aware mode, fill every dot (outlier or not) by its role color; mark outliers with a thicker accent ring (and slightly larger size) instead of overriding the fill. Non-role-aware behavior is unchanged (outliers keep `accentColor` fill).
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `MetricDistributionCard.roleaware.test.tsx`:
+
+```tsx
+  it('keeps role color on a flagged outlier dot (role-aware)', () => {
+    const squad = [
+      { account: 'S1', value: 100, role: 'support' as const },
+      { account: 'S2', value: 100, role: 'support' as const },
+      { account: 'S3', value: 100, role: 'support' as const },
+      { account: 'SLow', value: 0, role: 'support' as const },
+    ];
+    const { container } = render(
+      <MetricDistributionCard
+        title="Cleanses" accentColor="#60a5fa" higherIsBetter roleAware
+        players={squad} formatValue={(n) => String(Math.round(n))} />,
+    );
+    // The outlier dot for SLow is identified by its title attribute.
+    const dot = container.querySelector('[title^="SLow:"]') as HTMLElement;
+    expect(dot).toBeTruthy();
+    // Support role color is cyan (#22d3ee); it must remain the fill even though SLow is an outlier.
+    expect(dot.style.background).toMatch(/34,\s*211,\s*238|#22d3ee/i);
+    // And it is marked as an outlier via an outline.
+    expect(dot.style.outline).toContain('solid');
+  });
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/renderer/stats/components/__tests__/MetricDistributionCard.roleaware.test.tsx --maxWorkers=2`
+Expected: FAIL — outlier dot background is currently `accentColor` (#60a5fa), not the support color.
+
+- [ ] **Step 3: Implement**
+
+Replace the dot `.map` body (lines 102-119) so role color is the fill in role-aware mode regardless of outlier status, and outliers are marked by ring + size:
+
+```tsx
+        {s.players.map((p) => {
+          const isOutlier = outlierKeys.has(p.account);
+          const roleColor = roleOf.get(p.account) === 'support' ? '#22d3ee'
+            : roleOf.get(p.account) === 'damage' ? '#fb923c'
+            : 'var(--text-muted)';
+          const fill = roleAware ? roleColor : (isOutlier ? accentColor : 'var(--text-muted)');
+          return (
+            <div
+              key={p.account}
+              title={`${p.account}: ${formatValue(p.value)}`}
+              className={`absolute top-1/2 -translate-y-1/2 -translate-x-1/2 rounded-full ${isOutlier ? 'w-3 h-3' : 'w-2 h-2'}`}
+              style={{
+                left: `${pos(p.value)}%`,
+                background: fill,
+                outline: isOutlier ? `2px solid ${accentColor}` : 'none',
+              }}
+            />
+          );
+        })}
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `npx vitest run src/renderer/stats/components/__tests__/ --maxWorkers=2`
+Expected: PASS (new case + existing card/role-aware/large tests). Note the `large.test.tsx` asserts the plot wrapper height (`h-14`/`h-8`), not dot classes, so it is unaffected.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/renderer/stats/components/MetricDistributionCard.tsx src/renderer/stats/components/__tests__/MetricDistributionCard.roleaware.test.tsx
+git commit -m "feat: keep role color on outlier dots; mark outliers with ring"
+```
+
+---
+
+### Task 3: Typed role-classification accessor
+
+**Files:**
+- Modify: `src/renderer/stats/statsTypes.ts` (add an exported type)
+- Modify: `src/renderer/stats/sections/OffenseSection.tsx`, `DefenseSection.tsx`, `SupportSection.tsx`, `TopPlayersSection.tsx` (replace `(stats as any).roleClassifications` reads)
+
+**Interfaces:**
+- Produces:
+  ```ts
+  export interface RoleClassificationEntry {
+    account: string;
+    profession?: string;
+    professionList?: string[];
+    role: 'support' | 'damage';
+    supportScore?: number;
+    confidenceScore?: number;
+    threshold?: number;
+    factors?: unknown[];
+  }
+  ```
+
+Context: `StatsSharedContextValue.stats` is typed `any`, so the `as any` cast is redundant rather than wrong; this task removes the cast noise and gives the role map a real element type. It does NOT attempt to type the whole `stats` object.
+
+- [ ] **Step 1: Add the type**
+
+Append `RoleClassificationEntry` (above interface) to `src/renderer/stats/statsTypes.ts`.
+
+- [ ] **Step 2: Replace the four read sites**
+
+In each of the four files, the current pattern is:
+
+```tsx
+      (Array.isArray((stats as any).roleClassifications) ? (stats as any).roleClassifications : [])
+        .filter((r: any) => r && (r.role === 'support' || r.role === 'damage'))
+        .map((r: any) => [String(r.account), r.role as 'support' | 'damage']),
+```
+
+Replace with a typed read (import `RoleClassificationEntry` from `../statsTypes` in the sections, `../statsTypes` path adjusted as needed; `TopPlayersSection` is in the same `sections/` dir):
+
+```tsx
+      ((stats.roleClassifications as RoleClassificationEntry[] | undefined) ?? [])
+        .filter((r): r is RoleClassificationEntry => !!r && (r.role === 'support' || r.role === 'damage'))
+        .map((r) => [String(r.account), r.role] as [string, 'support' | 'damage']),
+```
+
+Keep the surrounding `new Map<string, 'support' | 'damage'>(...)` and the `roleOf` helper unchanged.
+
+- [ ] **Step 3: Validate**
+
+Run: `npm run validate`
+Expected: typecheck + lint clean.
+
+- [ ] **Step 4: Run section + card tests (no behavior change expected)**
+
+Run: `npx vitest run src/renderer/stats/sections/__tests__/ --maxWorkers=2`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/renderer/stats/statsTypes.ts src/renderer/stats/sections/OffenseSection.tsx src/renderer/stats/sections/DefenseSection.tsx src/renderer/stats/sections/SupportSection.tsx src/renderer/stats/sections/TopPlayersSection.tsx
+git commit -m "refactor: typed RoleClassificationEntry accessor, drop as-any casts"
+```
+
+---
+
+### Task 4: View-mode toggle in No Ego section branches
+
+**Files:**
+- Modify: `src/renderer/stats/sections/OffenseSection.tsx`, `DefenseSection.tsx`, `SupportSection.tsx` (the `if (noEgoMode && ...)` branch header)
+- Test: `src/renderer/stats/sections/__tests__/OffenseSection.noego.test.tsx` (add an assertion)
+
+**Interfaces:**
+- Consumes: `PillToggleGroup`, the section's `{x}ViewMode`/`set{X}ViewMode`.
+
+Add the Total/Stat-1s/Stat-60s toggle (same as normal mode) into each No Ego branch header, so users can switch the rate mode that the card + detail table already honor.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `OffenseSection.noego.test.tsx` (inside the existing No Ego render test, or a new one rendering the section with `noEgoMode`):
+
+```tsx
+    // view-mode toggle present in No Ego mode
+    expect(screen.getByText('Stat/1s')).toBeInTheDocument();
+    expect(screen.getByText('Stat/60s')).toBeInTheDocument();
+```
+
+- [ ] **Step 2: Run to confirm it fails**
+
+Run: `npx vitest run src/renderer/stats/sections/__tests__/OffenseSection.noego.test.tsx --maxWorkers=2`
+Expected: FAIL — the toggle is not rendered in the No Ego branch yet.
+
+- [ ] **Step 3: Add the toggle to each section's No Ego header**
+
+In each section's No Ego branch, change the header row to include the `PillToggleGroup` on the right. For OffenseSection replace the header `<div className="flex flex-wrap items-center gap-2 mb-3.5">…</div>` with one that keeps the icon + title and appends the toggle:
+
+```tsx
+            <div className="flex flex-wrap items-center justify-between gap-2 mb-3.5">
+                <div className="flex items-center gap-2">
+                    <Swords className="w-4 h-4 shrink-0" style={{ color: 'var(--section-offense)' }} />
+                    <h3 className="text-[11px] font-semibold uppercase tracking-[0.05em]" style={{ color: 'var(--text-primary)' }}>
+                        Offense Detailed
+                    </h3>
+                </div>
+                <PillToggleGroup
+                    value={offenseViewMode}
+                    onChange={setOffenseViewMode}
+                    options={[
+                        { value: 'total', label: 'Total' },
+                        { value: 'per1s', label: 'Stat/1s' },
+                        { value: 'per60s', label: 'Stat/60s' }
+                    ]}
+                    activeClassName="bg-[var(--accent-bg-strong)] text-[color:var(--brand-primary)] border border-[color:var(--accent-border)]"
+                    inactiveClassName="text-[color:var(--text-secondary)]"
+                />
+            </div>
+```
+
+Do the analogous edit in DefenseSection (icon `Shield`/its existing icon, title "Defense Detailed", `defenseViewMode`/`setDefenseViewMode`, accent `var(--section-defense)`) and SupportSection (its existing icon, title "Support Detailed", `supportViewMode`/`setSupportViewMode`, accent `var(--section-support)`). Use each section's existing header icon component — read the current No Ego header to copy it.
+
+Ensure `PillToggleGroup` is imported in each section (it already is for normal mode — verify).
+
+- [ ] **Step 4: Run the test**
+
+Run: `npx vitest run src/renderer/stats/sections/__tests__/OffenseSection.noego.test.tsx --maxWorkers=2`
+Expected: PASS.
+
+- [ ] **Step 5: Validate + commit**
+
+Run: `npm run validate`
+
+```bash
+git add src/renderer/stats/sections/OffenseSection.tsx src/renderer/stats/sections/DefenseSection.tsx src/renderer/stats/sections/SupportSection.tsx src/renderer/stats/sections/__tests__/OffenseSection.noego.test.tsx
+git commit -m "feat: view-mode toggle in No Ego Offense/Defense/Support sections"
+```
+
+---
+
+### Task 5: Defense + Support role-aware section tests
+
+**Files:**
+- Create: `src/renderer/stats/sections/__tests__/DefenseSection.noego.test.tsx`
+- Create: `src/renderer/stats/sections/__tests__/SupportSection.noego.test.tsx`
+
+**Interfaces:**
+- Consumes: the same rendering harness as `OffenseSection.noego.test.tsx`.
+
+Mirror the Offense No Ego role-aware test for Defense and Support so their (currently untested) role-aware path is guarded before Task 7's refactor.
+
+- [ ] **Step 1: Read the Offense test as the template**
+
+Run: `cat src/renderer/stats/sections/__tests__/OffenseSection.noego.test.tsx`
+Note the context fixture shape, how props are passed, and the discriminating-fixture pattern (many damage tightly high, ≥3 support tightly low; active stat set to the damage-style metric; assert support accounts absent from `metric-card-outliers`).
+
+- [ ] **Step 2: Write DefenseSection.noego.test.tsx**
+
+Create a test that renders `DefenseSection` with `noEgoMode`, a `stats.defensePlayers` fixture (≥10 damage-role players tightly high on a higher-is-better defense metric like `damageBarrier`, and ≥3 support-role players tightly low), `stats.roleClassifications` tagging them, and `activeDefenseStat` set to that metric. Assert: a `metric-card-mean` renders, the per-player detail expander button exists, and the low support accounts are NOT in `metric-card-outliers`. Use the section's real required props (read `DefenseSection`'s prop type and provide them, `as any` casts acceptable in the fixture as the Offense test does).
+
+Use a metric where `higherIsBetter` is true for defense (e.g. `damageBarrier`, which is in `DEFENSE_HIGHER_IS_BETTER`) so "low = needs improvement" and the support cohort discriminates.
+
+- [ ] **Step 3: Write SupportSection.noego.test.tsx**
+
+Same shape for `SupportSection` with `stats.supportPlayers`, `activeSupportStat` set to a higher-is-better support metric (e.g. `condiCleanse`), supports vs damage role tags, assert low-role players absent from outliers.
+
+- [ ] **Step 4: Run both**
+
+Run: `npx vitest run src/renderer/stats/sections/__tests__/DefenseSection.noego.test.tsx src/renderer/stats/sections/__tests__/SupportSection.noego.test.tsx --maxWorkers=2`
+Expected: PASS. (If a test passes vacuously — i.e. would pass even without role-awareness — adjust the fixture so the low players are >1.5σ below the SQUAD mean but within their cohort, matching the Offense test's discriminating design; verify by temporarily rendering with role-awareness conceptually disabled is not required, but ensure the squad-wide σ math flags them.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/renderer/stats/sections/__tests__/DefenseSection.noego.test.tsx src/renderer/stats/sections/__tests__/SupportSection.noego.test.tsx
+git commit -m "test: role-aware No Ego coverage for Defense and Support sections"
+```
+
+---
+
+### Task 6: Exact rollup card-count assertion
+
+**Files:**
+- Modify: `src/web/__tests__/rollup.noego.test.tsx:73-74,83-84`
+
+The rollup No Ego view renders a fixed set of cards (5 commander metrics: Raids Led, Fights Led, Kills, Commander Deaths, KDR; 2 player metrics: Raids Attended, Combat Time). Tighten the loose `>= 1` assertions to the exact counts so a dropped card is caught.
+
+- [ ] **Step 1: Update assertions**
+
+Replace the commander assertion:
+
+```tsx
+    const meanEls = commanderSection.querySelectorAll('[data-testid="metric-card-mean"]');
+    expect(meanEls.length).toBeGreaterThanOrEqual(1);
+```
+
+with:
+
+```tsx
+    const meanEls = commanderSection.querySelectorAll('[data-testid="metric-card-mean"]');
+    expect(meanEls.length).toBe(5);
+```
+
+and the player assertion's `toBeGreaterThanOrEqual(1)` with `toBe(2)`.
+
+- [ ] **Step 2: Run the test**
+
+Run: `npx vitest run src/web/__tests__/rollup.noego.test.tsx --maxWorkers=2`
+Expected: PASS. If the actual rendered counts differ from 5/2 (e.g. a metric card is skipped because its fixture rows are empty), make the fixture populate all metrics (non-zero values for each commander/player field the cards read) so all 5/2 cards render; do NOT change the assertion to match a partial render.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/web/__tests__/rollup.noego.test.tsx
+git commit -m "test: assert exact No Ego rollup card counts (5 commander, 2 player)"
+```
+
+---
+
+### Task 7: Extract shared `NoEgoMetricSection` component
+
+**Files:**
+- Create: `src/renderer/stats/sections/NoEgoMetricSection.tsx`
+- Modify: `src/renderer/stats/sections/OffenseSection.tsx`, `DefenseSection.tsx`, `SupportSection.tsx` (replace each `if (noEgoMode && ...)` branch body with a single `<NoEgoMetricSection .../>`)
+
+**Interfaces:**
+- Consumes: `StatsTableLayout`, `StatsTableShell`, `MetricDistributionCard`, `PillToggleGroup`, `RoleClassificationEntry` (Task 3), the shared context (`renderProfessionIcon`, `formatWithCommas`, `sidebarListClass`).
+- Produces:
+  ```ts
+  export interface NoEgoMetricDef { id: string; label: string; }
+  export interface NoEgoMetricSectionProps {
+    title: string;
+    icon: React.ReactNode;          // section header icon element
+    accentColor: string;            // e.g. 'var(--section-offense)'
+    sidebarLabel: string;           // e.g. 'Offensive Tabs'
+    metrics: NoEgoMetricDef[];      // full metric list for the sidebar
+    filteredMetrics: NoEgoMetricDef[];
+    players: any[];                 // section player rows (stats.{x}Players)
+    roleClassifications?: RoleClassificationEntry[];
+    activeStatId: string;
+    setActiveStatId: (id: string) => void;
+    search: string;
+    setSearch: (v: string) => void;
+    viewMode: 'total' | 'per1s' | 'per60s';
+    setViewMode: (v: 'total' | 'per1s' | 'per60s') => void;
+    detailOpen: boolean;
+    setDetailOpen: (v: boolean | ((p: boolean) => boolean)) => void;
+    higherIsBetter: (metric: NoEgoMetricDef) => boolean;
+    // pre-view-mode total for a row+metric (the section's totalValue):
+    resolveTotal: (row: any, metric: NoEgoMetricDef) => number;
+    // true when the metric is a percent/rate (skip per-1s/per-60s division):
+    isRateOrPercent: (metric: NoEgoMetricDef) => boolean;
+    // fight time in ms for a row (offense: totalFightMs; defense/support: activeMs/totalFightMs):
+    fightTimeMs: (row: any) => number;
+    formatValue: (metric: NoEgoMetricDef, val: number) => string;
+  }
+  export const NoEgoMetricSection: React.FC<NoEgoMetricSectionProps>;
+  ```
+
+The component owns: the header (icon + title + view-mode `PillToggleGroup`), the `StatsTableLayout` (sidebar metric selector built from `filteredMetrics`/`activeStatId`/`setActiveStatId`/`search`, content = large `roleAware` `MetricDistributionCard` for the active metric + the per-player detail expander). It computes the role map from `roleClassifications`, resolves the active metric, derives per-view-mode values via `resolveTotal`+`isRateOrPercent`+`fightTimeMs`, and renders the detail table (same columns/sort as today).
+
+This is a refactor: the rendered output must match the current per-section output. Tasks 1–6 (esp. the Offense/Defense/Support No Ego tests) are the regression guard.
+
+- [ ] **Step 1: Read the three current branches**
+
+Run: `sed -n '/if (noEgoMode/,/^    }/p' src/renderer/stats/sections/OffenseSection.tsx` (and the Defense/Support equivalents) to capture the exact shell, detail-table columns, sort, and per-section differences (offenseTotals vs defenseTotals vs supportTotals — these live inside each section's `resolveTotal`; the `condiCleanse`/`cleanseScope` handling stays inside Support's `resolveTotal`; the fight-time field differs).
+
+- [ ] **Step 2: Create `NoEgoMetricSection.tsx`**
+
+Implement the component per the interface above, lifting the shell verbatim from the current Offense branch (header now includes the Task 4 toggle; card has `large roleAware`; detail expander + `StatsTableShell` table identical, parameterized by the props). The role map + `roleOf` (with `split('::')[0]` fallback) live here, typed via `RoleClassificationEntry`.
+
+- [ ] **Step 3: Switch OffenseSection to use it**
+
+Replace the Offense `if (noEgoMode && stats.offensePlayers.length > 0) { ... return (...) }` body with:
+
+```tsx
+    if (noEgoMode && stats.offensePlayers.length > 0) {
+        return (
+            <NoEgoMetricSection
+                title="Offense Detailed"
+                icon={<Swords className="w-4 h-4 shrink-0" style={{ color: 'var(--section-offense)' }} />}
+                accentColor="var(--section-offense)"
+                sidebarLabel="Offensive Tabs"
+                metrics={OFFENSE_METRICS}
+                filteredMetrics={filteredOffenseMetrics}
+                players={stats.offensePlayers}
+                roleClassifications={stats.roleClassifications}
+                activeStatId={activeOffenseStat}
+                setActiveStatId={setActiveOffenseStat}
+                search={offenseSearch}
+                setSearch={setOffenseSearch}
+                viewMode={offenseViewMode}
+                setViewMode={setOffenseViewMode}
+                detailOpen={detailOpen}
+                setDetailOpen={setDetailOpen}
+                higherIsBetter={(m) => !OFFENSE_LOWER_IS_BETTER.has(m.id)}
+                resolveTotal={(row, m) => /* the section's existing totalValue(row, m) */ totalValue(row, m)}
+                isRateOrPercent={(m) => !!(m as any).isPercent || !!(m as any).isRate}
+                fightTimeMs={(row) => row.totalFightMs || 0}
+                formatValue={(m, val) => {
+                    const decimals = roundCountStats && !(m as any).isPercent && offenseViewMode === 'total' ? 0 : 2;
+                    const formatted = formatWithCommas(val, decimals);
+                    return (m as any).isPercent ? `${formatted}%` : formatted;
+                }}
+            />
+        );
+    }
+```
+
+Keep the section's `totalValue` helper (move it above the branch if needed). Run the Offense No Ego test after this step:
+Run: `npx vitest run src/renderer/stats/sections/__tests__/OffenseSection.noego.test.tsx --maxWorkers=2`
+Expected: PASS (output unchanged).
+
+- [ ] **Step 4: Switch DefenseSection and SupportSection the same way**
+
+Defense: `DEFENSE_METRICS`, `filteredDefenseMetrics`, `stats.defensePlayers`, `activeDefenseStat`, `defenseViewMode`, accent `var(--section-defense)`, `higherIsBetter={(m)=>DEFENSE_HIGHER_IS_BETTER.has(m.id)}`, `resolveTotal` = the section's defense total helper, `fightTimeMs` = the section's fight-time field (e.g. `row.activeMs` or `row.totalFightMs` — use whatever the current Defense detail table uses).
+Support: `SUPPORT_METRICS`, `filteredSupportMetrics`, `stats.supportPlayers`, `activeSupportStat`, `supportViewMode`, accent `var(--section-support)`, `higherIsBetter={(m)=>!SUPPORT_LOWER_IS_BETTER.has(m.id)}`, `resolveTotal` = the section's support total helper (including `condiCleanse`/`cleanseScope`), `isRateOrPercent` per support metric, `formatValue` honoring `isTime` decimals.
+
+Run: `npx vitest run src/renderer/stats/sections/__tests__/ --maxWorkers=2`
+Expected: PASS (Offense/Defense/Support No Ego tests all green).
+
+- [ ] **Step 5: Confirm no leftover dead code**
+
+Search each section for now-unused helpers/imports (e.g. a stale `makeFormatValue`, unused `ChevronDown`/`StatsTableShell` if fully moved). Remove them. Run `npm run validate` (lint will flag unused).
+
+If the abstraction turns out to require section-specific branching that makes `NoEgoMetricSection` significantly more complex than the three current branches combined, STOP and report DONE_WITH_CONCERNS describing the leak — a forced bad abstraction is worse than the reviewed duplication.
+
+- [ ] **Step 6: Validate + commit**
+
+Run: `npm run validate`
+Expected: pass.
+
+```bash
+git add src/renderer/stats/sections/NoEgoMetricSection.tsx src/renderer/stats/sections/OffenseSection.tsx src/renderer/stats/sections/DefenseSection.tsx src/renderer/stats/sections/SupportSection.tsx
+git commit -m "refactor: extract shared NoEgoMetricSection for Offense/Defense/Support"
+```
+
+---
+
+### Task 8: Full validation sweep
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Full unit suite** — Run: `npx vitest run --maxWorkers=2` — Expected: all pass.
+- [ ] **Step 2: Validate** — Run: `npm run validate` — Expected: typecheck + lint clean.
+- [ ] **Step 3: Web build** — Run: `npm run build:web` — Expected: succeeds.
+- [ ] **Step 4: Commit (only if a fix was needed)** — `git add -A && git commit -m "chore: No Ego follow-ups validation fixes"`
+
+---
+
+## Notes for the implementer
+
+- Tasks 1–6 are independent and low-risk; Task 7 is the only structural change and relies on the section No Ego tests (Offense from prior work + Defense/Support from Task 5) as its regression net — do Task 5 before Task 7.
+- Task 7 must preserve rendered output; it is a DRY refactor, not a redesign. The view-mode toggle added in Task 4 should live in `NoEgoMetricSection` after extraction (it moves from the three branches into the one component).
+- `stats` is typed `any`; Task 3 only adds an element type for the role array, it does not type the whole `stats` object.

--- a/docs/superpowers/plans/2026-06-23-no-ego-sidebar-large-card.md
+++ b/docs/superpowers/plans/2026-06-23-no-ego-sidebar-large-card.md
@@ -1,0 +1,227 @@
+# No Ego Sidebar + Large Card Layout Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** In No Ego mode, the Offense/Defense/Support detailed sections keep their left metric-selector sidebar (as in normal mode) and render ONE large `MetricDistributionCard` for the selected metric, instead of the current grid of small cards. The "Per-player detail" expander stays, now showing the table for the selected metric.
+
+**Architecture:** Each section's `if (noEgoMode && ...)` branch is restructured to use the existing `StatsTableLayout` (240–280px sidebar + content). The sidebar is the section's existing metric-selector list (search box + `activeXStat` buttons) already present in normal mode. The content is a single large `MetricDistributionCard` built for the active metric, followed by the existing "Per-player detail" expander whose table is keyed to the active metric. `MetricDistributionCard` gains an opt-in `large` mode (taller dot-plot, larger headline) used here.
+
+**Tech Stack:** TypeScript, React 18, Vitest + jsdom, Tailwind CSS variables.
+
+## Global Constraints
+
+- Run vitest with `--maxWorkers=2`. `npm run validate` (typecheck + ESLint, max-warnings 0) must pass before each commit.
+- Scope: Offense, Defense, Support sections ONLY. Do NOT change the Squad Summary (TopPlayersSection) — it stays a grid.
+- Role-awareness, σ math, and outlier selection are unchanged — this is layout only. `MetricDistributionCard` already renders ALL needs-improvement outliers (no cap) and is `roleAware`; keep that.
+- Default-off safety: when `noEgoMode` is false, every section renders exactly as before (the normal-mode `StatsTableLayout` path is untouched). When `large` is absent/false, `MetricDistributionCard` renders byte-for-byte as today.
+- Reuse existing pieces — do not duplicate: `StatsTableLayout` (`src/renderer/stats/ui/StatsTableLayout.tsx`), the section's existing sidebar markup (search input + `filteredXMetrics.map` buttons using `activeXStat`/`setActiveXStat` and `sidebarListClass`), `StatsTableShell`, and the per-metric `players`-array + `formatValue` builders already in the No Ego branch.
+- The active metric drives BOTH the large card and the detail table: use `activeOffenseStat` / `activeDefenseStat` / `activeSupportStat` (already props, already available in the No Ego branch).
+
+---
+
+### Task 1: `large` mode for `MetricDistributionCard`
+
+**Files:**
+- Modify: `src/renderer/stats/components/MetricDistributionCard.tsx`
+- Test: `src/renderer/stats/components/__tests__/MetricDistributionCard.large.test.tsx` (new)
+
+**Interfaces:**
+- Produces: `MetricDistributionCardProps.large?: boolean` (default false → current sizing).
+
+- [ ] **Step 1: Write the failing test**
+
+```tsx
+// src/renderer/stats/components/__tests__/MetricDistributionCard.large.test.tsx
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/react';
+import { MetricDistributionCard } from '../MetricDistributionCard';
+
+const players = (vals: number[]) =>
+  vals.map((value, i) => ({ account: `P${i}`, value, profession: 'Guardian' }));
+
+describe('MetricDistributionCard — large mode', () => {
+  it('renders a taller dot-plot when large is set', () => {
+    const small = render(
+      <MetricDistributionCard title="Cleanses" accentColor="#60a5fa" higherIsBetter
+        players={players([2, 4, 6, 8])} formatValue={(n) => String(n)} />,
+    );
+    const smallPlot = small.container.querySelector('[data-testid="metric-card-plot"]');
+    expect(smallPlot?.className).toContain('h-8');
+
+    const big = render(
+      <MetricDistributionCard title="Cleanses" accentColor="#60a5fa" higherIsBetter large
+        players={players([2, 4, 6, 8])} formatValue={(n) => String(n)} />,
+    );
+    const bigPlot = big.container.querySelector('[data-testid="metric-card-plot"]');
+    expect(bigPlot?.className).toContain('h-14');
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/renderer/stats/components/__tests__/MetricDistributionCard.large.test.tsx --maxWorkers=2`
+Expected: FAIL — no `metric-card-plot` testid / `h-14` not present.
+
+- [ ] **Step 3: Implement**
+
+In `MetricDistributionCard.tsx`:
+1. Add `large?: boolean` to `MetricDistributionCardProps`; destructure with default `false`.
+2. On the dot-plot wrapper `<div className="relative h-8 mt-1">`, add `data-testid="metric-card-plot"` and make the height conditional: `` `relative ${large ? 'h-14' : 'h-8'} mt-1` ``.
+3. (Optional polish, keep minimal) when `large`, you MAY bump the single-Avg headline value class from `text-2xl` to `text-3xl`. Do not change any other behavior.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run src/renderer/stats/components/__tests__/MetricDistributionCard.large.test.tsx --maxWorkers=2`
+Expected: PASS.
+
+- [ ] **Step 5: Confirm existing card tests still pass**
+
+Run: `npx vitest run src/renderer/stats/components/__tests__/ --maxWorkers=2`
+Expected: PASS (existing card + role-aware tests unchanged).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/renderer/stats/components/MetricDistributionCard.tsx src/renderer/stats/components/__tests__/MetricDistributionCard.large.test.tsx
+git commit -m "feat: large mode (taller plot) for MetricDistributionCard"
+```
+
+---
+
+### Task 2: Offense section — sidebar + large card layout
+
+**Files:**
+- Modify: `src/renderer/stats/sections/OffenseSection.tsx` (the `if (noEgoMode && stats.offensePlayers.length > 0)` branch)
+- Test: `src/renderer/stats/sections/__tests__/OffenseSection.noego.test.tsx` (update)
+
+**Interfaces:**
+- Consumes: `StatsTableLayout`, `MetricDistributionCard` (`large`, `roleAware`), `activeOffenseStat`/`setActiveOffenseStat`, `offenseSearch`/`setOffenseSearch`, `sidebarListClass`, `StatsTableShell`.
+
+- [ ] **Step 1: Read the current No Ego branch and the normal-mode sidebar**
+
+Run: `sed -n '57,247p' src/renderer/stats/sections/OffenseSection.tsx` and `sed -n '480,628p' src/renderer/stats/sections/OffenseSection.tsx`.
+Identify: (a) the per-metric `players`-array + `formatValue` builders in the No Ego grid loop; (b) the normal-mode sidebar markup (search input + `filteredOffenseMetrics.map` buttons); (c) the per-player detail `StatsTableShell` already inside the current expander.
+
+- [ ] **Step 2: Update the test to the new layout contract**
+
+In `OffenseSection.noego.test.tsx`, the existing No Ego test currently asserts `metric-card-mean` present and a "Per-player detail" expander present. Update/extend it so it also asserts the sidebar metric buttons render. Add assertions (keep the existing role-aware test from prior work intact):
+
+```tsx
+// within the existing noEgoMode render:
+// sidebar metric selector is present
+expect(screen.getByText('Offensive Tabs')).toBeInTheDocument();
+// exactly one large card (one mean readout) is shown for the active metric
+expect(screen.getAllByTestId('metric-card-mean').length).toBe(1);
+// the large dot-plot is rendered
+expect(document.querySelector('[data-testid="metric-card-plot"]')?.className).toContain('h-14');
+// the per-player detail expander still exists
+expect(screen.getByRole('button', { name: /per-player detail/i })).toBeInTheDocument();
+```
+
+(If the section's sidebar label text differs from `Offensive Tabs`, use the actual literal found in Step 1.)
+
+- [ ] **Step 3: Run the test to confirm it fails**
+
+Run: `npx vitest run src/renderer/stats/sections/__tests__/OffenseSection.noego.test.tsx --maxWorkers=2`
+Expected: FAIL — grid currently renders many `metric-card-mean` (not exactly 1) and no `h-14` plot / no sidebar in the No Ego branch.
+
+- [ ] **Step 4: Restructure the No Ego branch**
+
+Replace the grid-of-cards + the current expander (which had its own inner `StatsTableLayout`) with a single `StatsTableLayout`:
+
+- **sidebar**: the SAME search input + `filteredOffenseMetrics.map(...)` button list used in normal mode (reuse the markup; it already calls `setActiveOffenseStat` and styles the `activeOffenseStat` button). Reuse `offenseSearch`/`setOffenseSearch` and `sidebarListClass`.
+- **content**: 
+  1. Resolve the active metric: `const metric = OFFENSE_METRICS.find((e) => e.id === activeOffenseStat) || OFFENSE_METRICS[0];`
+  2. Build the `players` array + `higherIsBetter` + `formatValue` for THAT metric using the existing builders (the same ones the grid loop used, applied to the single active metric; include `role: roleOf(row.account)` exactly as the current grid does).
+  3. Render ONE `<MetricDistributionCard large roleAware title={metric.label} accentColor="var(--section-offense)" higherIsBetter={...} players={players} formatValue={...} renderProfessionIcon={renderProfessionIcon} />`.
+  4. Below the card, keep the existing "Per-player detail" expander (`detailOpen`/`setDetailOpen` + chevrons), but its content is now just the per-player `StatsTableShell` table for the ACTIVE metric (the same table that was already in the old expander) — it no longer needs its own sidebar since the section sidebar drives the selection.
+
+Keep the section header (`Offense Detailed`) above the `StatsTableLayout`.
+
+- [ ] **Step 5: Run the test to confirm it passes**
+
+Run: `npx vitest run src/renderer/stats/sections/__tests__/OffenseSection.noego.test.tsx --maxWorkers=2`
+Expected: PASS.
+
+- [ ] **Step 6: Validate + commit**
+
+Run: `npm run validate`
+Expected: pass.
+
+```bash
+git add src/renderer/stats/sections/OffenseSection.tsx src/renderer/stats/sections/__tests__/OffenseSection.noego.test.tsx
+git commit -m "feat: No Ego Offense uses sidebar + large card layout"
+```
+
+---
+
+### Task 3: Defense + Support sections — mirror the Offense layout
+
+**Files:**
+- Modify: `src/renderer/stats/sections/DefenseSection.tsx`, `src/renderer/stats/sections/SupportSection.tsx` (their `if (noEgoMode && ...)` branches)
+
+**Interfaces:**
+- Same as Task 2, using each section's own `activeDefenseStat`/`setActiveDefenseStat` + `DEFENSE_METRICS` (accent `var(--section-defense)`) and `activeSupportStat`/`setActiveSupportStat` + `SUPPORT_METRICS` (accent `var(--section-support)`), and each section's existing sidebar markup, `players`/`formatValue` builders, `roleOf`, and detail `StatsTableShell`.
+
+- [ ] **Step 1: Apply the Task 2 restructure to DefenseSection**
+
+Mirror Task 2 Step 4 exactly in `DefenseSection.tsx`: replace the grid + inner-sidebar expander with one `StatsTableLayout` (sidebar = existing defense metric selector; content = one `large roleAware` `MetricDistributionCard` for the active defense metric + the per-player detail expander showing the active-metric table). Use `var(--section-defense)` for `accentColor` and the existing defense `higherIsBetter`/`formatValue`/`roleOf` logic.
+
+- [ ] **Step 2: Apply the same restructure to SupportSection**
+
+Mirror in `SupportSection.tsx` using `activeSupportStat`, `SUPPORT_METRICS`, `var(--section-support)`, and the existing support `formatValue` (respect `condiCleanse`/`cleanseScope` and `isTime` handling already present) + `roleOf`.
+
+- [ ] **Step 3: Typecheck + lint**
+
+Run: `npm run validate`
+Expected: pass.
+
+- [ ] **Step 4: Sanity-check both sections render**
+
+Run: `npx vitest run src/renderer/stats/sections/__tests__/ --maxWorkers=2`
+Expected: PASS (Offense No Ego test + any Defense/Support tests; nothing regressed).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/renderer/stats/sections/DefenseSection.tsx src/renderer/stats/sections/SupportSection.tsx
+git commit -m "feat: No Ego Defense/Support use sidebar + large card layout"
+```
+
+---
+
+### Task 4: Full validation sweep
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Full unit suite**
+
+Run: `npx vitest run --maxWorkers=2`
+Expected: all pass.
+
+- [ ] **Step 2: Validate**
+
+Run: `npm run validate`
+Expected: typecheck + lint clean.
+
+- [ ] **Step 3: Build the web report**
+
+Run: `npm run build:web`
+Expected: succeeds.
+
+- [ ] **Step 4: Commit (only if a fix was needed)**
+
+```bash
+git add -A && git commit -m "chore: No Ego sidebar+large-card validation fixes"
+```
+
+---
+
+## Notes for the implementer
+
+- This is a layout refactor: do not change the squad/cohort math, role logic, or which outliers are flagged.
+- The normal-mode (`!noEgoMode`) path in each section is untouched.
+- The Squad Summary (TopPlayersSection) is explicitly out of scope.
+- The detail expander's table already existed in the old No Ego branch keyed to the active stat — reuse it; just lift it out of the now-removed inner `StatsTableLayout`.
+- If a section's existing No Ego branch built `players` only inside a `.map` over all metrics, refactor that into a small inline helper applied to the single active metric (and reused if you prefer), rather than duplicating the body.

--- a/docs/superpowers/specs/2026-06-22-no-ego-mode-design.md
+++ b/docs/superpowers/specs/2026-06-22-no-ego-mode-design.md
@@ -1,0 +1,139 @@
+# No Ego Mode — Design
+
+**Date:** 2026-06-22
+**Status:** Approved (pending spec review)
+
+## Summary
+
+"No Ego mode" is a single master toggle that removes all competitive / ranking
+framing from AxiBridge's stats — across **both** the desktop app and the
+published web report — and replaces it with squad-level distribution readouts.
+
+The guiding philosophy: focus entirely on **areas of improvement**, not on "who
+did best." Concretely that means:
+
+- No MVP podium (gold/silver/bronze), no crown, no #1/#2/#3 rank numbers, no
+  "best value" highlighting, no head-to-head "who won" comparison.
+- Each metric is presented as a **distribution**: squad **average**,
+  **deviation** (σ), range, shown as a **visual dot-plot plus hard numbers**.
+- **Outliers are surfaced only on the needs-improvement end.** High performers
+  are never celebrated — emphasizing the high end is just ego-boosting in
+  reverse. The "needs-improvement" end is chosen per metric using the catalog's
+  `higherIsBetter` flag (low end for damage/cleanses/healing; high end for
+  deaths/downs/damage-taken).
+
+The mode must **permeate every surface**.
+
+## Decisions (from brainstorming)
+
+- **Core behavior:** hide rankings, surface gaps. Lean on averages + deviation +
+  outliers rather than top performers.
+- **Outlier framing:** named, but neutral; only the needs-improvement end is
+  called out. High end shows on the plot as a dot but is never labeled/celebrated.
+- **Control:** a single master toggle. When on, it overrides
+  `showMvp` / `showTopStats` everywhere. Value is baked into `report.json` at
+  publish time. No per-viewer web toggle.
+- **Tables (Offense/Defense/Support):** rethought — the per-player grid stops
+  being the primary object. Each section becomes a **list of metric cards** (every
+  metric gets a card) with dot-plot + hard numbers + needs-improvement callouts.
+  The full per-player grid remains available but **secondary, collapsed behind an
+  expander**.
+- **Top Skills section:** hidden in No Ego mode.
+- **Player Comparison:** hidden in No Ego mode.
+- **Rollup (`rollup.ts`):** computations always run in full (never gated off);
+  its **display** follows the same No-Ego reframing (leaderboards → average /
+  deviation / outlier readout).
+- **Outlier threshold:** fixed at **1.5σ** from the mean for named callouts.
+
+## Architecture
+
+### Where the reshaping happens — shared util (Approach C)
+
+A single new helper `src/shared/squadStats.ts` computes the distribution summary
+from the per-player metric arrays that aggregation already produces. This avoids
+changing the heavy worker payload / `report.json` size, avoids duplicating math
+across sections, and makes the math unit-testable in isolation.
+
+```
+squadStats(values: number[], higherIsBetter: boolean): {
+  mean: number;
+  stdDev: number;
+  min: number;
+  max: number;
+  players: { account, value, profession }[];   // all players, for the dot-plot
+  needsImprovementOutliers: { account, value, profession }[]; // beyond 1.5σ on the bad end
+}
+```
+
+- "Needs-improvement end" = low end when `higherIsBetter`, high end otherwise.
+- Outlier = a player whose value is more than **1.5σ** from the mean on the
+  needs-improvement end.
+
+### Setting & plumbing
+
+- Add `noEgoMode: boolean` to `IStatsViewSettings` (`src/renderer/global.d.ts`),
+  default `false`; add to `DEFAULT_STATS_VIEW_SETTINGS`.
+- Add a toggle in `SettingsView.tsx` near the existing `showTopStats` /
+  `showMvp` toggles, with a one-line description.
+- When `noEgoMode` is on it **overrides** `showMvp` / `showTopStats` regardless
+  of their values (in `StatsView.tsx` where those settings are read,
+  ~lines 230-236).
+- The value flows into `report.json` at publish time via the same settings path
+  the web report already consumes.
+
+### Desktop renderer changes
+
+| Surface | File | No Ego behavior |
+|---------|------|-----------------|
+| Top Players / MVP podium | `stats/sections/TopPlayersSection.tsx` | Replace podium + leaderboard cards with a **Squad Summary**: one card per top-stat metric (dot-plot + hard numbers + needs-improvement callouts). No podium/crown/medals/rank numbers. |
+| Offense table | `stats/sections/OffenseSection.tsx` | Becomes a list of metric cards (every metric); full grid collapsed behind an expander. No rank numbers / best-value highlight. |
+| Defense table | `stats/sections/DefenseSection.tsx` | Same as Offense. |
+| Support table | `stats/sections/SupportSection.tsx` | Same as Offense. |
+| Top Skills | `stats/sections/TopSkillsSection.tsx` | Hidden. |
+| Player Comparison | `stats/sections/PlayerComparisonSection.tsx` | Hidden. |
+
+The MVP calculation in `incrementalAggregation.ts` (~lines 1225-1248) may be
+skipped when `noEgoMode` is on (no MVP is rendered), but this is an
+optimization, not a correctness requirement.
+
+### Metric card (shared presentation component)
+
+A reusable card component renders one metric's distribution:
+
+- **Dot-plot:** each player is a dot positioned by value across the squad
+  min→max range; mean marked; ±σ band shaded. High-end dots are not styled
+  differently from any other dot.
+- **Hard numbers:** average, σ (deviation), and range (min–max).
+- **Needs-improvement callouts:** named players beyond 1.5σ on the bad end,
+  framed neutrally (e.g. "below squad range: PlayerX, PlayerY"). When there are
+  none, show nothing (or a quiet "squad is consistent here").
+
+Used by the Squad Summary, the Offense/Defense/Support sections, and the web
+rollup, so the language stays identical everywhere.
+
+### Web report
+
+The web report reuses the same React components and reads settings from
+`report.json`, so all of the above applies automatically when the baked flag is
+`noEgoMode: true`. The rollup (`rollup.ts`) continues to compute all aggregates;
+its display is converted to the metric-card treatment.
+
+## Testing
+
+- **Unit:** `src/shared/__tests__/squadStats.test.ts` — mean/σ correctness;
+  outlier direction for both `higherIsBetter: true` and `false` metrics;
+  edge cases (single player, all-equal values → σ 0 / no outliers, empty input).
+- **Integration:** a `StatsView` test asserting that with `noEgoMode: true` the
+  podium, rank numbers, Top Skills, and Player Comparison are **absent**, and
+  squad-summary metric cards are **present**; and the inverse with
+  `noEgoMode: false`.
+- **Web:** confirm the web report honors the baked `noEgoMode` flag from
+  `report.json`.
+
+## Out of scope (YAGNI)
+
+- Per-viewer toggle inside the web report.
+- Configurable σ threshold (fixed at 1.5σ to start).
+- New animations / chart libraries — the dot-plot is a simple inline render.
+- Changing the underlying aggregation payload or `report.json` schema beyond the
+  single `noEgoMode` flag.

--- a/docs/superpowers/specs/2026-06-22-no-ego-role-aware-design.md
+++ b/docs/superpowers/specs/2026-06-22-no-ego-role-aware-design.md
@@ -1,0 +1,146 @@
+# No Ego Mode — Role-Aware Comparisons (Design)
+
+**Date:** 2026-06-22
+**Status:** Approved (pending spec review)
+**Builds on:** [No Ego Mode design](2026-06-22-no-ego-mode-design.md). Same branch (`feat/no-ego-mode`), not yet merged.
+
+## Problem
+
+No Ego mode flags "needs-improvement" outliers by comparing every player against a
+single squad-wide average per metric. That is unfair across roles: a healer with low
+down-contribution gets flagged even though low down-contribution is expected for that
+role. The fix is to compare like-with-like.
+
+## What already exists (reused, not rebuilt)
+
+- A binary role classifier: `packages/bridge-metrics/src/roles.ts`
+  (`PlayerRoleClassification` = `{ role: 'support' | 'damage'; supportScore; confidenceScore; threshold; factors }`)
+  and `src/renderer/stats/classifyPlayerRoles.ts`.
+- It is populated per player as `roleClassification` during aggregation
+  (`computePlayerAggregation.ts`, `incrementalAggregation.ts`) and already used to filter
+  MVP candidates (damage → Offensive MVP, support → Defensive MVP).
+- The aggregation output also carries a `roleClassifications` array
+  (`{ account, profession, professionList, role, supportScore, confidenceScore, threshold, factors }`).
+- `computeSquadStat(players, higherIsBetter, sigmaThreshold=1.5)` in `src/shared/squadStats.ts`
+  computes mean/σ/outliers for a set of players.
+
+## Decisions (from brainstorming)
+
+- **Cohort comparison (#1):** needs-improvement outliers are computed *within the
+  player's role group* (support vs damage), not against the whole squad.
+- **One card per metric** (no card doubling). The dot-plot colors dots by role; headline
+  shows **per-cohort averages** when both roles are present, collapsing to a single average
+  when only one role is present.
+- **Outlier row shows value + gap** (`value · −1.6σ`) measured against that player's cohort,
+  replacing the bare value.
+- **Applies to all metrics uniformly.** No per-metric role-relevance list.
+- **Small-cohort fallback:** if a player's role group has **fewer than 3 players**, that
+  player is compared squad-wide instead (σ from <3 players is meaningless), and is not
+  spuriously flagged.
+- **Trust the classifier as-is** (same one MVP uses); no confidence-gating.
+- **Binary support/damage only.** Finer roles (healer vs boon-support) are out of scope.
+- **Rollup stays squad-wide / unchanged.** Roles are not stable across many reports.
+- **Always on inside No Ego mode** — no separate toggle.
+
+## Architecture
+
+### New shared helper: cohort-aware squad stats
+
+Add to `src/shared/squadStats.ts` (keep it dependency-free):
+
+```ts
+export type PlayerRole = 'support' | 'damage';
+
+export interface CohortStatPlayer extends SquadStatPlayer {
+  role?: PlayerRole;   // omitted/unknown players are treated squad-wide
+}
+
+export interface CohortStatSummary {
+  // Per-cohort summaries (undefined when that cohort has 0 players)
+  support?: SquadStatSummary;
+  damage?: SquadStatSummary;
+  squad: SquadStatSummary;            // always present (whole-squad), for fallback + dot-plot context
+  // Outliers across the squad, each flagged against the correct baseline:
+  needsImprovementOutliers: Array<SquadStatPlayer & {
+    role?: PlayerRole;
+    baseline: 'support' | 'damage' | 'squad';  // which cohort it was judged against
+    sigmaGap: number;                            // signed distance in σ on the needs-improvement side (>= sigmaThreshold)
+  }>;
+}
+
+export function computeCohortStat(
+  players: CohortStatPlayer[],
+  higherIsBetter: boolean,
+  sigmaThreshold?: number,            // default 1.5
+  minCohortSize?: number,             // default 3
+): CohortStatSummary;
+```
+
+Rules:
+- Partition players into `support`, `damage`, and `unknown` (no role).
+- A cohort with `>= minCohortSize` players is a valid baseline; otherwise its members fall
+  back to the squad baseline. `unknown`-role players always use the squad baseline.
+- For each player, run the 1.5σ needs-improvement test against its chosen baseline
+  (cohort or squad), reusing the existing `computeSquadStat` math; `sigmaGap` = how far past
+  the mean on the bad end (in σ).
+- `squad` summary is always computed (used for the dot-plot extent and headline collapse).
+
+This isolates all role-vs-squad logic in one tested pure function. `computeSquadStat` is
+unchanged.
+
+### Card presentation: `MetricDistributionCard`
+
+Extend `MetricDistributionCardProps` with an optional role channel:
+
+```ts
+players: Array<SquadStatPlayer & { role?: 'support' | 'damage' }>;
+roleAware?: boolean;   // when true, use computeCohortStat; default false = current behavior
+```
+
+When `roleAware` is true:
+- Compute via `computeCohortStat`.
+- Dot-plot: color dots by role (damage = warm accent, support = cool accent, unknown =
+  neutral). Outlier dots keep the accent-outline treatment.
+- Headline: when both `support` and `damage` baselines exist, render two compact averages
+  (`DPS <avg> · Sup <avg>`) each with σ; otherwise a single average as today.
+- "Most room to improve": each row shows profession icon · account · `value · −<sigmaGap>σ`,
+  with a small role/baseline tag when the baseline is a cohort.
+
+When `roleAware` is false/absent, the card behaves exactly as today (default-off safety).
+
+### Wiring
+
+The Squad Summary (`TopPlayersSection`) and the Offense/Defense/Support section cards build
+their `players` arrays. Add `role` to each player from the aggregation's `roleClassifications`
+(join by account, respecting `splitPlayersByClass` keys the same way existing code does), and
+pass `roleAware={noEgoMode}` (role-aware is part of No Ego mode). The rollup cards are NOT
+changed.
+
+Role lookup: build a `Map<account, 'support'|'damage'>` from `stats.roleClassifications` once
+per section and attach `role` when constructing each card's player list. Players missing from
+the map get no role (squad-wide fallback).
+
+## Testing
+
+- **Unit (`squadStats.test.ts` additions):** `computeCohortStat`
+  - healer with low value-for-damage-metric is NOT flagged when judged among supports;
+  - a genuinely-low support IS flagged against the support baseline;
+  - small cohort (<3) falls back to squad baseline (no spurious flag);
+  - unknown-role players use squad baseline;
+  - `sigmaGap` sign/magnitude correct for both higherIsBetter true/false;
+  - both-cohorts-present vs single-cohort summaries populated correctly;
+  - empty input safe.
+- **Component (`MetricDistributionCard` additions):** with `roleAware` and a mixed-role
+  fixture, dual-average headline renders, dots carry role colors, and a damage-metric does
+  not flag a support player; outlier rows show the `· −Xσ` gap.
+- **Integration:** extend the existing No Ego StatsView test (or add one) asserting that a
+  support player with low down-contribution is not listed as a down-contribution
+  outlier when role-aware comparison is active.
+
+## Out of scope (YAGNI)
+
+- Finer sub-roles (healer vs boon-support vs power vs condi).
+- Role-aware treatment of the cross-report rollup.
+- A separate toggle (role-awareness is intrinsic to No Ego mode).
+- Confidence-score gating of classifications.
+- Persisting elite-spec through aggregation.

--- a/packages/bridge-metrics/src/__tests__/rollup.noego.test.ts
+++ b/packages/bridge-metrics/src/__tests__/rollup.noego.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, it } from 'vitest';
+import { buildRollupData, extractRollupSource } from '../rollup';
+
+/** Minimal report payload factory with optional noEgoMode. */
+const makeReport = (id: string, noEgoMode?: boolean) => ({
+    meta: {
+        id,
+        dateStart: `2026-01-0${id}T00:00:00Z`,
+        dateEnd: `2026-01-0${id}T03:00:00Z`,
+        generatedAt: `2026-01-0${id}T03:05:00Z`
+    },
+    stats: {
+        commanderStats: {
+            rows: [
+                {
+                    account: `cmd.${id}`,
+                    characterNames: [`Commander ${id}`],
+                    profession: 'Guardian',
+                    fights: 2,
+                    kills: 5,
+                    downs: 6,
+                    commanderDeaths: 1,
+                    alliesDead: 3,
+                    wins: 1,
+                    losses: 1
+                }
+            ]
+        },
+        attendanceData: [
+            {
+                account: `player.${id}`,
+                characterNames: [`Player ${id}`],
+                classTimes: [{ profession: 'Guardian', timeMs: 30 * 60 * 1000 }],
+                combatTimeMs: 30 * 60 * 1000,
+                squadTimeMs: 45 * 60 * 1000
+            }
+        ],
+        ...(noEgoMode !== undefined ? { statsViewSettings: { noEgoMode } } : {})
+    }
+});
+
+describe('buildRollupData – noEgoMode propagation', () => {
+    it('returns noEgoMode=false when no reports declare the setting', () => {
+        const rollup = buildRollupData([makeReport('1'), makeReport('2')]);
+        expect(rollup.noEgoMode).toBe(false);
+    });
+
+    it('returns noEgoMode=false when reports declare noEgoMode=false', () => {
+        const rollup = buildRollupData([
+            makeReport('1', false),
+            makeReport('2', false)
+        ]);
+        expect(rollup.noEgoMode).toBe(false);
+    });
+
+    it('returns noEgoMode=true when all reports have noEgoMode=true', () => {
+        const rollup = buildRollupData([
+            makeReport('1', true),
+            makeReport('2', true)
+        ]);
+        expect(rollup.noEgoMode).toBe(true);
+    });
+
+    it('uses majority vote: true wins when more than half of declaring reports are true', () => {
+        const rollup = buildRollupData([
+            makeReport('1', true),
+            makeReport('2', true),
+            makeReport('3', false)
+        ]);
+        expect(rollup.noEgoMode).toBe(true);
+    });
+
+    it('uses majority vote: false wins when half or fewer are true', () => {
+        const rollup = buildRollupData([
+            makeReport('1', true),
+            makeReport('2', false),
+            makeReport('3', false)
+        ]);
+        expect(rollup.noEgoMode).toBe(false);
+    });
+
+    it('ignores reports without statsViewSettings for the majority calculation', () => {
+        // Report '3' has no statsViewSettings - only reports 1 and 2 vote
+        const rollup = buildRollupData([
+            makeReport('1', true),
+            makeReport('2', false),
+            makeReport('3')  // no setting - neutral
+        ]);
+        // 1 true out of 2 declaring = 50%, not > 50% → false
+        expect(rollup.noEgoMode).toBe(false);
+    });
+
+    it('ALWAYS computes full aggregates regardless of noEgoMode (no gating on computation)', () => {
+        const noEgoRollup = buildRollupData([
+            makeReport('1', true),
+            makeReport('2', true)
+        ]);
+        const normalRollup = buildRollupData([
+            makeReport('1', false),
+            makeReport('2', false)
+        ]);
+
+        // Computation is identical regardless of flag; only the flag value differs
+        expect(noEgoRollup.commanderRows).toHaveLength(normalRollup.commanderRows.length);
+        expect(noEgoRollup.playerRows).toHaveLength(normalRollup.playerRows.length);
+        expect(noEgoRollup.uniqueRaids).toBe(normalRollup.uniqueRaids);
+        expect(noEgoRollup.sourceReports).toBe(normalRollup.sourceReports);
+        // Commander and player data are fully computed in both cases
+        expect(noEgoRollup.commanderRows[0]?.kills).toBe(normalRollup.commanderRows[0]?.kills);
+        expect(noEgoRollup.playerRows[0]?.combatTimeMs).toBe(normalRollup.playerRows[0]?.combatTimeMs);
+    });
+
+    it('returns noEgoMode=false for an empty report list', () => {
+        const rollup = buildRollupData([]);
+        expect(rollup.noEgoMode).toBe(false);
+    });
+});
+
+describe('extractRollupSource – preserves statsViewSettings.noEgoMode', () => {
+    it('includes noEgoMode=true in the extracted projection', () => {
+        const source = extractRollupSource(makeReport('1', true));
+        expect(source.stats?.statsViewSettings?.noEgoMode).toBe(true);
+    });
+
+    it('includes noEgoMode=false in the extracted projection', () => {
+        const source = extractRollupSource(makeReport('1', false));
+        expect(source.stats?.statsViewSettings?.noEgoMode).toBe(false);
+    });
+
+    it('omits statsViewSettings when the original report has none', () => {
+        const source = extractRollupSource(makeReport('1'));
+        expect(source.stats?.statsViewSettings).toBeUndefined();
+    });
+
+    it('round-trips through extract: buildRollupData from extracted source preserves noEgoMode', () => {
+        const report = makeReport('1', true);
+        const extracted = extractRollupSource(report);
+        const rollup = buildRollupData([extracted]);
+        expect(rollup.noEgoMode).toBe(true);
+    });
+});

--- a/packages/bridge-metrics/src/rollup.ts
+++ b/packages/bridge-metrics/src/rollup.ts
@@ -42,6 +42,8 @@ export interface RollupData {
     reportsMissingCommanderDetails: number;
     reportsWithAttendanceDetails: number;
     reportsMissingAttendanceDetails: number;
+    /** True when the majority of source reports had No Ego Mode enabled. */
+    noEgoMode: boolean;
 }
 
 type RollupReportPayload = {
@@ -56,6 +58,7 @@ type RollupReportPayload = {
     stats?: {
         commanderStats?: { rows?: any[] };
         attendanceData?: any[];
+        statsViewSettings?: { noEgoMode?: boolean };
     };
 };
 
@@ -88,6 +91,8 @@ export const extractRollupSource = (payload: RollupReportPayload): RollupReportP
     const attendanceRows = Array.isArray(payload?.stats?.attendanceData)
         ? payload.stats!.attendanceData!
         : [];
+    const rawSettings = payload?.stats?.statsViewSettings;
+    const statsViewSettings = rawSettings ? { noEgoMode: Boolean(rawSettings.noEgoMode) } : undefined;
     return {
         meta: {
             id: meta.id,
@@ -96,6 +101,7 @@ export const extractRollupSource = (payload: RollupReportPayload): RollupReportP
             generatedAt: meta.generatedAt
         },
         stats: {
+            ...(statsViewSettings ? { statsViewSettings } : {}),
             commanderStats: {
                 rows: commanderRows.map((row: any) => ({
                     key: row?.key,
@@ -509,6 +515,12 @@ export const buildRollupData = (reports: RollupReportPayload[]): RollupData => {
             return a.account.localeCompare(b.account);
         });
 
+    // Determine noEgoMode via majority vote across all source reports that declare the setting.
+    // Reports without statsViewSettings are treated as neutral (not counted either way).
+    const reportsWithSetting = reports.filter((r) => r?.stats?.statsViewSettings !== undefined);
+    const noEgoCount = reportsWithSetting.filter((r) => r.stats?.statsViewSettings?.noEgoMode === true).length;
+    const noEgoMode = reportsWithSetting.length > 0 && noEgoCount > reportsWithSetting.length / 2;
+
     return {
         commanderRows,
         playerRows,
@@ -519,6 +531,7 @@ export const buildRollupData = (reports: RollupReportPayload[]): RollupData => {
         reportsWithCommanderDetails,
         reportsMissingCommanderDetails,
         reportsWithAttendanceDetails,
-        reportsMissingAttendanceDetails
+        reportsMissingAttendanceDetails,
+        noEgoMode
     };
 };

--- a/src/renderer/SettingsView.tsx
+++ b/src/renderer/SettingsView.tsx
@@ -2185,6 +2185,12 @@ export function SettingsView({ onBack: _onBack, onEmbedStatSettingsSaved, onOpen
                         </p>
                         <div className="divide-y divide-white/5">
                             <Toggle
+                                enabled={statsViewSettings.noEgoMode}
+                                onChange={(v) => updateStatsViewSetting('noEgoMode', v)}
+                                label="No Ego mode"
+                                description="Hide MVP, rankings, and leaderboards. Show squad averages, spread, and areas to improve instead — across the app and web reports."
+                            />
+                            <Toggle
                                 enabled={statsViewSettings.showTopStats}
                                 onChange={(v) => updateStatsViewSetting('showTopStats', v)}
                                 label="Show Top Stats Section"

--- a/src/renderer/StatsView.tsx
+++ b/src/renderer/StatsView.tsx
@@ -4370,6 +4370,7 @@ type SpikeFight = {
                                 setActiveOffenseStat={setActiveOffenseStat}
                                 offenseViewMode={offenseViewMode}
                                 setOffenseViewMode={setOffenseViewMode}
+                                noEgoMode={noEgoMode}
                             />)}
 
                             {renderSectionWrap(<DamageModifiersSection
@@ -4478,6 +4479,7 @@ type SpikeFight = {
                                 setActiveDefenseStat={setActiveDefenseStat}
                                 defenseViewMode={defenseViewMode}
                                 setDefenseViewMode={setDefenseViewMode}
+                                noEgoMode={noEgoMode}
                             />)}
 
                             {renderSectionWrap(<DamageModifiersSection
@@ -4541,6 +4543,7 @@ type SpikeFight = {
                                 setSupportViewMode={setSupportViewMode}
                                 cleanseScope={cleanseScope}
                                 setCleanseScope={setCleanseScope}
+                                noEgoMode={noEgoMode}
                             />)}
 
                             {renderSectionWrap(<HealingSection
@@ -4804,6 +4807,7 @@ type SpikeFight = {
                                 setActiveOffenseStat={setActiveOffenseStat}
                                 offenseViewMode={offenseViewMode}
                                 setOffenseViewMode={setOffenseViewMode}
+                                noEgoMode={noEgoMode}
                             /> },
                             { id: 'damage-modifiers', element: <DamageModifiersSection
                                 search={damageModSearch}
@@ -4917,6 +4921,7 @@ type SpikeFight = {
                                 setActiveDefenseStat={setActiveDefenseStat}
                                 defenseViewMode={defenseViewMode}
                                 setDefenseViewMode={setDefenseViewMode}
+                                noEgoMode={noEgoMode}
                             /> },
                             { id: 'incoming-damage-modifiers', element: <DamageModifiersSection
                                 search={incomingDamageModSearch}
@@ -5067,6 +5072,7 @@ type SpikeFight = {
                                 setSupportViewMode={setSupportViewMode}
                                 cleanseScope={cleanseScope}
                                 setCleanseScope={setCleanseScope}
+                                noEgoMode={noEgoMode}
                             /> },
                             { id: 'healing-stats', element: <HealingSection
                                 activeHealingMetric={activeHealingMetric}

--- a/src/renderer/StatsView.tsx
+++ b/src/renderer/StatsView.tsx
@@ -4272,6 +4272,7 @@ type SpikeFight = {
                                     formatTopStatValue={formatTopStatValue}
                                     isMvpStatEnabled={isMvpStatEnabled}
                                     enabledTopStats={enabledTopStats}
+                                    noEgoMode={noEgoMode}
                                 />)}
                             </div>
 
@@ -4717,6 +4718,7 @@ type SpikeFight = {
                                 formatTopStatValue={formatTopStatValue}
                                 isMvpStatEnabled={isMvpStatEnabled}
                                 enabledTopStats={enabledTopStats}
+                                noEgoMode={noEgoMode}
                             /> },
                             { id: 'top-skills-outgoing', element: <TopSkillsSection
                                 topSkillsMetric={topSkillsMetric}

--- a/src/renderer/StatsView.tsx
+++ b/src/renderer/StatsView.tsx
@@ -4276,7 +4276,7 @@ type SpikeFight = {
                                 />)}
                             </div>
 
-                            {renderSectionWrap(<TopSkillsSection
+                            {!noEgoMode && renderSectionWrap(<TopSkillsSection
                                 topSkillsMetric={topSkillsMetric}
                                 onTopSkillsMetricChange={updateTopSkillsMetric}
                             />)}
@@ -4723,10 +4723,10 @@ type SpikeFight = {
                                 enabledTopStats={enabledTopStats}
                                 noEgoMode={noEgoMode}
                             /> },
-                            { id: 'top-skills-outgoing', element: <TopSkillsSection
+                            ...(!noEgoMode ? [{ id: 'top-skills-outgoing', element: <TopSkillsSection
                                 topSkillsMetric={topSkillsMetric}
                                 onTopSkillsMetricChange={updateTopSkillsMetric}
-                            /> },
+                            /> }] : []),
                             { id: 'squad-composition', element: <SquadCompositionSection
                                 sortedSquadClassData={sortedSquadClassData}
                                 sortedEnemyClassData={sortedEnemyClassData}
@@ -5162,7 +5162,7 @@ type SpikeFight = {
                                 formatCastRateValue={formatCastRateValue}
                                 formatCastCountValue={formatCastCountValue}
                             /> },
-                            { id: 'player-comparison', element: <PlayerComparisonSection
+                            ...(!noEgoMode ? [{ id: 'player-comparison', element: <PlayerComparisonSection
                                 comparisonMode={comparisonMode}
                                 setComparisonMode={setComparisonMode}
                                 comparisonCategory={comparisonCategory}
@@ -5171,7 +5171,7 @@ type SpikeFight = {
                                 setPlayerAKey={setComparisonPlayerAKey}
                                 playerBKey={comparisonPlayerBKey}
                                 setPlayerBKey={setComparisonPlayerBKey}
-                            /> },
+                            /> }] : []),
                         ])}
                         {renderGroup('map', [
                             { id: 'replay', element: <div style={{ height: '88vh', minHeight: 500, maxHeight: 1000, display: 'flex', width: '100%' }}>{r2ReplayStatus === 'loading' ? <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', width: '100%', fontSize: '0.875rem', color: '#9ca3af' }}>Loading replay data...</div> : r2ReplayStatus === 'error' ? <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', width: '100%', fontSize: '0.875rem', color: '#fb7185' }}>Failed to load replay data.</div> : <ReplaySection fights={getReplayFights()} />}</div> },

--- a/src/renderer/StatsView.tsx
+++ b/src/renderer/StatsView.tsx
@@ -229,8 +229,10 @@ export const StatsView = memo(function StatsView({ logs, onBack: _onBack, mvpWei
 
     const activeStatsViewSettings = statsViewSettings || DEFAULT_STATS_VIEW_SETTINGS;
     const activeWebUploadState = webUploadState || DEFAULT_WEB_UPLOAD_STATE;
-    const showTopStats = activeStatsViewSettings.showTopStats;
-    const showMvp = activeStatsViewSettings.showMvp;
+    const noEgoMode = activeStatsViewSettings.noEgoMode === true;
+    // No Ego mode forces the squad-summary layout on and the MVP podium off.
+    const showTopStats = noEgoMode ? true : activeStatsViewSettings.showTopStats;
+    const showMvp = noEgoMode ? false : activeStatsViewSettings.showMvp;
     const roundCountStats = activeStatsViewSettings.roundCountStats;
     const topStatsMode = activeStatsViewSettings.topStatsMode || 'total';
     const enabledTopStats = normalizeEnabledTopStats(activeStatsViewSettings.enabledTopStats);

--- a/src/renderer/__tests__/StatsView.noego.integration.test.tsx
+++ b/src/renderer/__tests__/StatsView.noego.integration.test.tsx
@@ -1,0 +1,78 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { StatsView } from '../StatsView';
+import { DEFAULT_STATS_VIEW_SETTINGS } from '../global.d';
+
+/**
+ * Integration test for StatsView No Ego mode.
+ *
+ * No Ego mode (statsViewSettings.noEgoMode: true):
+ *  - Forces squad-summary layout on (data-testid="squad-summary" present)
+ *  - Hides MVP podium ("Offensive MVP" / "Defensive MVP" absent)
+ *  - Hides Top Outgoing Skills section ("Top Outgoing Skills" absent)
+ *  - Hides Player Comparison section ("Player Comparison" absent)
+ *
+ * Header literals confirmed via grep:
+ *  - TopSkillsSection.tsx:46  → "Top Outgoing Skills"
+ *  - PlayerComparisonSection.tsx:90 → "Player Comparison"
+ *  - TopPlayersSection.tsx:186 → data-testid="squad-summary"
+ *  - TopPlayersSection.tsx:234,257 → "Offensive MVP" / "Defensive MVP"
+ */
+
+const baseStats = {
+    fightSummaries: [],
+    playerSkillBreakdowns: [],
+    apmBreakdowns: [],
+    skillUsageBreakdowns: [],
+    fightDiffMode: {},
+};
+
+describe('StatsView – No Ego mode (integration)', () => {
+    it('hides MVP podium + Top Skills + Player Comparison, and shows squad-summary when noEgoMode:true', () => {
+        render(
+            <StatsView
+                logs={[]}
+                onBack={() => {}}
+                precomputedStats={baseStats as any}
+                statsViewSettings={{ ...DEFAULT_STATS_VIEW_SETTINGS, noEgoMode: true }}
+                embedded
+                dashboardTitle="No Ego Test – enabled"
+            />
+        );
+
+        // squad-summary block must be present
+        expect(screen.getByTestId('squad-summary')).toBeInTheDocument();
+
+        // MVP podium must be absent
+        expect(screen.queryByText('Offensive MVP')).toBeNull();
+        expect(screen.queryByText('Defensive MVP')).toBeNull();
+
+        // Top Skills section must be absent
+        expect(screen.queryByText('Top Outgoing Skills')).toBeNull();
+
+        // Player Comparison section must be absent
+        expect(screen.queryByText('Player Comparison')).toBeNull();
+    });
+
+    it('shows MVP podium + Top Skills + Player Comparison, and hides squad-summary when noEgoMode:false (control)', () => {
+        render(
+            <StatsView
+                logs={[]}
+                onBack={() => {}}
+                precomputedStats={baseStats as any}
+                statsViewSettings={{ ...DEFAULT_STATS_VIEW_SETTINGS, noEgoMode: false, showMvp: true, showTopStats: false }}
+                embedded
+                dashboardTitle="No Ego Test – disabled"
+            />
+        );
+
+        // squad-summary must NOT be present in normal mode
+        expect(screen.queryByTestId('squad-summary')).toBeNull();
+
+        // Top Skills section header must appear
+        expect(screen.getByText('Top Outgoing Skills')).toBeInTheDocument();
+
+        // Player Comparison section header must appear
+        expect(screen.getByText('Player Comparison')).toBeInTheDocument();
+    });
+});

--- a/src/renderer/__tests__/computeStatsAggregation.minParticipation.test.ts
+++ b/src/renderer/__tests__/computeStatsAggregation.minParticipation.test.ts
@@ -65,6 +65,7 @@ describe('computeStatsAggregation (min participation threshold)', () => {
                 stackingBoonBucketIntervalMs: 5000,
                 interruptMode: 'ccOnly' as const,
                 mvpBoonMetric: 'uptime' as const,
+                noEgoMode: false,
                 enabledTopStats: DEFAULT_ENABLED_TOP_STATS,
             }
         });
@@ -110,6 +111,7 @@ describe('computeStatsAggregation (min participation threshold)', () => {
                 stackingBoonBucketIntervalMs: 5000,
                 interruptMode: 'ccOnly' as const,
                 mvpBoonMetric: 'uptime' as const,
+                noEgoMode: false,
                 enabledTopStats: DEFAULT_ENABLED_TOP_STATS,
             }
         });
@@ -165,6 +167,7 @@ describe('computeStatsAggregation (min participation threshold)', () => {
                 stackingBoonBucketIntervalMs: 5000,
                 interruptMode: 'ccOnly' as const,
                 mvpBoonMetric: 'uptime' as const,
+                noEgoMode: false,
                 enabledTopStats: DEFAULT_ENABLED_TOP_STATS,
             }
         });

--- a/src/renderer/__tests__/computeStatsAggregation.topStatsLeaderboards.test.ts
+++ b/src/renderer/__tests__/computeStatsAggregation.topStatsLeaderboards.test.ts
@@ -60,6 +60,7 @@ const settings = {
     stackingBoonBucketIntervalMs: 5000,
     interruptMode: 'ccOnly' as const,
     mvpBoonMetric: 'uptime' as const,
+    noEgoMode: false,
     enabledTopStats: DEFAULT_ENABLED_TOP_STATS,
 };
 

--- a/src/renderer/__tests__/noEgoSettings.test.ts
+++ b/src/renderer/__tests__/noEgoSettings.test.ts
@@ -1,0 +1,8 @@
+import { describe, it, expect } from 'vitest';
+import { DEFAULT_STATS_VIEW_SETTINGS } from '../global.d';
+
+describe('noEgoMode setting', () => {
+  it('defaults to false', () => {
+    expect(DEFAULT_STATS_VIEW_SETTINGS.noEgoMode).toBe(false);
+  });
+});

--- a/src/renderer/global.d.ts
+++ b/src/renderer/global.d.ts
@@ -88,6 +88,10 @@ export interface IStatsViewSettings {
     enabledTopStats: string[];
     // How boons are scored in MVP weighting: 'average' (gen/sec), 'uptime' (%/avg stacks), or 'total' (total gen, "count").
     mvpBoonMetric: 'total' | 'average' | 'uptime';
+    // No Ego mode: removes ranking/MVP framing everywhere; shows squad
+    // average/deviation/needs-improvement outliers instead. Overrides
+    // showTopStats/showMvp when true.
+    noEgoMode: boolean;
 }
 
 export interface IDiscordEnemySplitSettings {
@@ -233,6 +237,7 @@ export const DEFAULT_STATS_VIEW_SETTINGS: IStatsViewSettings = {
     stackingBoonBucketIntervalMs: 5000,
     interruptMode: 'separate',
     mvpBoonMetric: 'uptime',
+    noEgoMode: false,
     // Keep in sync with DEFAULT_ENABLED_TOP_STATS in stats/topStatsCatalog.ts
     // (a unit test enforces this). Inlined as plain strings so this module does
     // not import the catalog, which pulls in lucide-react and breaks the

--- a/src/renderer/stats/components/MetricDistributionCard.tsx
+++ b/src/renderer/stats/components/MetricDistributionCard.tsx
@@ -1,14 +1,15 @@
 // src/renderer/stats/components/MetricDistributionCard.tsx
 import React from 'react';
-import { computeSquadStat, type SquadStatPlayer } from '../../../shared/squadStats';
+import { computeSquadStat, computeCohortStat, type SquadStatPlayer, type PlayerRole } from '../../../shared/squadStats';
 
 export interface MetricDistributionCardProps {
   title: string;
   accentColor: string;
   higherIsBetter: boolean;
-  players: SquadStatPlayer[];
+  players: Array<SquadStatPlayer & { role?: PlayerRole }>;
   formatValue: (n: number) => string;
   unit?: string;
+  roleAware?: boolean;
   renderProfessionIcon?: (
     profession: string,
     professionList: string[] | undefined,
@@ -23,12 +24,16 @@ export const MetricDistributionCard: React.FC<MetricDistributionCardProps> = ({
   players,
   formatValue,
   unit = '',
+  roleAware = false,
   renderProfessionIcon,
 }) => {
-  const s = computeSquadStat(players, higherIsBetter);
+  const cohort = roleAware ? computeCohortStat(players, higherIsBetter) : null;
+  const s = cohort ? cohort.squad : computeSquadStat(players, higherIsBetter);
+  const outliers = cohort ? cohort.needsImprovementOutliers : s.needsImprovementOutliers;
+  const outlierKeys = new Set(outliers.map((p) => p.account));
+  const roleOf = new Map(players.map((p) => [p.account, (p as { role?: PlayerRole }).role]));
   const range = s.max - s.min;
   const pos = (v: number) => (range > 0 ? ((v - s.min) / range) * 100 : 50);
-  const outlierKeys = new Set(s.needsImprovementOutliers.map((p) => p.account));
 
   // σ band as a fraction of the plotted range, centered on the mean
   const bandLeft = range > 0 ? Math.max(0, ((s.mean - s.stdDev - s.min) / range) * 100) : 0;
@@ -51,12 +56,23 @@ export const MetricDistributionCard: React.FC<MetricDistributionCardProps> = ({
 
       {/* Hard numbers */}
       <div className="flex items-end gap-4">
-        <div>
-          <div className="text-[10px] uppercase tracking-wide text-[color:var(--text-muted)]">Avg</div>
-          <div data-testid="metric-card-mean" className="text-2xl font-bold text-white">
-            {formatValue(s.mean)} <span className="text-sm font-normal text-[color:var(--text-secondary)]">{unit}</span>
+        {cohort && cohort.support && cohort.damage ? (
+          <div>
+            <div className="text-[10px] uppercase tracking-wide text-[color:var(--text-muted)]">Avg by role</div>
+            <div data-testid="metric-card-mean" className="text-lg font-bold text-white">
+              <span style={{ color: '#fb923c' }}>DPS {formatValue(cohort.damage.mean)}</span>
+              {' · '}
+              <span style={{ color: '#22d3ee' }}>Sup {formatValue(cohort.support.mean)}</span>
+            </div>
           </div>
-        </div>
+        ) : (
+          <div>
+            <div className="text-[10px] uppercase tracking-wide text-[color:var(--text-muted)]">Avg</div>
+            <div data-testid="metric-card-mean" className="text-2xl font-bold text-white">
+              {formatValue(s.mean)} <span className="text-sm font-normal text-[color:var(--text-secondary)]">{unit}</span>
+            </div>
+          </div>
+        )}
         <div>
           <div className="text-[10px] uppercase tracking-wide text-[color:var(--text-muted)]">σ Deviation</div>
           <div data-testid="metric-card-stddev" className="text-lg font-semibold text-[color:var(--text-secondary)]">
@@ -88,7 +104,13 @@ export const MetricDistributionCard: React.FC<MetricDistributionCardProps> = ({
             className="absolute top-1/2 -translate-y-1/2 -translate-x-1/2 w-2 h-2 rounded-full"
             style={{
               left: `${pos(p.value)}%`,
-              background: outlierKeys.has(p.account) ? accentColor : 'var(--text-muted)',
+              background: outlierKeys.has(p.account)
+                ? accentColor
+                : roleAware
+                  ? (roleOf.get(p.account) === 'support' ? '#22d3ee'
+                     : roleOf.get(p.account) === 'damage' ? '#fb923c'
+                     : 'var(--text-muted)')
+                  : 'var(--text-muted)',
               outline: outlierKeys.has(p.account) ? `1px solid ${accentColor}` : 'none',
             }}
           />
@@ -100,16 +122,21 @@ export const MetricDistributionCard: React.FC<MetricDistributionCardProps> = ({
         data-testid="metric-card-outliers"
         className="border-t border-[color:var(--border-subtle)] pt-2 text-xs text-[color:var(--text-secondary)]"
       >
-        {s.needsImprovementOutliers.length ? (
+        {outliers.length ? (
           <div className="flex flex-col gap-1">
             <div className="text-[10px] uppercase tracking-wide text-[color:var(--text-muted)]">
               Most room to improve
             </div>
-            {s.needsImprovementOutliers.map((p) => (
+            {outliers.map((p) => (
               <div key={p.account} className="flex items-center gap-2 min-w-0">
                 {renderProfessionIcon?.(p.profession || 'Unknown', p.professionList, 'w-4 h-4')}
                 <span className="truncate flex-1">{p.account}</span>
-                <span className="font-mono text-[color:var(--text-secondary)]">{formatValue(p.value)}</span>
+                <span className="font-mono text-[color:var(--text-secondary)]">
+                  {formatValue(p.value)}
+                  {'sigmaGap' in p && typeof (p as { sigmaGap?: number }).sigmaGap === 'number'
+                    ? ` · −${(p as { sigmaGap: number }).sigmaGap.toFixed(1)}σ`
+                    : ''}
+                </span>
               </div>
             ))}
           </div>

--- a/src/renderer/stats/components/MetricDistributionCard.tsx
+++ b/src/renderer/stats/components/MetricDistributionCard.tsx
@@ -99,24 +99,25 @@ export const MetricDistributionCard: React.FC<MetricDistributionCardProps> = ({
           className="absolute top-0 bottom-0 w-px"
           style={{ left: `${pos(s.mean)}%`, background: 'var(--border-hover)' }}
         />
-        {s.players.map((p) => (
-          <div
-            key={p.account}
-            title={`${p.account}: ${formatValue(p.value)}`}
-            className="absolute top-1/2 -translate-y-1/2 -translate-x-1/2 w-2 h-2 rounded-full"
-            style={{
-              left: `${pos(p.value)}%`,
-              background: outlierKeys.has(p.account)
-                ? accentColor
-                : roleAware
-                  ? (roleOf.get(p.account) === 'support' ? '#22d3ee'
-                     : roleOf.get(p.account) === 'damage' ? '#fb923c'
-                     : 'var(--text-muted)')
-                  : 'var(--text-muted)',
-              outline: outlierKeys.has(p.account) ? `1px solid ${accentColor}` : 'none',
-            }}
-          />
-        ))}
+        {s.players.map((p) => {
+          const isOutlier = outlierKeys.has(p.account);
+          const roleColor = roleOf.get(p.account) === 'support' ? '#22d3ee'
+            : roleOf.get(p.account) === 'damage' ? '#fb923c'
+            : 'var(--text-muted)';
+          const fill = roleAware ? roleColor : (isOutlier ? accentColor : 'var(--text-muted)');
+          return (
+            <div
+              key={p.account}
+              title={`${p.account}: ${formatValue(p.value)}`}
+              className={`absolute top-1/2 -translate-y-1/2 -translate-x-1/2 rounded-full ${isOutlier ? 'w-3 h-3' : 'w-2 h-2'}`}
+              style={{
+                left: `${pos(p.value)}%`,
+                background: fill,
+                outline: isOutlier ? `2px solid ${accentColor}` : 'none',
+              }}
+            />
+          );
+        })}
       </div>
 
       {/* Needs-improvement callouts (neutral language, low/bad end only) */}

--- a/src/renderer/stats/components/MetricDistributionCard.tsx
+++ b/src/renderer/stats/components/MetricDistributionCard.tsx
@@ -10,6 +10,7 @@ export interface MetricDistributionCardProps {
   formatValue: (n: number) => string;
   unit?: string;
   roleAware?: boolean;
+  large?: boolean;
   renderProfessionIcon?: (
     profession: string,
     professionList: string[] | undefined,
@@ -25,6 +26,7 @@ export const MetricDistributionCard: React.FC<MetricDistributionCardProps> = ({
   formatValue,
   unit = '',
   roleAware = false,
+  large = false,
   renderProfessionIcon,
 }) => {
   const cohort = roleAware ? computeCohortStat(players, higherIsBetter) : null;
@@ -68,7 +70,7 @@ export const MetricDistributionCard: React.FC<MetricDistributionCardProps> = ({
         ) : (
           <div>
             <div className="text-[10px] uppercase tracking-wide text-[color:var(--text-muted)]">Avg</div>
-            <div data-testid="metric-card-mean" className="text-2xl font-bold text-white">
+            <div data-testid="metric-card-mean" className={`font-bold text-white ${large ? 'text-3xl' : 'text-2xl'}`}>
               {formatValue(s.mean)} <span className="text-sm font-normal text-[color:var(--text-secondary)]">{unit}</span>
             </div>
           </div>
@@ -88,7 +90,7 @@ export const MetricDistributionCard: React.FC<MetricDistributionCardProps> = ({
       </div>
 
       {/* Dot-plot: every player a neutral dot; σ band shaded; mean line. */}
-      <div className="relative h-8 mt-1">
+      <div data-testid="metric-card-plot" className={`relative ${large ? 'h-14' : 'h-8'} mt-1`}>
         <div
           className="absolute top-1/2 -translate-y-1/2 h-2 rounded-full"
           style={{ left: `${bandLeft}%`, width: `${Math.max(0, bandRight - bandLeft)}%`, background: `${accentColor}22` }}

--- a/src/renderer/stats/components/MetricDistributionCard.tsx
+++ b/src/renderer/stats/components/MetricDistributionCard.tsx
@@ -1,0 +1,122 @@
+// src/renderer/stats/components/MetricDistributionCard.tsx
+import React from 'react';
+import { computeSquadStat, type SquadStatPlayer } from '../../../shared/squadStats';
+
+export interface MetricDistributionCardProps {
+  title: string;
+  accentColor: string;
+  higherIsBetter: boolean;
+  players: SquadStatPlayer[];
+  formatValue: (n: number) => string;
+  unit?: string;
+  renderProfessionIcon?: (
+    profession: string,
+    professionList: string[] | undefined,
+    className: string,
+  ) => React.ReactNode;
+}
+
+export const MetricDistributionCard: React.FC<MetricDistributionCardProps> = ({
+  title,
+  accentColor,
+  higherIsBetter,
+  players,
+  formatValue,
+  unit = '',
+  renderProfessionIcon,
+}) => {
+  const s = computeSquadStat(players, higherIsBetter);
+  const range = s.max - s.min;
+  const pos = (v: number) => (range > 0 ? ((v - s.min) / range) * 100 : 50);
+  const outlierKeys = new Set(s.needsImprovementOutliers.map((p) => p.account));
+
+  // σ band as a fraction of the plotted range, centered on the mean
+  const bandLeft = range > 0 ? Math.max(0, ((s.mean - s.stdDev - s.min) / range) * 100) : 0;
+  const bandRight = range > 0 ? Math.min(100, ((s.mean + s.stdDev - s.min) / range) * 100) : 100;
+
+  return (
+    <div
+      className="border rounded-[var(--radius-md)] p-4 flex flex-col gap-3"
+      style={{ borderColor: 'var(--border-default)' }}
+    >
+      <div className="flex items-baseline justify-between gap-2">
+        <div
+          className="text-xs font-bold uppercase tracking-wider truncate"
+          style={{ color: 'var(--text-secondary)' }}
+        >
+          {title}
+        </div>
+        <div className="text-xs text-[color:var(--text-muted)]">{s.count} players</div>
+      </div>
+
+      {/* Hard numbers */}
+      <div className="flex items-end gap-4">
+        <div>
+          <div className="text-[10px] uppercase tracking-wide text-[color:var(--text-muted)]">Avg</div>
+          <div data-testid="metric-card-mean" className="text-2xl font-bold text-white">
+            {formatValue(s.mean)} <span className="text-sm font-normal text-[color:var(--text-secondary)]">{unit}</span>
+          </div>
+        </div>
+        <div>
+          <div className="text-[10px] uppercase tracking-wide text-[color:var(--text-muted)]">σ Deviation</div>
+          <div data-testid="metric-card-stddev" className="text-lg font-semibold text-[color:var(--text-secondary)]">
+            {formatValue(s.stdDev)}
+          </div>
+        </div>
+        <div>
+          <div className="text-[10px] uppercase tracking-wide text-[color:var(--text-muted)]">Range</div>
+          <div className="text-sm text-[color:var(--text-secondary)]">
+            {formatValue(s.min)}–{formatValue(s.max)}
+          </div>
+        </div>
+      </div>
+
+      {/* Dot-plot: every player a neutral dot; σ band shaded; mean line. */}
+      <div className="relative h-8 mt-1">
+        <div
+          className="absolute top-1/2 -translate-y-1/2 h-2 rounded-full"
+          style={{ left: `${bandLeft}%`, width: `${Math.max(0, bandRight - bandLeft)}%`, background: `${accentColor}22` }}
+        />
+        <div
+          className="absolute top-0 bottom-0 w-px"
+          style={{ left: `${pos(s.mean)}%`, background: 'var(--border-hover)' }}
+        />
+        {s.players.map((p) => (
+          <div
+            key={p.account}
+            title={`${p.account}: ${formatValue(p.value)}`}
+            className="absolute top-1/2 -translate-y-1/2 -translate-x-1/2 w-2 h-2 rounded-full"
+            style={{
+              left: `${pos(p.value)}%`,
+              background: outlierKeys.has(p.account) ? accentColor : 'var(--text-muted)',
+              outline: outlierKeys.has(p.account) ? `1px solid ${accentColor}` : 'none',
+            }}
+          />
+        ))}
+      </div>
+
+      {/* Needs-improvement callouts (neutral language, low/bad end only) */}
+      <div
+        data-testid="metric-card-outliers"
+        className="border-t border-[color:var(--border-subtle)] pt-2 text-xs text-[color:var(--text-secondary)]"
+      >
+        {s.needsImprovementOutliers.length ? (
+          <div className="flex flex-col gap-1">
+            <div className="text-[10px] uppercase tracking-wide text-[color:var(--text-muted)]">
+              Most room to improve
+            </div>
+            {s.needsImprovementOutliers.map((p) => (
+              <div key={p.account} className="flex items-center gap-2 min-w-0">
+                {renderProfessionIcon?.(p.profession || 'Unknown', p.professionList, 'w-4 h-4')}
+                <span className="truncate flex-1">{p.account}</span>
+                <span className="font-mono text-[color:var(--text-secondary)]">{formatValue(p.value)}</span>
+              </div>
+            ))}
+          </div>
+        ) : (
+          <span className="text-[color:var(--text-muted)]">Squad is consistent here.</span>
+        )}
+      </div>
+    </div>
+  );
+};

--- a/src/renderer/stats/components/__tests__/MetricDistributionCard.large.test.tsx
+++ b/src/renderer/stats/components/__tests__/MetricDistributionCard.large.test.tsx
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/react';
+import { MetricDistributionCard } from '../MetricDistributionCard';
+
+const players = (vals: number[]) =>
+  vals.map((value, i) => ({ account: `P${i}`, value, profession: 'Guardian' }));
+
+describe('MetricDistributionCard — large mode', () => {
+  it('renders a taller dot-plot when large is set', () => {
+    const small = render(
+      <MetricDistributionCard title="Cleanses" accentColor="#60a5fa" higherIsBetter
+        players={players([2, 4, 6, 8])} formatValue={(n) => String(n)} />,
+    );
+    const smallPlot = small.container.querySelector('[data-testid="metric-card-plot"]');
+    expect(smallPlot?.className).toContain('h-8');
+
+    const big = render(
+      <MetricDistributionCard title="Cleanses" accentColor="#60a5fa" higherIsBetter large
+        players={players([2, 4, 6, 8])} formatValue={(n) => String(n)} />,
+    );
+    const bigPlot = big.container.querySelector('[data-testid="metric-card-plot"]');
+    expect(bigPlot?.className).toContain('h-14');
+  });
+});

--- a/src/renderer/stats/components/__tests__/MetricDistributionCard.roleaware.test.tsx
+++ b/src/renderer/stats/components/__tests__/MetricDistributionCard.roleaware.test.tsx
@@ -1,0 +1,76 @@
+// src/renderer/stats/components/__tests__/MetricDistributionCard.roleaware.test.tsx
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MetricDistributionCard } from '../MetricDistributionCard';
+
+const downContrib = [
+  { account: 'D1', value: 40, role: 'damage' as const },
+  { account: 'D2', value: 42, role: 'damage' as const },
+  { account: 'D3', value: 44, role: 'damage' as const },
+  { account: 'D4', value: 46, role: 'damage' as const },
+  { account: 'D5', value: 48, role: 'damage' as const },
+  { account: 'Healer1', value: 3, role: 'support' as const },
+  { account: 'Healer2', value: 4, role: 'support' as const },
+  { account: 'Healer3', value: 5, role: 'support' as const },
+  { account: 'Healer4', value: 4, role: 'support' as const },
+];
+
+describe('MetricDistributionCard — role-aware', () => {
+  it('does not flag a support player on a damage metric', () => {
+    render(
+      <MetricDistributionCard
+        title="Down Contribution"
+        accentColor="#f87171"
+        higherIsBetter
+        roleAware
+        players={downContrib}
+        formatValue={(n) => String(Math.round(n))}
+      />,
+    );
+    const outliers = screen.getByTestId('metric-card-outliers');
+    expect(outliers).not.toHaveTextContent('Healer1');
+    expect(outliers).not.toHaveTextContent('Healer2');
+  });
+
+  it('shows the σ gap on a flagged outlier row', () => {
+    const squad = [
+      { account: 'S1', value: 100, role: 'support' as const },
+      { account: 'S2', value: 100, role: 'support' as const },
+      { account: 'S3', value: 100, role: 'support' as const },
+      { account: 'SLow', value: 0, role: 'support' as const },
+    ];
+    render(
+      <MetricDistributionCard
+        title="Cleanses"
+        accentColor="#60a5fa"
+        higherIsBetter
+        roleAware
+        players={squad}
+        formatValue={(n) => String(Math.round(n))}
+      />,
+    );
+    const outliers = screen.getByTestId('metric-card-outliers');
+    expect(outliers).toHaveTextContent('SLow');
+    expect(outliers.textContent || '').toMatch(/σ/); // gap rendered with a sigma marker
+  });
+
+  it('falls back to current behavior when roleAware is false', () => {
+    // With a single squad-wide baseline, the lone low player IS flagged.
+    const squad = [
+      { account: 'A', value: 100 },
+      { account: 'B', value: 100 },
+      { account: 'C', value: 100 },
+      { account: 'Low', value: 0 },
+    ];
+    render(
+      <MetricDistributionCard
+        title="Cleanses"
+        accentColor="#60a5fa"
+        higherIsBetter
+        players={squad}
+        formatValue={(n) => String(Math.round(n))}
+      />,
+    );
+    expect(screen.getByTestId('metric-card-outliers')).toHaveTextContent('Low');
+  });
+});

--- a/src/renderer/stats/components/__tests__/MetricDistributionCard.roleaware.test.tsx
+++ b/src/renderer/stats/components/__tests__/MetricDistributionCard.roleaware.test.tsx
@@ -54,6 +54,27 @@ describe('MetricDistributionCard — role-aware', () => {
     expect(outliers.textContent || '').toMatch(/σ/); // gap rendered with a sigma marker
   });
 
+  it('keeps role color on a flagged outlier dot (role-aware)', () => {
+    const squad = [
+      { account: 'S1', value: 100, role: 'support' as const },
+      { account: 'S2', value: 100, role: 'support' as const },
+      { account: 'S3', value: 100, role: 'support' as const },
+      { account: 'SLow', value: 0, role: 'support' as const },
+    ];
+    const { container } = render(
+      <MetricDistributionCard
+        title="Cleanses" accentColor="#60a5fa" higherIsBetter roleAware
+        players={squad} formatValue={(n) => String(Math.round(n))} />,
+    );
+    // The outlier dot for SLow is identified by its title attribute.
+    const dot = container.querySelector('[title^="SLow:"]') as HTMLElement;
+    expect(dot).toBeTruthy();
+    // Support role color is cyan (#22d3ee); it must remain the fill even though SLow is an outlier.
+    expect(dot.style.background).toMatch(/34,\s*211,\s*238|#22d3ee/i);
+    // And it is marked as an outlier via an outline.
+    expect(dot.style.outline).toContain('solid');
+  });
+
   it('falls back to current behavior when roleAware is false', () => {
     // With a single squad-wide baseline, the lone low player IS flagged.
     const squad = [

--- a/src/renderer/stats/components/__tests__/MetricDistributionCard.test.tsx
+++ b/src/renderer/stats/components/__tests__/MetricDistributionCard.test.tsx
@@ -1,0 +1,53 @@
+// src/renderer/stats/components/__tests__/MetricDistributionCard.test.tsx
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MetricDistributionCard } from '../MetricDistributionCard';
+
+const players = (vals: number[]) =>
+  vals.map((value, i) => ({ account: `Player${i}`, value, profession: 'Guardian' }));
+
+describe('MetricDistributionCard', () => {
+  it('renders title, average and deviation hard numbers', () => {
+    render(
+      <MetricDistributionCard
+        title="Cleanses"
+        accentColor="#60a5fa"
+        higherIsBetter
+        players={players([2, 4, 4, 4, 5, 5, 7, 9])}
+        formatValue={(n) => String(Math.round(n))}
+      />,
+    );
+    expect(screen.getByText('Cleanses')).toBeInTheDocument();
+    expect(screen.getByTestId('metric-card-mean')).toHaveTextContent('5');
+    expect(screen.getByTestId('metric-card-stddev')).toHaveTextContent('2');
+  });
+
+  it('names needs-improvement outliers and never celebrates the high end', () => {
+    render(
+      <MetricDistributionCard
+        title="Cleanses"
+        accentColor="#60a5fa"
+        higherIsBetter
+        players={players([100, 100, 100, 100, 0]).map((p, i) => ({ ...p, account: i === 4 ? 'LowGuy' : p.account }))}
+        formatValue={(n) => String(Math.round(n))}
+      />,
+    );
+    const callouts = screen.getByTestId('metric-card-outliers');
+    expect(callouts).toHaveTextContent('LowGuy');
+    // No "MVP"/"top"/crown language anywhere
+    expect(screen.queryByText(/MVP|top performer|#1/i)).toBeNull();
+  });
+
+  it('shows a quiet consistent-squad note when there are no outliers', () => {
+    render(
+      <MetricDistributionCard
+        title="Cleanses"
+        accentColor="#60a5fa"
+        higherIsBetter
+        players={players([5, 5, 5])}
+        formatValue={(n) => String(Math.round(n))}
+      />,
+    );
+    expect(screen.getByTestId('metric-card-outliers')).toHaveTextContent(/consistent/i);
+  });
+});

--- a/src/renderer/stats/components/__tests__/MetricDistributionCard.test.tsx
+++ b/src/renderer/stats/components/__tests__/MetricDistributionCard.test.tsx
@@ -35,7 +35,7 @@ describe('MetricDistributionCard', () => {
     const callouts = screen.getByTestId('metric-card-outliers');
     expect(callouts).toHaveTextContent('LowGuy');
     // No "MVP"/"top"/crown language anywhere
-    expect(screen.queryByText(/MVP|top performer|#1/i)).toBeNull();
+    expect(screen.queryByText(/\bMVP\b|top performer|#1|crown|\bbest\b|elite|winner|podium|champion/i)).toBeNull();
   });
 
   it('shows a quiet consistent-squad note when there are no outliers', () => {

--- a/src/renderer/stats/sections/DefenseSection.tsx
+++ b/src/renderer/stats/sections/DefenseSection.tsx
@@ -82,6 +82,13 @@ export const DefenseSection = ({
 
     // ── No Ego mode: one MetricDistributionCard per DEFENSE_METRICS entry ──
     if (noEgoMode && stats.defensePlayers.length > 0) {
+        const roleByAccount = new Map<string, 'support' | 'damage'>(
+          (Array.isArray((stats as any).roleClassifications) ? (stats as any).roleClassifications : [])
+            .filter((r: any) => r && (r.role === 'support' || r.role === 'damage'))
+            .map((r: any) => [String(r.account), r.role as 'support' | 'damage']),
+        );
+        const roleOf = (account: string): 'support' | 'damage' | undefined =>
+          roleByAccount.get(account) ?? roleByAccount.get(String(account).split('::')[0]);
         const totalSeconds = (row: any) => Math.max(1, (row.activeMs || 0) / 1000);
         const resolvedValue = (row: any, metricEntry: typeof DEFENSE_METRICS[number]) => {
             const total = row.defenseTotals?.[metricEntry.id] || 0;
@@ -106,6 +113,7 @@ export const DefenseSection = ({
                             value: resolvedValue(row, metricEntry),
                             profession: row.profession,
                             professionList: row.professionList,
+                            role: roleOf(row.account),
                         }));
                         const higherIsBetter = DEFENSE_HIGHER_IS_BETTER.has(metricEntry.id);
                         const makeFormatValue = () => (val: number) => {
@@ -123,6 +131,7 @@ export const DefenseSection = ({
                                 players={players}
                                 formatValue={makeFormatValue()}
                                 renderProfessionIcon={renderProfessionIcon}
+                                roleAware
                             />
                         );
                     })}

--- a/src/renderer/stats/sections/DefenseSection.tsx
+++ b/src/renderer/stats/sections/DefenseSection.tsx
@@ -116,11 +116,24 @@ export const DefenseSection = ({
         };
         return (
             <div>
-                <div className="flex flex-wrap items-center gap-2 mb-3.5">
-                    <Shield className="w-4 h-4 shrink-0" style={{ color: 'var(--section-defense)' }} />
-                    <h3 className="text-[11px] font-semibold uppercase tracking-[0.05em]" style={{ color: 'var(--text-primary)' }}>
-                        Defense Detailed
-                    </h3>
+                <div className="flex flex-wrap items-center justify-between gap-2 mb-3.5">
+                    <div className="flex items-center gap-2">
+                        <Shield className="w-4 h-4 shrink-0" style={{ color: 'var(--section-defense)' }} />
+                        <h3 className="text-[11px] font-semibold uppercase tracking-[0.05em]" style={{ color: 'var(--text-primary)' }}>
+                            Defense Detailed
+                        </h3>
+                    </div>
+                    <PillToggleGroup
+                        value={defenseViewMode}
+                        onChange={setDefenseViewMode}
+                        options={[
+                            { value: 'total', label: 'Total' },
+                            { value: 'per1s', label: 'Stat/1s' },
+                            { value: 'per60s', label: 'Stat/60s' }
+                        ]}
+                        activeClassName="bg-[var(--accent-bg-strong)] text-[color:var(--brand-primary)] border border-[color:var(--accent-border)]"
+                        inactiveClassName="text-[color:var(--text-secondary)]"
+                    />
                 </div>
                 <StatsTableLayout
                     expanded={false}

--- a/src/renderer/stats/sections/DefenseSection.tsx
+++ b/src/renderer/stats/sections/DefenseSection.tsx
@@ -88,6 +88,7 @@ export const DefenseSection = ({
                 icon={<Shield className="w-4 h-4 shrink-0" style={{ color: 'var(--section-defense)' }} />}
                 accentColor="var(--section-defense)"
                 sidebarLabel="Defensive Tabs"
+                keyPrefix="noego-defense"
                 metrics={DEFENSE_METRICS}
                 filteredMetrics={filteredDefenseMetrics}
                 players={stats.defensePlayers}

--- a/src/renderer/stats/sections/DefenseSection.tsx
+++ b/src/renderer/stats/sections/DefenseSection.tsx
@@ -10,6 +10,7 @@ import { StatsTableShell } from '../ui/StatsTableShell';
 import { useStatsSharedContext } from '../StatsViewContext';
 import { DEFENSE_METRICS } from '../statsMetrics';
 import { MetricDistributionCard } from '../components/MetricDistributionCard';
+import type { RoleClassificationEntry } from '../statsTypes';
 
 // For defense, lower damage taken / fewer downs = better; higher blocks/evades = better
 const DEFENSE_HIGHER_IS_BETTER = new Set([
@@ -83,9 +84,9 @@ export const DefenseSection = ({
     // ── No Ego mode: sidebar + one large MetricDistributionCard for active metric ──
     if (noEgoMode && stats.defensePlayers.length > 0) {
         const roleByAccount = new Map<string, 'support' | 'damage'>(
-          (Array.isArray((stats as any).roleClassifications) ? (stats as any).roleClassifications : [])
-            .filter((r: any) => r && (r.role === 'support' || r.role === 'damage'))
-            .map((r: any) => [String(r.account), r.role as 'support' | 'damage']),
+          ((stats.roleClassifications as RoleClassificationEntry[] | undefined) ?? [])
+            .filter((r): r is RoleClassificationEntry => !!r && (r.role === 'support' || r.role === 'damage'))
+            .map((r) => [String(r.account), r.role] as [string, 'support' | 'damage']),
         );
         const roleOf = (account: string): 'support' | 'damage' | undefined =>
           roleByAccount.get(account) ?? roleByAccount.get(String(account).split('::')[0]);

--- a/src/renderer/stats/sections/DefenseSection.tsx
+++ b/src/renderer/stats/sections/DefenseSection.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { useMetricSectionState } from '../hooks/useMetricSectionState';
-import { Maximize2, X, Columns, Users, Shield, ChevronDown, ChevronRight } from 'lucide-react';
+import { Maximize2, X, Columns, Users, Shield } from 'lucide-react';
 import { ColumnFilterDropdown } from '../ui/ColumnFilterDropdown';
 import { SearchSelectDropdown, SearchSelectOption } from '../ui/SearchSelectDropdown';
 import { DenseStatsTable } from '../ui/DenseStatsTable';
@@ -9,8 +9,7 @@ import { StatsTableLayout } from '../ui/StatsTableLayout';
 import { StatsTableShell } from '../ui/StatsTableShell';
 import { useStatsSharedContext } from '../StatsViewContext';
 import { DEFENSE_METRICS } from '../statsMetrics';
-import { MetricDistributionCard } from '../components/MetricDistributionCard';
-import type { RoleClassificationEntry } from '../statsTypes';
+import { NoEgoMetricSection } from './NoEgoMetricSection';
 
 // For defense, lower damage taken / fewer downs = better; higher blocks/evades = better
 const DEFENSE_HIGHER_IS_BETTER = new Set([
@@ -83,177 +82,35 @@ export const DefenseSection = ({
 
     // ── No Ego mode: sidebar + one large MetricDistributionCard for active metric ──
     if (noEgoMode && stats.defensePlayers.length > 0) {
-        const roleByAccount = new Map<string, 'support' | 'damage'>(
-          ((stats.roleClassifications as RoleClassificationEntry[] | undefined) ?? [])
-            .filter((r): r is RoleClassificationEntry => !!r && (r.role === 'support' || r.role === 'damage'))
-            .map((r) => [String(r.account), r.role] as [string, 'support' | 'damage']),
-        );
-        const roleOf = (account: string): 'support' | 'damage' | undefined =>
-          roleByAccount.get(account) ?? roleByAccount.get(String(account).split('::')[0]);
-        const totalSeconds = (row: any) => Math.max(1, (row.activeMs || 0) / 1000);
-        const resolvedValue = (row: any, metricEntry: typeof DEFENSE_METRICS[number]) => {
-            const total = row.defenseTotals?.[metricEntry.id] || 0;
-            const isPercent = (metricEntry as any).isPercent;
-            if (isPercent) return total;
-            if (defenseViewMode === 'per1s') return total / totalSeconds(row);
-            if (defenseViewMode === 'per60s') return (total * 60) / totalSeconds(row);
-            return total;
-        };
-        const activeMetric = DEFENSE_METRICS.find((e) => e.id === activeDefenseStat) || DEFENSE_METRICS[0];
-        const activePlayers = stats.defensePlayers.map((row: any) => ({
-            account: row.account,
-            value: resolvedValue(row, activeMetric),
-            profession: row.profession,
-            professionList: row.professionList,
-            role: roleOf(row.account),
-        }));
-        const activeHigherIsBetter = DEFENSE_HIGHER_IS_BETTER.has(activeMetric.id);
-        const activeFormatValue = (val: number) => {
-            const isPercent = (activeMetric as any).isPercent;
-            const decimals = roundCountStats && !isPercent && defenseViewMode === 'total' ? 0 : 2;
-            const formatted = formatWithCommas(val, decimals);
-            return isPercent ? `${formatted}%` : formatted;
-        };
         return (
-            <div>
-                <div className="flex flex-wrap items-center justify-between gap-2 mb-3.5">
-                    <div className="flex items-center gap-2">
-                        <Shield className="w-4 h-4 shrink-0" style={{ color: 'var(--section-defense)' }} />
-                        <h3 className="text-[11px] font-semibold uppercase tracking-[0.05em]" style={{ color: 'var(--text-primary)' }}>
-                            Defense Detailed
-                        </h3>
-                    </div>
-                    <PillToggleGroup
-                        value={defenseViewMode}
-                        onChange={setDefenseViewMode}
-                        options={[
-                            { value: 'total', label: 'Total' },
-                            { value: 'per1s', label: 'Stat/1s' },
-                            { value: 'per60s', label: 'Stat/60s' }
-                        ]}
-                        activeClassName="bg-[var(--accent-bg-strong)] text-[color:var(--brand-primary)] border border-[color:var(--accent-border)]"
-                        inactiveClassName="text-[color:var(--text-secondary)]"
-                    />
-                </div>
-                <StatsTableLayout
-                    expanded={false}
-                    sidebarClassName="pr-3 flex flex-col overflow-y-auto"
-                    sidebarStyle={undefined}
-                    contentClassName="overflow-hidden"
-                    contentStyle={undefined}
-                    sidebar={
-                        <>
-                            <div className="text-xs uppercase tracking-widest mb-2" style={{ color: 'var(--text-secondary)' }}>Defensive Tabs</div>
-                            <input
-                                value={defenseSearch}
-                                onChange={(e) => setDefenseSearch(e.target.value)}
-                                placeholder="Search..."
-                                className="w-full px-2 py-1 text-xs focus:outline-none mb-2"
-                                style={{ background: 'transparent', borderBottom: '1px solid var(--border-subtle)', color: 'var(--text-primary)' }}
-                            />
-                            <div className={sidebarListClass}>
-                                {filteredDefenseMetrics.map((metric) => (
-                                    <button
-                                        key={metric.id}
-                                        onClick={() => setActiveDefenseStat(metric.id)}
-                                        className={`w-full text-left px-3 py-1.5 rounded-[var(--radius-md)] text-xs transition-colors ${activeDefenseStat === metric.id
-                                            ? 'bg-[var(--accent-bg-strong)] text-[color:var(--brand-primary)] font-semibold'
-                                            : 'hover:bg-[var(--bg-hover)] hover:text-[color:var(--text-primary)]'
-                                            }`}
-                                        style={activeDefenseStat !== metric.id ? { color: 'var(--text-secondary)' } : undefined}
-                                    >
-                                        {metric.label}
-                                    </button>
-                                ))}
-                            </div>
-                        </>
-                    }
-                    content={
-                        <div className="flex flex-col gap-4">
-                            <MetricDistributionCard
-                                large
-                                roleAware
-                                title={activeMetric.label}
-                                accentColor="var(--section-defense)"
-                                higherIsBetter={activeHigherIsBetter}
-                                players={activePlayers}
-                                formatValue={activeFormatValue}
-                                renderProfessionIcon={renderProfessionIcon}
-                            />
-                            <div>
-                                <button
-                                    type="button"
-                                    aria-expanded={detailOpen}
-                                    onClick={() => setDetailOpen((v) => !v)}
-                                    className="flex items-center gap-1 text-xs px-3 py-1.5 rounded-[var(--radius-md)]"
-                                    style={{ border: '1px solid var(--border-default)', color: 'var(--text-secondary)', background: 'var(--bg-hover)' }}
-                                >
-                                    {detailOpen ? <ChevronDown className="w-3 h-3" /> : <ChevronRight className="w-3 h-3" />}
-                                    Per-player detail
-                                </button>
-                                {detailOpen && (
-                                    <div className="mt-3">
-                                        {(() => {
-                                            const metric = activeMetric;
-                                            const tsec = (row: any) => Math.max(1, (row.activeMs || 0) / 1000);
-                                            const sourceRows = [...stats.defensePlayers];
-                                            const effectiveRows = isMinionDamageMetric(metric.id)
-                                                ? getMinionRows(sourceRows, minionDamageMode)
-                                                : sourceRows;
-                                            const rows = [...effectiveRows]
-                                                .map((row: any) => ({
-                                                    ...row,
-                                                    total: row.defenseTotals?.[metric.id] || 0,
-                                                    per1s: (row.defenseTotals?.[metric.id] || 0) / tsec(row),
-                                                    per60s: ((row.defenseTotals?.[metric.id] || 0) * 60) / tsec(row)
-                                                }))
-                                                .sort((a, b) => {
-                                                    const aVal = Number(defenseViewMode === 'total' ? a.total : defenseViewMode === 'per1s' ? a.per1s : a.per60s);
-                                                    const bVal = Number(defenseViewMode === 'total' ? b.total : defenseViewMode === 'per1s' ? b.per1s : b.per60s);
-                                                    return bVal - aVal || a.account.localeCompare(b.account);
-                                                });
-                                            return (
-                                                <StatsTableShell
-                                                    expanded={false}
-                                                    animationKey={`noego-defense-${activeDefenseStat}-${defenseViewMode}`}
-                                                    header={null}
-                                                    columns={
-                                                        <div className="grid grid-cols-[1.5fr_1fr_0.9fr] text-[10px] uppercase tracking-widest text-[color:var(--text-secondary)] px-3 py-2 border-b border-[color:var(--border-default)]">
-                                                            <div>Player</div>
-                                                            <div className="text-right">
-                                                                {defenseViewMode === 'total' ? 'Total' : defenseViewMode === 'per1s' ? 'Stat/1s' : 'Stat/60s'}
-                                                            </div>
-                                                            <div className="text-right">Fight Time</div>
-                                                        </div>
-                                                    }
-                                                    rows={
-                                                        <>
-                                                            {rows.map((row: any, idx: number) => (
-                                                                <div key={`noego-defense-${metric.id}-${row.account}-${idx}`} className="grid grid-cols-[1.5fr_1fr_0.9fr] px-3 py-2 text-xs border-b border-[color:var(--border-subtle)] hover:bg-[var(--bg-hover)]" style={{ color: 'var(--text-primary)' }}>
-                                                                    <div className="flex items-center gap-2 min-w-0">
-                                                                        {renderProfessionIcon(row.profession, row.professionList, 'w-4 h-4')}
-                                                                        <span className="truncate">{row.account}</span>
-                                                                    </div>
-                                                                    <div className="text-right font-mono" style={{ color: 'var(--text-secondary)' }}>
-                                                                        {formatWithCommas(defenseViewMode === 'total' ? row.total : defenseViewMode === 'per1s' ? row.per1s : row.per60s, roundCountStats && defenseViewMode === 'total' ? 0 : 2)}
-                                                                    </div>
-                                                                    <div className="text-right font-mono" style={{ color: 'var(--text-secondary)' }}>
-                                                                        {row.activeMs ? `${(row.activeMs / 1000).toFixed(1)}s` : '-'}
-                                                                    </div>
-                                                                </div>
-                                                            ))}
-                                                        </>
-                                                    }
-                                                />
-                                            );
-                                        })()}
-                                    </div>
-                                )}
-                            </div>
-                        </div>
-                    }
-                />
-            </div>
+            <NoEgoMetricSection
+                title="Defense Detailed"
+                icon={<Shield className="w-4 h-4 shrink-0" style={{ color: 'var(--section-defense)' }} />}
+                accentColor="var(--section-defense)"
+                sidebarLabel="Defensive Tabs"
+                metrics={DEFENSE_METRICS}
+                filteredMetrics={filteredDefenseMetrics}
+                players={stats.defensePlayers}
+                roleClassifications={stats.roleClassifications}
+                activeStatId={activeDefenseStat}
+                setActiveStatId={setActiveDefenseStat}
+                search={defenseSearch}
+                setSearch={setDefenseSearch}
+                viewMode={defenseViewMode}
+                setViewMode={setDefenseViewMode}
+                detailOpen={detailOpen}
+                setDetailOpen={setDetailOpen}
+                higherIsBetter={(m) => DEFENSE_HIGHER_IS_BETTER.has(m.id)}
+                resolveTotal={(row, m) => row.defenseTotals?.[m.id] || 0}
+                isRateOrPercent={(m) => !!(m as any).isPercent}
+                fightTimeMs={(row) => row.activeMs || 0}
+                formatValue={(m, val) => {
+                    const isPercent = (m as any).isPercent;
+                    const decimals = roundCountStats && !isPercent && defenseViewMode === 'total' ? 0 : 2;
+                    const formatted = formatWithCommas(val, decimals);
+                    return isPercent ? `${formatted}%` : formatted;
+                }}
+            />
         );
     }
 

--- a/src/renderer/stats/sections/DefenseSection.tsx
+++ b/src/renderer/stats/sections/DefenseSection.tsx
@@ -80,7 +80,7 @@ export const DefenseSection = ({
         });
     };
 
-    // ── No Ego mode: one MetricDistributionCard per DEFENSE_METRICS entry ──
+    // ── No Ego mode: sidebar + one large MetricDistributionCard for active metric ──
     if (noEgoMode && stats.defensePlayers.length > 0) {
         const roleByAccount = new Map<string, 'support' | 'damage'>(
           (Array.isArray((stats as any).roleClassifications) ? (stats as any).roleClassifications : [])
@@ -98,6 +98,21 @@ export const DefenseSection = ({
             if (defenseViewMode === 'per60s') return (total * 60) / totalSeconds(row);
             return total;
         };
+        const activeMetric = DEFENSE_METRICS.find((e) => e.id === activeDefenseStat) || DEFENSE_METRICS[0];
+        const activePlayers = stats.defensePlayers.map((row: any) => ({
+            account: row.account,
+            value: resolvedValue(row, activeMetric),
+            profession: row.profession,
+            professionList: row.professionList,
+            role: roleOf(row.account),
+        }));
+        const activeHigherIsBetter = DEFENSE_HIGHER_IS_BETTER.has(activeMetric.id);
+        const activeFormatValue = (val: number) => {
+            const isPercent = (activeMetric as any).isPercent;
+            const decimals = roundCountStats && !isPercent && defenseViewMode === 'total' ? 0 : 2;
+            const formatted = formatWithCommas(val, decimals);
+            return isPercent ? `${formatted}%` : formatted;
+        };
         return (
             <div>
                 <div className="flex flex-wrap items-center gap-2 mb-3.5">
@@ -106,86 +121,66 @@ export const DefenseSection = ({
                         Defense Detailed
                     </h3>
                 </div>
-                <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4">
-                    {DEFENSE_METRICS.map((metricEntry) => {
-                        const players = stats.defensePlayers.map((row: any) => ({
-                            account: row.account,
-                            value: resolvedValue(row, metricEntry),
-                            profession: row.profession,
-                            professionList: row.professionList,
-                            role: roleOf(row.account),
-                        }));
-                        const higherIsBetter = DEFENSE_HIGHER_IS_BETTER.has(metricEntry.id);
-                        const makeFormatValue = () => (val: number) => {
-                            const isPercent = (metricEntry as any).isPercent;
-                            const decimals = roundCountStats && !isPercent && defenseViewMode === 'total' ? 0 : 2;
-                            const formatted = formatWithCommas(val, decimals);
-                            return isPercent ? `${formatted}%` : formatted;
-                        };
-                        return (
-                            <MetricDistributionCard
-                                key={metricEntry.id}
-                                title={metricEntry.label}
-                                accentColor="var(--section-defense)"
-                                higherIsBetter={higherIsBetter}
-                                players={players}
-                                formatValue={makeFormatValue()}
-                                renderProfessionIcon={renderProfessionIcon}
-                                roleAware
+                <StatsTableLayout
+                    expanded={false}
+                    sidebarClassName="pr-3 flex flex-col overflow-y-auto"
+                    sidebarStyle={undefined}
+                    contentClassName="overflow-hidden"
+                    contentStyle={undefined}
+                    sidebar={
+                        <>
+                            <div className="text-xs uppercase tracking-widest mb-2" style={{ color: 'var(--text-secondary)' }}>Defensive Tabs</div>
+                            <input
+                                value={defenseSearch}
+                                onChange={(e) => setDefenseSearch(e.target.value)}
+                                placeholder="Search..."
+                                className="w-full px-2 py-1 text-xs focus:outline-none mb-2"
+                                style={{ background: 'transparent', borderBottom: '1px solid var(--border-subtle)', color: 'var(--text-primary)' }}
                             />
-                        );
-                    })}
-                </div>
-                <div className="mt-4">
-                    <button
-                        type="button"
-                        aria-expanded={detailOpen}
-                        onClick={() => setDetailOpen((v) => !v)}
-                        className="flex items-center gap-1 text-xs px-3 py-1.5 rounded-[var(--radius-md)]"
-                        style={{ border: '1px solid var(--border-default)', color: 'var(--text-secondary)', background: 'var(--bg-hover)' }}
-                    >
-                        {detailOpen ? <ChevronDown className="w-3 h-3" /> : <ChevronRight className="w-3 h-3" />}
-                        Per-player detail
-                    </button>
-                    {detailOpen && (
-                        <div className="mt-3">
-                            <StatsTableLayout
-                                expanded={false}
-                                sidebarClassName="pr-3 flex flex-col overflow-y-auto"
-                                sidebarStyle={undefined}
-                                contentClassName="overflow-hidden"
-                                contentStyle={undefined}
-                                sidebar={
-                                    <>
-                                        <div className="text-xs uppercase tracking-widest mb-2" style={{ color: 'var(--text-secondary)' }}>Defensive Tabs</div>
-                                        <input
-                                            value={defenseSearch}
-                                            onChange={(e) => setDefenseSearch(e.target.value)}
-                                            placeholder="Search..."
-                                            className="w-full px-2 py-1 text-xs focus:outline-none mb-2"
-                                            style={{ background: 'transparent', borderBottom: '1px solid var(--border-subtle)', color: 'var(--text-primary)' }}
-                                        />
-                                        <div className={sidebarListClass}>
-                                            {filteredDefenseMetrics.map((metric) => (
-                                                <button
-                                                    key={metric.id}
-                                                    onClick={() => setActiveDefenseStat(metric.id)}
-                                                    className={`w-full text-left px-3 py-1.5 rounded-[var(--radius-md)] text-xs transition-colors ${activeDefenseStat === metric.id
-                                                        ? 'bg-[var(--accent-bg-strong)] text-[color:var(--brand-primary)] font-semibold'
-                                                        : 'hover:bg-[var(--bg-hover)] hover:text-[color:var(--text-primary)]'
-                                                        }`}
-                                                    style={activeDefenseStat !== metric.id ? { color: 'var(--text-secondary)' } : undefined}
-                                                >
-                                                    {metric.label}
-                                                </button>
-                                            ))}
-                                        </div>
-                                    </>
-                                }
-                                content={
-                                    <>
+                            <div className={sidebarListClass}>
+                                {filteredDefenseMetrics.map((metric) => (
+                                    <button
+                                        key={metric.id}
+                                        onClick={() => setActiveDefenseStat(metric.id)}
+                                        className={`w-full text-left px-3 py-1.5 rounded-[var(--radius-md)] text-xs transition-colors ${activeDefenseStat === metric.id
+                                            ? 'bg-[var(--accent-bg-strong)] text-[color:var(--brand-primary)] font-semibold'
+                                            : 'hover:bg-[var(--bg-hover)] hover:text-[color:var(--text-primary)]'
+                                            }`}
+                                        style={activeDefenseStat !== metric.id ? { color: 'var(--text-secondary)' } : undefined}
+                                    >
+                                        {metric.label}
+                                    </button>
+                                ))}
+                            </div>
+                        </>
+                    }
+                    content={
+                        <div className="flex flex-col gap-4">
+                            <MetricDistributionCard
+                                large
+                                roleAware
+                                title={activeMetric.label}
+                                accentColor="var(--section-defense)"
+                                higherIsBetter={activeHigherIsBetter}
+                                players={activePlayers}
+                                formatValue={activeFormatValue}
+                                renderProfessionIcon={renderProfessionIcon}
+                            />
+                            <div>
+                                <button
+                                    type="button"
+                                    aria-expanded={detailOpen}
+                                    onClick={() => setDetailOpen((v) => !v)}
+                                    className="flex items-center gap-1 text-xs px-3 py-1.5 rounded-[var(--radius-md)]"
+                                    style={{ border: '1px solid var(--border-default)', color: 'var(--text-secondary)', background: 'var(--bg-hover)' }}
+                                >
+                                    {detailOpen ? <ChevronDown className="w-3 h-3" /> : <ChevronRight className="w-3 h-3" />}
+                                    Per-player detail
+                                </button>
+                                {detailOpen && (
+                                    <div className="mt-3">
                                         {(() => {
-                                            const metric = DEFENSE_METRICS.find((entry) => entry.id === activeDefenseStat) || DEFENSE_METRICS[0];
+                                            const metric = activeMetric;
                                             const tsec = (row: any) => Math.max(1, (row.activeMs || 0) / 1000);
                                             const sourceRows = [...stats.defensePlayers];
                                             const effectiveRows = isMinionDamageMetric(metric.id)
@@ -238,12 +233,12 @@ export const DefenseSection = ({
                                                 />
                                             );
                                         })()}
-                                    </>
-                                }
-                            />
+                                    </div>
+                                )}
+                            </div>
                         </div>
-                    )}
-                </div>
+                    }
+                />
             </div>
         );
     }

--- a/src/renderer/stats/sections/DefenseSection.tsx
+++ b/src/renderer/stats/sections/DefenseSection.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { useMetricSectionState } from '../hooks/useMetricSectionState';
-import { Maximize2, X, Columns, Users, Shield } from 'lucide-react';
+import { Maximize2, X, Columns, Users, Shield, ChevronDown, ChevronRight } from 'lucide-react';
 import { ColumnFilterDropdown } from '../ui/ColumnFilterDropdown';
 import { SearchSelectDropdown, SearchSelectOption } from '../ui/SearchSelectDropdown';
 import { DenseStatsTable } from '../ui/DenseStatsTable';
@@ -9,6 +9,12 @@ import { StatsTableLayout } from '../ui/StatsTableLayout';
 import { StatsTableShell } from '../ui/StatsTableShell';
 import { useStatsSharedContext } from '../StatsViewContext';
 import { DEFENSE_METRICS } from '../statsMetrics';
+import { MetricDistributionCard } from '../components/MetricDistributionCard';
+
+// For defense, lower damage taken / fewer downs = better; higher blocks/evades = better
+const DEFENSE_HIGHER_IS_BETTER = new Set([
+    'damageBarrier', 'damageBarrierCount', 'blockedCount', 'evadedCount', 'missedCount', 'dodgeCount', 'invulnedCount'
+]);
 
 type DefenseSectionProps = {
     defenseSearch: string;
@@ -17,6 +23,7 @@ type DefenseSectionProps = {
     setActiveDefenseStat: (value: string) => void;
     defenseViewMode: 'total' | 'per1s' | 'per60s';
     setDefenseViewMode: (value: 'total' | 'per1s' | 'per60s') => void;
+    noEgoMode?: boolean;
 };
 
 export const DefenseSection = ({
@@ -25,7 +32,8 @@ export const DefenseSection = ({
     activeDefenseStat,
     setActiveDefenseStat,
     defenseViewMode,
-    setDefenseViewMode
+    setDefenseViewMode,
+    noEgoMode = false,
 }: DefenseSectionProps) => {
     const { stats, roundCountStats, formatWithCommas, renderProfessionIcon, expandedSection, expandedSectionClosing, openExpandedSection, closeExpandedSection, sidebarListClass } = useStatsSharedContext();
     const {
@@ -46,6 +54,7 @@ export const DefenseSection = ({
         renderProfessionIcon,
     });
     const [minionDamageMode, setMinionDamageMode] = useState<'combined' | 'separate'>('combined');
+    const [detailOpen, setDetailOpen] = useState(false);
     const isExpanded = expandedSection === 'defense-detailed';
     const isMinionDamageMetric = (id?: string) => id === 'minionDamageTaken';
     const getMinionRows = (rows: any[], mode: 'combined' | 'separate') => {
@@ -70,6 +79,166 @@ export const DefenseSection = ({
             }));
         });
     };
+
+    // ── No Ego mode: one MetricDistributionCard per DEFENSE_METRICS entry ──
+    if (noEgoMode && stats.defensePlayers.length > 0) {
+        const totalSeconds = (row: any) => Math.max(1, (row.activeMs || 0) / 1000);
+        const resolvedValue = (row: any, metricEntry: typeof DEFENSE_METRICS[number]) => {
+            const total = row.defenseTotals?.[metricEntry.id] || 0;
+            const isPercent = (metricEntry as any).isPercent;
+            if (isPercent) return total;
+            if (defenseViewMode === 'per1s') return total / totalSeconds(row);
+            if (defenseViewMode === 'per60s') return (total * 60) / totalSeconds(row);
+            return total;
+        };
+        return (
+            <div>
+                <div className="flex flex-wrap items-center gap-2 mb-3.5">
+                    <Shield className="w-4 h-4 shrink-0" style={{ color: 'var(--section-defense)' }} />
+                    <h3 className="text-[11px] font-semibold uppercase tracking-[0.05em]" style={{ color: 'var(--text-primary)' }}>
+                        Defense Detailed
+                    </h3>
+                </div>
+                <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4">
+                    {DEFENSE_METRICS.map((metricEntry) => {
+                        const players = stats.defensePlayers.map((row: any) => ({
+                            account: row.account,
+                            value: resolvedValue(row, metricEntry),
+                            profession: row.profession,
+                            professionList: row.professionList,
+                        }));
+                        const higherIsBetter = DEFENSE_HIGHER_IS_BETTER.has(metricEntry.id);
+                        const makeFormatValue = () => (val: number) => {
+                            const isPercent = (metricEntry as any).isPercent;
+                            const decimals = roundCountStats && !isPercent && defenseViewMode === 'total' ? 0 : 2;
+                            const formatted = formatWithCommas(val, decimals);
+                            return isPercent ? `${formatted}%` : formatted;
+                        };
+                        return (
+                            <MetricDistributionCard
+                                key={metricEntry.id}
+                                title={metricEntry.label}
+                                accentColor="var(--section-defense)"
+                                higherIsBetter={higherIsBetter}
+                                players={players}
+                                formatValue={makeFormatValue()}
+                                renderProfessionIcon={renderProfessionIcon}
+                            />
+                        );
+                    })}
+                </div>
+                <div className="mt-4">
+                    <button
+                        type="button"
+                        aria-expanded={detailOpen}
+                        onClick={() => setDetailOpen((v) => !v)}
+                        className="flex items-center gap-1 text-xs px-3 py-1.5 rounded-[var(--radius-md)]"
+                        style={{ border: '1px solid var(--border-default)', color: 'var(--text-secondary)', background: 'var(--bg-hover)' }}
+                    >
+                        {detailOpen ? <ChevronDown className="w-3 h-3" /> : <ChevronRight className="w-3 h-3" />}
+                        Per-player detail
+                    </button>
+                    {detailOpen && (
+                        <div className="mt-3">
+                            <StatsTableLayout
+                                expanded={false}
+                                sidebarClassName="pr-3 flex flex-col overflow-y-auto"
+                                sidebarStyle={undefined}
+                                contentClassName="overflow-hidden"
+                                contentStyle={undefined}
+                                sidebar={
+                                    <>
+                                        <div className="text-xs uppercase tracking-widest mb-2" style={{ color: 'var(--text-secondary)' }}>Defensive Tabs</div>
+                                        <input
+                                            value={defenseSearch}
+                                            onChange={(e) => setDefenseSearch(e.target.value)}
+                                            placeholder="Search..."
+                                            className="w-full px-2 py-1 text-xs focus:outline-none mb-2"
+                                            style={{ background: 'transparent', borderBottom: '1px solid var(--border-subtle)', color: 'var(--text-primary)' }}
+                                        />
+                                        <div className={sidebarListClass}>
+                                            {filteredDefenseMetrics.map((metric) => (
+                                                <button
+                                                    key={metric.id}
+                                                    onClick={() => setActiveDefenseStat(metric.id)}
+                                                    className={`w-full text-left px-3 py-1.5 rounded-[var(--radius-md)] text-xs transition-colors ${activeDefenseStat === metric.id
+                                                        ? 'bg-[var(--accent-bg-strong)] text-[color:var(--brand-primary)] font-semibold'
+                                                        : 'hover:bg-[var(--bg-hover)] hover:text-[color:var(--text-primary)]'
+                                                        }`}
+                                                    style={activeDefenseStat !== metric.id ? { color: 'var(--text-secondary)' } : undefined}
+                                                >
+                                                    {metric.label}
+                                                </button>
+                                            ))}
+                                        </div>
+                                    </>
+                                }
+                                content={
+                                    <>
+                                        {(() => {
+                                            const metric = DEFENSE_METRICS.find((entry) => entry.id === activeDefenseStat) || DEFENSE_METRICS[0];
+                                            const tsec = (row: any) => Math.max(1, (row.activeMs || 0) / 1000);
+                                            const sourceRows = [...stats.defensePlayers];
+                                            const effectiveRows = isMinionDamageMetric(metric.id)
+                                                ? getMinionRows(sourceRows, minionDamageMode)
+                                                : sourceRows;
+                                            const rows = [...effectiveRows]
+                                                .map((row: any) => ({
+                                                    ...row,
+                                                    total: row.defenseTotals?.[metric.id] || 0,
+                                                    per1s: (row.defenseTotals?.[metric.id] || 0) / tsec(row),
+                                                    per60s: ((row.defenseTotals?.[metric.id] || 0) * 60) / tsec(row)
+                                                }))
+                                                .sort((a, b) => {
+                                                    const aVal = Number(defenseViewMode === 'total' ? a.total : defenseViewMode === 'per1s' ? a.per1s : a.per60s);
+                                                    const bVal = Number(defenseViewMode === 'total' ? b.total : defenseViewMode === 'per1s' ? b.per1s : b.per60s);
+                                                    return bVal - aVal || a.account.localeCompare(b.account);
+                                                });
+                                            return (
+                                                <StatsTableShell
+                                                    expanded={false}
+                                                    animationKey={`noego-defense-${activeDefenseStat}-${defenseViewMode}`}
+                                                    header={null}
+                                                    columns={
+                                                        <div className="grid grid-cols-[1.5fr_1fr_0.9fr] text-[10px] uppercase tracking-widest text-[color:var(--text-secondary)] px-3 py-2 border-b border-[color:var(--border-default)]">
+                                                            <div>Player</div>
+                                                            <div className="text-right">
+                                                                {defenseViewMode === 'total' ? 'Total' : defenseViewMode === 'per1s' ? 'Stat/1s' : 'Stat/60s'}
+                                                            </div>
+                                                            <div className="text-right">Fight Time</div>
+                                                        </div>
+                                                    }
+                                                    rows={
+                                                        <>
+                                                            {rows.map((row: any, idx: number) => (
+                                                                <div key={`noego-defense-${metric.id}-${row.account}-${idx}`} className="grid grid-cols-[1.5fr_1fr_0.9fr] px-3 py-2 text-xs border-b border-[color:var(--border-subtle)] hover:bg-[var(--bg-hover)]" style={{ color: 'var(--text-primary)' }}>
+                                                                    <div className="flex items-center gap-2 min-w-0">
+                                                                        {renderProfessionIcon(row.profession, row.professionList, 'w-4 h-4')}
+                                                                        <span className="truncate">{row.account}</span>
+                                                                    </div>
+                                                                    <div className="text-right font-mono" style={{ color: 'var(--text-secondary)' }}>
+                                                                        {formatWithCommas(defenseViewMode === 'total' ? row.total : defenseViewMode === 'per1s' ? row.per1s : row.per60s, roundCountStats && defenseViewMode === 'total' ? 0 : 2)}
+                                                                    </div>
+                                                                    <div className="text-right font-mono" style={{ color: 'var(--text-secondary)' }}>
+                                                                        {row.activeMs ? `${(row.activeMs / 1000).toFixed(1)}s` : '-'}
+                                                                    </div>
+                                                                </div>
+                                                            ))}
+                                                        </>
+                                                    }
+                                                />
+                                            );
+                                        })()}
+                                    </>
+                                }
+                            />
+                        </div>
+                    )}
+                </div>
+            </div>
+        );
+    }
+
     return (
     <div
         className={`${

--- a/src/renderer/stats/sections/NoEgoMetricSection.tsx
+++ b/src/renderer/stats/sections/NoEgoMetricSection.tsx
@@ -17,6 +17,7 @@ export interface NoEgoMetricSectionProps {
     icon: React.ReactNode;
     accentColor: string;
     sidebarLabel: string;
+    keyPrefix: string;
     metrics: NoEgoMetricDef[];
     filteredMetrics: NoEgoMetricDef[];
     players: any[];
@@ -41,6 +42,7 @@ export const NoEgoMetricSection: React.FC<NoEgoMetricSectionProps> = ({
     icon,
     accentColor,
     sidebarLabel,
+    keyPrefix,
     metrics,
     filteredMetrics,
     players,
@@ -189,11 +191,10 @@ export const NoEgoMetricSection: React.FC<NoEgoMetricSectionProps> = ({
                                                 const bVal = Number(viewMode === 'total' ? b.total : viewMode === 'per1s' ? b.per1s : b.per60s);
                                                 return bVal - aVal || a.account.localeCompare(b.account);
                                             });
-                                        const fightTimeMsField = (row: any) => fightTimeMs(row);
                                         return (
                                             <StatsTableShell
                                                 expanded={false}
-                                                animationKey={`noego-${activeStatId}-${viewMode}`}
+                                                animationKey={`${keyPrefix}-${activeStatId}-${viewMode}`}
                                                 header={null}
                                                 columns={
                                                     <div className="grid grid-cols-[1.5fr_1fr_0.9fr] text-[10px] uppercase tracking-widest text-[color:var(--text-secondary)] px-3 py-2 border-b border-[color:var(--border-default)]">
@@ -207,7 +208,7 @@ export const NoEgoMetricSection: React.FC<NoEgoMetricSectionProps> = ({
                                                 rows={
                                                     <>
                                                         {rows.map((row: any, idx: number) => (
-                                                            <div key={`noego-${metric.id}-${row.account}-${idx}`} className="grid grid-cols-[1.5fr_1fr_0.9fr] px-3 py-2 text-xs border-b border-[color:var(--border-subtle)] hover:bg-[var(--bg-hover)]" style={{ color: 'var(--text-primary)' }}>
+                                                            <div key={`${keyPrefix}-${metric.id}-${row.account}-${idx}`} className="grid grid-cols-[1.5fr_1fr_0.9fr] px-3 py-2 text-xs border-b border-[color:var(--border-subtle)] hover:bg-[var(--bg-hover)]" style={{ color: 'var(--text-primary)' }}>
                                                                 <div className="flex items-center gap-2 min-w-0">
                                                                     {renderProfessionIcon(row.profession, row.professionList, 'w-4 h-4')}
                                                                     <span className="truncate">{row.account}</span>
@@ -216,7 +217,7 @@ export const NoEgoMetricSection: React.FC<NoEgoMetricSectionProps> = ({
                                                                     {fmtVal(viewMode === 'total' ? row.total : viewMode === 'per1s' ? row.per1s : row.per60s)}
                                                                 </div>
                                                                 <div className="text-right font-mono" style={{ color: 'var(--text-secondary)' }}>
-                                                                    {fightTimeMsField(row) ? `${(fightTimeMsField(row) / 1000).toFixed(1)}s` : '-'}
+                                                                    {fightTimeMs(row) ? `${(fightTimeMs(row) / 1000).toFixed(1)}s` : '-'}
                                                                 </div>
                                                             </div>
                                                         ))}

--- a/src/renderer/stats/sections/NoEgoMetricSection.tsx
+++ b/src/renderer/stats/sections/NoEgoMetricSection.tsx
@@ -1,0 +1,236 @@
+import React from 'react';
+import { ChevronDown, ChevronRight } from 'lucide-react';
+import { PillToggleGroup } from '../ui/PillToggleGroup';
+import { StatsTableLayout } from '../ui/StatsTableLayout';
+import { StatsTableShell } from '../ui/StatsTableShell';
+import { MetricDistributionCard } from '../components/MetricDistributionCard';
+import { useStatsSharedContext } from '../StatsViewContext';
+import type { RoleClassificationEntry } from '../statsTypes';
+
+export interface NoEgoMetricDef {
+    id: string;
+    label: string;
+}
+
+export interface NoEgoMetricSectionProps {
+    title: string;
+    icon: React.ReactNode;
+    accentColor: string;
+    sidebarLabel: string;
+    metrics: NoEgoMetricDef[];
+    filteredMetrics: NoEgoMetricDef[];
+    players: any[];
+    roleClassifications?: RoleClassificationEntry[];
+    activeStatId: string;
+    setActiveStatId: (id: string) => void;
+    search: string;
+    setSearch: (v: string) => void;
+    viewMode: 'total' | 'per1s' | 'per60s';
+    setViewMode: (v: 'total' | 'per1s' | 'per60s') => void;
+    detailOpen: boolean;
+    setDetailOpen: (v: boolean | ((p: boolean) => boolean)) => void;
+    higherIsBetter: (metric: NoEgoMetricDef) => boolean;
+    resolveTotal: (row: any, metric: NoEgoMetricDef) => number;
+    isRateOrPercent: (metric: NoEgoMetricDef) => boolean;
+    fightTimeMs: (row: any) => number;
+    formatValue: (metric: NoEgoMetricDef, val: number) => string;
+}
+
+export const NoEgoMetricSection: React.FC<NoEgoMetricSectionProps> = ({
+    title,
+    icon,
+    accentColor,
+    sidebarLabel,
+    metrics,
+    filteredMetrics,
+    players,
+    roleClassifications,
+    activeStatId,
+    setActiveStatId,
+    search,
+    setSearch,
+    viewMode,
+    setViewMode,
+    detailOpen,
+    setDetailOpen,
+    higherIsBetter,
+    resolveTotal,
+    isRateOrPercent,
+    fightTimeMs,
+    formatValue,
+}) => {
+    const { renderProfessionIcon, sidebarListClass } = useStatsSharedContext();
+
+    const roleByAccount = new Map<string, 'support' | 'damage'>(
+        ((roleClassifications as RoleClassificationEntry[] | undefined) ?? [])
+            .filter((r): r is RoleClassificationEntry => !!r && (r.role === 'support' || r.role === 'damage'))
+            .map((r) => [String(r.account), r.role] as [string, 'support' | 'damage']),
+    );
+    const roleOf = (account: string): 'support' | 'damage' | undefined =>
+        roleByAccount.get(account) ?? roleByAccount.get(String(account).split('::')[0]);
+
+    const totalSeconds = (row: any) => Math.max(1, fightTimeMs(row) / 1000);
+
+    const resolvedValue = (row: any, metricEntry: NoEgoMetricDef): number => {
+        const total = resolveTotal(row, metricEntry);
+        if (isRateOrPercent(metricEntry)) return total;
+        if (viewMode === 'per1s') return total / totalSeconds(row);
+        if (viewMode === 'per60s') return (total * 60) / totalSeconds(row);
+        return total;
+    };
+
+    const activeMetric = metrics.find((e) => e.id === activeStatId) || metrics[0];
+    const activePlayers = players.map((row: any) => ({
+        account: row.account,
+        value: activeMetric ? resolvedValue(row, activeMetric) : 0,
+        profession: row.profession,
+        professionList: row.professionList,
+        role: roleOf(row.account),
+    }));
+    const activeHigherIsBetter = activeMetric ? higherIsBetter(activeMetric) : true;
+    const activeFormatValue = (val: number) =>
+        activeMetric ? formatValue(activeMetric, val) : String(val);
+
+    return (
+        <div>
+            <div className="flex flex-wrap items-center justify-between gap-2 mb-3.5">
+                <div className="flex items-center gap-2">
+                    {icon}
+                    <h3 className="text-[11px] font-semibold uppercase tracking-[0.05em]" style={{ color: 'var(--text-primary)' }}>
+                        {title}
+                    </h3>
+                </div>
+                <PillToggleGroup
+                    value={viewMode}
+                    onChange={setViewMode}
+                    options={[
+                        { value: 'total', label: 'Total' },
+                        { value: 'per1s', label: 'Stat/1s' },
+                        { value: 'per60s', label: 'Stat/60s' }
+                    ]}
+                    activeClassName="bg-[var(--accent-bg-strong)] text-[color:var(--brand-primary)] border border-[color:var(--accent-border)]"
+                    inactiveClassName="text-[color:var(--text-secondary)]"
+                />
+            </div>
+            <StatsTableLayout
+                expanded={false}
+                sidebarClassName="pr-3 flex flex-col overflow-y-auto"
+                sidebarStyle={undefined}
+                contentClassName="overflow-hidden"
+                contentStyle={undefined}
+                sidebar={
+                    <>
+                        <div className="text-xs uppercase tracking-widest mb-2" style={{ color: 'var(--text-secondary)' }}>{sidebarLabel}</div>
+                        <input
+                            value={search}
+                            onChange={(e) => setSearch(e.target.value)}
+                            placeholder="Search..."
+                            className="w-full px-2 py-1 text-xs focus:outline-none mb-2"
+                            style={{ background: 'transparent', borderBottom: '1px solid var(--border-subtle)', color: 'var(--text-primary)' }}
+                        />
+                        <div className={sidebarListClass}>
+                            {filteredMetrics.map((metric) => (
+                                <button
+                                    key={metric.id}
+                                    onClick={() => setActiveStatId(metric.id)}
+                                    className={`w-full text-left px-3 py-1.5 rounded-[var(--radius-md)] text-xs transition-colors ${activeStatId === metric.id
+                                        ? 'bg-[var(--accent-bg-strong)] text-[color:var(--brand-primary)] font-semibold'
+                                        : 'hover:bg-[var(--bg-hover)] hover:text-[color:var(--text-primary)]'
+                                        }`}
+                                    style={activeStatId !== metric.id ? { color: 'var(--text-secondary)' } : undefined}
+                                >
+                                    {metric.label}
+                                </button>
+                            ))}
+                        </div>
+                    </>
+                }
+                content={
+                    <div className="flex flex-col gap-4">
+                        {activeMetric && (
+                            <MetricDistributionCard
+                                large
+                                roleAware
+                                title={activeMetric.label}
+                                accentColor={accentColor}
+                                higherIsBetter={activeHigherIsBetter}
+                                players={activePlayers}
+                                formatValue={activeFormatValue}
+                                renderProfessionIcon={renderProfessionIcon}
+                            />
+                        )}
+                        <div>
+                            <button
+                                type="button"
+                                aria-expanded={detailOpen}
+                                onClick={() => setDetailOpen((v) => !v)}
+                                className="flex items-center gap-1 text-xs px-3 py-1.5 rounded-[var(--radius-md)]"
+                                style={{ border: '1px solid var(--border-default)', color: 'var(--text-secondary)', background: 'var(--bg-hover)' }}
+                            >
+                                {detailOpen ? <ChevronDown className="w-3 h-3" /> : <ChevronRight className="w-3 h-3" />}
+                                Per-player detail
+                            </button>
+                            {detailOpen && activeMetric && (
+                                <div className="mt-3">
+                                    {(() => {
+                                        const metric = activeMetric;
+                                        const tsec = (row: any) => Math.max(1, fightTimeMs(row) / 1000);
+                                        const tval = (row: any) => resolveTotal(row, metric);
+                                        const fmtVal = (val: number) => formatValue(metric, val);
+                                        const rows = [...players]
+                                            .map((row: any) => ({
+                                                ...row,
+                                                total: tval(row),
+                                                per1s: isRateOrPercent(metric) ? tval(row) : tval(row) / tsec(row),
+                                                per60s: isRateOrPercent(metric) ? tval(row) : (tval(row) * 60) / tsec(row)
+                                            }))
+                                            .sort((a, b) => {
+                                                const aVal = Number(viewMode === 'total' ? a.total : viewMode === 'per1s' ? a.per1s : a.per60s);
+                                                const bVal = Number(viewMode === 'total' ? b.total : viewMode === 'per1s' ? b.per1s : b.per60s);
+                                                return bVal - aVal || a.account.localeCompare(b.account);
+                                            });
+                                        const fightTimeMsField = (row: any) => fightTimeMs(row);
+                                        return (
+                                            <StatsTableShell
+                                                expanded={false}
+                                                animationKey={`noego-${activeStatId}-${viewMode}`}
+                                                header={null}
+                                                columns={
+                                                    <div className="grid grid-cols-[1.5fr_1fr_0.9fr] text-[10px] uppercase tracking-widest text-[color:var(--text-secondary)] px-3 py-2 border-b border-[color:var(--border-default)]">
+                                                        <div>Player</div>
+                                                        <div className="text-right">
+                                                            {viewMode === 'total' ? 'Total' : viewMode === 'per1s' ? 'Stat/1s' : 'Stat/60s'}
+                                                        </div>
+                                                        <div className="text-right">Fight Time</div>
+                                                    </div>
+                                                }
+                                                rows={
+                                                    <>
+                                                        {rows.map((row: any, idx: number) => (
+                                                            <div key={`noego-${metric.id}-${row.account}-${idx}`} className="grid grid-cols-[1.5fr_1fr_0.9fr] px-3 py-2 text-xs border-b border-[color:var(--border-subtle)] hover:bg-[var(--bg-hover)]" style={{ color: 'var(--text-primary)' }}>
+                                                                <div className="flex items-center gap-2 min-w-0">
+                                                                    {renderProfessionIcon(row.profession, row.professionList, 'w-4 h-4')}
+                                                                    <span className="truncate">{row.account}</span>
+                                                                </div>
+                                                                <div className="text-right font-mono" style={{ color: 'var(--text-secondary)' }}>
+                                                                    {fmtVal(viewMode === 'total' ? row.total : viewMode === 'per1s' ? row.per1s : row.per60s)}
+                                                                </div>
+                                                                <div className="text-right font-mono" style={{ color: 'var(--text-secondary)' }}>
+                                                                    {fightTimeMsField(row) ? `${(fightTimeMsField(row) / 1000).toFixed(1)}s` : '-'}
+                                                                </div>
+                                                            </div>
+                                                        ))}
+                                                    </>
+                                                }
+                                            />
+                                        );
+                                    })()}
+                                </div>
+                            )}
+                        </div>
+                    </div>
+                }
+            />
+        </div>
+    );
+};

--- a/src/renderer/stats/sections/OffenseSection.tsx
+++ b/src/renderer/stats/sections/OffenseSection.tsx
@@ -101,11 +101,24 @@ export const OffenseSection = ({
         };
         return (
             <div>
-                <div className="flex flex-wrap items-center gap-2 mb-3.5">
-                    <Swords className="w-4 h-4 shrink-0" style={{ color: 'var(--section-offense)' }} />
-                    <h3 className="text-[11px] font-semibold uppercase tracking-[0.05em]" style={{ color: 'var(--text-primary)' }}>
-                        Offense Detailed
-                    </h3>
+                <div className="flex flex-wrap items-center justify-between gap-2 mb-3.5">
+                    <div className="flex items-center gap-2">
+                        <Swords className="w-4 h-4 shrink-0" style={{ color: 'var(--section-offense)' }} />
+                        <h3 className="text-[11px] font-semibold uppercase tracking-[0.05em]" style={{ color: 'var(--text-primary)' }}>
+                            Offense Detailed
+                        </h3>
+                    </div>
+                    <PillToggleGroup
+                        value={offenseViewMode}
+                        onChange={setOffenseViewMode}
+                        options={[
+                            { value: 'total', label: 'Total' },
+                            { value: 'per1s', label: 'Stat/1s' },
+                            { value: 'per60s', label: 'Stat/60s' }
+                        ]}
+                        activeClassName="bg-[var(--accent-bg-strong)] text-[color:var(--brand-primary)] border border-[color:var(--accent-border)]"
+                        inactiveClassName="text-[color:var(--text-secondary)]"
+                    />
                 </div>
                 <StatsTableLayout
                     expanded={false}

--- a/src/renderer/stats/sections/OffenseSection.tsx
+++ b/src/renderer/stats/sections/OffenseSection.tsx
@@ -54,7 +54,7 @@ export const OffenseSection = ({
     const isExpanded = expandedSection === 'offense-detailed';
     const [detailOpen, setDetailOpen] = useState(false);
 
-    // ── No Ego mode: one MetricDistributionCard per OFFENSE_METRICS entry ──
+    // ── No Ego mode: sidebar + one large MetricDistributionCard for active metric ──
     if (noEgoMode && stats.offensePlayers.length > 0) {
         const roleByAccount = new Map<string, 'support' | 'damage'>(
           (Array.isArray((stats as any).roleClassifications) ? (stats as any).roleClassifications : [])
@@ -84,6 +84,20 @@ export const OffenseSection = ({
             if (offenseViewMode === 'per60s') return (total * 60) / totalSeconds(row);
             return total;
         };
+        const activeMetric = OFFENSE_METRICS.find((e) => e.id === activeOffenseStat) || OFFENSE_METRICS[0];
+        const activePlayers = stats.offensePlayers.map((row: any) => ({
+            account: row.account,
+            value: resolvedValue(row, activeMetric),
+            profession: row.profession,
+            professionList: row.professionList,
+            role: roleOf(row.account),
+        }));
+        const activeHigherIsBetter = !OFFENSE_LOWER_IS_BETTER.has(activeMetric.id);
+        const activeFormatValue = (val: number) => {
+            const decimals = roundCountStats && !activeMetric.isPercent && offenseViewMode === 'total' ? 0 : 2;
+            const formatted = formatWithCommas(val, decimals);
+            return activeMetric.isPercent ? `${formatted}%` : formatted;
+        };
         return (
             <div>
                 <div className="flex flex-wrap items-center gap-2 mb-3.5">
@@ -92,99 +106,68 @@ export const OffenseSection = ({
                         Offense Detailed
                     </h3>
                 </div>
-                <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4">
-                    {OFFENSE_METRICS.map((metricEntry) => {
-                        const players = stats.offensePlayers.map((row: any) => ({
-                            account: row.account,
-                            value: resolvedValue(row, metricEntry),
-                            profession: row.profession,
-                            professionList: row.professionList,
-                            role: roleOf(row.account),
-                        }));
-                        const higherIsBetter = !OFFENSE_LOWER_IS_BETTER.has(metricEntry.id);
-                        const makeFormatValue = () => (val: number) => {
-                            const decimals = roundCountStats && !metricEntry.isPercent && offenseViewMode === 'total' ? 0 : 2;
-                            const formatted = formatWithCommas(val, decimals);
-                            return metricEntry.isPercent ? `${formatted}%` : formatted;
-                        };
-                        return (
-                            <MetricDistributionCard
-                                key={metricEntry.id}
-                                title={metricEntry.label}
-                                accentColor="var(--section-offense)"
-                                higherIsBetter={higherIsBetter}
-                                players={players}
-                                formatValue={makeFormatValue()}
-                                renderProfessionIcon={renderProfessionIcon}
-                                roleAware
+                <StatsTableLayout
+                    expanded={false}
+                    sidebarClassName="pr-3 flex flex-col overflow-y-auto"
+                    sidebarStyle={undefined}
+                    contentClassName="overflow-hidden"
+                    contentStyle={undefined}
+                    sidebar={
+                        <>
+                            <div className="text-xs uppercase tracking-widest mb-2" style={{ color: 'var(--text-secondary)' }}>Offensive Tabs</div>
+                            <input
+                                value={offenseSearch}
+                                onChange={(e) => setOffenseSearch(e.target.value)}
+                                placeholder="Search..."
+                                className="w-full px-2 py-1 text-xs focus:outline-none mb-2"
+                                style={{ background: 'transparent', borderBottom: '1px solid var(--border-subtle)', color: 'var(--text-primary)' }}
                             />
-                        );
-                    })}
-                </div>
-                <div className="mt-4">
-                    <button
-                        type="button"
-                        aria-expanded={detailOpen}
-                        onClick={() => setDetailOpen((v) => !v)}
-                        className="flex items-center gap-1 text-xs px-3 py-1.5 rounded-[var(--radius-md)]"
-                        style={{ border: '1px solid var(--border-default)', color: 'var(--text-secondary)', background: 'var(--bg-hover)' }}
-                    >
-                        {detailOpen ? <ChevronDown className="w-3 h-3" /> : <ChevronRight className="w-3 h-3" />}
-                        Per-player detail
-                    </button>
-                    {detailOpen && (
-                        <div className="mt-3">
-                            <StatsTableLayout
-                                expanded={false}
-                                sidebarClassName="pr-3 flex flex-col overflow-y-auto"
-                                sidebarStyle={undefined}
-                                contentClassName="overflow-hidden"
-                                contentStyle={undefined}
-                                sidebar={
-                                    <>
-                                        <div className="text-xs uppercase tracking-widest mb-2" style={{ color: 'var(--text-secondary)' }}>Offensive Tabs</div>
-                                        <input
-                                            value={offenseSearch}
-                                            onChange={(e) => setOffenseSearch(e.target.value)}
-                                            placeholder="Search..."
-                                            className="w-full px-2 py-1 text-xs focus:outline-none mb-2"
-                                            style={{ background: 'transparent', borderBottom: '1px solid var(--border-subtle)', color: 'var(--text-primary)' }}
-                                        />
-                                        <div className={sidebarListClass}>
-                                            {filteredOffenseMetrics.map((metric) => (
-                                                <button
-                                                    key={metric.id}
-                                                    onClick={() => setActiveOffenseStat(metric.id)}
-                                                    className={`w-full text-left px-3 py-1.5 rounded-[var(--radius-md)] text-xs transition-colors ${activeOffenseStat === metric.id
-                                                        ? 'bg-[var(--accent-bg-strong)] text-[color:var(--brand-primary)] font-semibold'
-                                                        : 'hover:bg-[var(--bg-hover)] hover:text-[color:var(--text-primary)]'
-                                                        }`}
-                                                    style={activeOffenseStat !== metric.id ? { color: 'var(--text-secondary)' } : undefined}
-                                                >
-                                                    {metric.label}
-                                                </button>
-                                            ))}
-                                        </div>
-                                    </>
-                                }
-                                content={
-                                    <>
+                            <div className={sidebarListClass}>
+                                {filteredOffenseMetrics.map((metric) => (
+                                    <button
+                                        key={metric.id}
+                                        onClick={() => setActiveOffenseStat(metric.id)}
+                                        className={`w-full text-left px-3 py-1.5 rounded-[var(--radius-md)] text-xs transition-colors ${activeOffenseStat === metric.id
+                                            ? 'bg-[var(--accent-bg-strong)] text-[color:var(--brand-primary)] font-semibold'
+                                            : 'hover:bg-[var(--bg-hover)] hover:text-[color:var(--text-primary)]'
+                                            }`}
+                                        style={activeOffenseStat !== metric.id ? { color: 'var(--text-secondary)' } : undefined}
+                                    >
+                                        {metric.label}
+                                    </button>
+                                ))}
+                            </div>
+                        </>
+                    }
+                    content={
+                        <div className="flex flex-col gap-4">
+                            <MetricDistributionCard
+                                large
+                                roleAware
+                                title={activeMetric.label}
+                                accentColor="var(--section-offense)"
+                                higherIsBetter={activeHigherIsBetter}
+                                players={activePlayers}
+                                formatValue={activeFormatValue}
+                                renderProfessionIcon={renderProfessionIcon}
+                            />
+                            <div>
+                                <button
+                                    type="button"
+                                    aria-expanded={detailOpen}
+                                    onClick={() => setDetailOpen((v) => !v)}
+                                    className="flex items-center gap-1 text-xs px-3 py-1.5 rounded-[var(--radius-md)]"
+                                    style={{ border: '1px solid var(--border-default)', color: 'var(--text-secondary)', background: 'var(--bg-hover)' }}
+                                >
+                                    {detailOpen ? <ChevronDown className="w-3 h-3" /> : <ChevronRight className="w-3 h-3" />}
+                                    Per-player detail
+                                </button>
+                                {detailOpen && (
+                                    <div className="mt-3">
                                         {(() => {
-                                            const metric = OFFENSE_METRICS.find((entry) => entry.id === activeOffenseStat) || OFFENSE_METRICS[0];
+                                            const metric = activeMetric;
                                             const tsec = (row: any) => Math.max(1, (row.totalFightMs || 0) / 1000);
-                                            const tval = (row: any) => {
-                                                if (metric.id === 'downContributionPercent') {
-                                                    const dc = row.offenseTotals?.downContribution || 0;
-                                                    const td = row.offenseTotals?.damage || 0;
-                                                    return td > 0 ? (dc / td) * 100 : 0;
-                                                }
-                                                if (metric.isRate) {
-                                                    const denom = row.offenseRateWeights?.[metric.id] || 0;
-                                                    const numer = row.offenseTotals?.[metric.id] || 0;
-                                                    return denom > 0 ? (numer / denom) * 100 : 0;
-                                                }
-                                                return row.offenseTotals?.[metric.id] || 0;
-                                            };
+                                            const tval = (row: any) => totalValue(row, metric);
                                             const fmtVal = (val: number) => {
                                                 const decimals = roundCountStats && !metric.isPercent && offenseViewMode === 'total' ? 0 : 2;
                                                 const formatted = formatWithCommas(val, decimals);
@@ -237,12 +220,12 @@ export const OffenseSection = ({
                                                 />
                                             );
                                         })()}
-                                    </>
-                                }
-                            />
+                                    </div>
+                                )}
+                            </div>
                         </div>
-                    )}
-                </div>
+                    }
+                />
             </div>
         );
     }

--- a/src/renderer/stats/sections/OffenseSection.tsx
+++ b/src/renderer/stats/sections/OffenseSection.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { useMetricSectionState } from '../hooks/useMetricSectionState';
-import { Maximize2, X, Columns, Users, Swords, ChevronDown, ChevronRight } from 'lucide-react';
+import { Maximize2, X, Columns, Users, Swords } from 'lucide-react';
 import { ColumnFilterDropdown } from '../ui/ColumnFilterDropdown';
 import { SearchSelectDropdown, SearchSelectOption } from '../ui/SearchSelectDropdown';
 import { DenseStatsTable } from '../ui/DenseStatsTable';
@@ -9,8 +9,7 @@ import { StatsTableLayout } from '../ui/StatsTableLayout';
 import { StatsTableShell } from '../ui/StatsTableShell';
 import { useStatsSharedContext } from '../StatsViewContext';
 import { OFFENSE_METRICS } from '../statsMetrics';
-import { MetricDistributionCard } from '../components/MetricDistributionCard';
-import type { RoleClassificationEntry } from '../statsTypes';
+import { NoEgoMetricSection } from './NoEgoMetricSection';
 
 // Metrics where lower is better (negatively oriented — your offense being negated)
 const OFFENSE_LOWER_IS_BETTER = new Set(['glanceRate', 'missed', 'evaded', 'blocked', 'invulned']);
@@ -57,14 +56,6 @@ export const OffenseSection = ({
 
     // ── No Ego mode: sidebar + one large MetricDistributionCard for active metric ──
     if (noEgoMode && stats.offensePlayers.length > 0) {
-        const roleByAccount = new Map<string, 'support' | 'damage'>(
-          ((stats.roleClassifications as RoleClassificationEntry[] | undefined) ?? [])
-            .filter((r): r is RoleClassificationEntry => !!r && (r.role === 'support' || r.role === 'damage'))
-            .map((r) => [String(r.account), r.role] as [string, 'support' | 'damage']),
-        );
-        const roleOf = (account: string): 'support' | 'damage' | undefined =>
-          roleByAccount.get(account) ?? roleByAccount.get(String(account).split('::')[0]);
-        const totalSeconds = (row: any) => Math.max(1, (row.totalFightMs || 0) / 1000);
         const totalValue = (row: any, metricEntry: typeof OFFENSE_METRICS[number]) => {
             if (metricEntry.id === 'downContributionPercent') {
                 const downContribution = row.offenseTotals?.downContribution || 0;
@@ -78,169 +69,34 @@ export const OffenseSection = ({
             }
             return row.offenseTotals?.[metricEntry.id] || 0;
         };
-        const resolvedValue = (row: any, metricEntry: typeof OFFENSE_METRICS[number]) => {
-            const total = totalValue(row, metricEntry);
-            if (metricEntry.isPercent || metricEntry.isRate) return total;
-            if (offenseViewMode === 'per1s') return total / totalSeconds(row);
-            if (offenseViewMode === 'per60s') return (total * 60) / totalSeconds(row);
-            return total;
-        };
-        const activeMetric = OFFENSE_METRICS.find((e) => e.id === activeOffenseStat) || OFFENSE_METRICS[0];
-        const activePlayers = stats.offensePlayers.map((row: any) => ({
-            account: row.account,
-            value: resolvedValue(row, activeMetric),
-            profession: row.profession,
-            professionList: row.professionList,
-            role: roleOf(row.account),
-        }));
-        const activeHigherIsBetter = !OFFENSE_LOWER_IS_BETTER.has(activeMetric.id);
-        const activeFormatValue = (val: number) => {
-            const decimals = roundCountStats && !activeMetric.isPercent && offenseViewMode === 'total' ? 0 : 2;
-            const formatted = formatWithCommas(val, decimals);
-            return activeMetric.isPercent ? `${formatted}%` : formatted;
-        };
         return (
-            <div>
-                <div className="flex flex-wrap items-center justify-between gap-2 mb-3.5">
-                    <div className="flex items-center gap-2">
-                        <Swords className="w-4 h-4 shrink-0" style={{ color: 'var(--section-offense)' }} />
-                        <h3 className="text-[11px] font-semibold uppercase tracking-[0.05em]" style={{ color: 'var(--text-primary)' }}>
-                            Offense Detailed
-                        </h3>
-                    </div>
-                    <PillToggleGroup
-                        value={offenseViewMode}
-                        onChange={setOffenseViewMode}
-                        options={[
-                            { value: 'total', label: 'Total' },
-                            { value: 'per1s', label: 'Stat/1s' },
-                            { value: 'per60s', label: 'Stat/60s' }
-                        ]}
-                        activeClassName="bg-[var(--accent-bg-strong)] text-[color:var(--brand-primary)] border border-[color:var(--accent-border)]"
-                        inactiveClassName="text-[color:var(--text-secondary)]"
-                    />
-                </div>
-                <StatsTableLayout
-                    expanded={false}
-                    sidebarClassName="pr-3 flex flex-col overflow-y-auto"
-                    sidebarStyle={undefined}
-                    contentClassName="overflow-hidden"
-                    contentStyle={undefined}
-                    sidebar={
-                        <>
-                            <div className="text-xs uppercase tracking-widest mb-2" style={{ color: 'var(--text-secondary)' }}>Offensive Tabs</div>
-                            <input
-                                value={offenseSearch}
-                                onChange={(e) => setOffenseSearch(e.target.value)}
-                                placeholder="Search..."
-                                className="w-full px-2 py-1 text-xs focus:outline-none mb-2"
-                                style={{ background: 'transparent', borderBottom: '1px solid var(--border-subtle)', color: 'var(--text-primary)' }}
-                            />
-                            <div className={sidebarListClass}>
-                                {filteredOffenseMetrics.map((metric) => (
-                                    <button
-                                        key={metric.id}
-                                        onClick={() => setActiveOffenseStat(metric.id)}
-                                        className={`w-full text-left px-3 py-1.5 rounded-[var(--radius-md)] text-xs transition-colors ${activeOffenseStat === metric.id
-                                            ? 'bg-[var(--accent-bg-strong)] text-[color:var(--brand-primary)] font-semibold'
-                                            : 'hover:bg-[var(--bg-hover)] hover:text-[color:var(--text-primary)]'
-                                            }`}
-                                        style={activeOffenseStat !== metric.id ? { color: 'var(--text-secondary)' } : undefined}
-                                    >
-                                        {metric.label}
-                                    </button>
-                                ))}
-                            </div>
-                        </>
-                    }
-                    content={
-                        <div className="flex flex-col gap-4">
-                            <MetricDistributionCard
-                                large
-                                roleAware
-                                title={activeMetric.label}
-                                accentColor="var(--section-offense)"
-                                higherIsBetter={activeHigherIsBetter}
-                                players={activePlayers}
-                                formatValue={activeFormatValue}
-                                renderProfessionIcon={renderProfessionIcon}
-                            />
-                            <div>
-                                <button
-                                    type="button"
-                                    aria-expanded={detailOpen}
-                                    onClick={() => setDetailOpen((v) => !v)}
-                                    className="flex items-center gap-1 text-xs px-3 py-1.5 rounded-[var(--radius-md)]"
-                                    style={{ border: '1px solid var(--border-default)', color: 'var(--text-secondary)', background: 'var(--bg-hover)' }}
-                                >
-                                    {detailOpen ? <ChevronDown className="w-3 h-3" /> : <ChevronRight className="w-3 h-3" />}
-                                    Per-player detail
-                                </button>
-                                {detailOpen && (
-                                    <div className="mt-3">
-                                        {(() => {
-                                            const metric = activeMetric;
-                                            const tsec = (row: any) => Math.max(1, (row.totalFightMs || 0) / 1000);
-                                            const tval = (row: any) => totalValue(row, metric);
-                                            const fmtVal = (val: number) => {
-                                                const decimals = roundCountStats && !metric.isPercent && offenseViewMode === 'total' ? 0 : 2;
-                                                const formatted = formatWithCommas(val, decimals);
-                                                return metric.isPercent ? `${formatted}%` : formatted;
-                                            };
-                                            const rows = [...stats.offensePlayers]
-                                                .map((row: any) => ({
-                                                    ...row,
-                                                    total: tval(row),
-                                                    per1s: metric.isPercent || metric.isRate ? tval(row) : tval(row) / tsec(row),
-                                                    per60s: metric.isPercent || metric.isRate ? tval(row) : (tval(row) * 60) / tsec(row)
-                                                }))
-                                                .sort((a, b) => {
-                                                    const aVal = Number(offenseViewMode === 'total' ? a.total : offenseViewMode === 'per1s' ? a.per1s : a.per60s);
-                                                    const bVal = Number(offenseViewMode === 'total' ? b.total : offenseViewMode === 'per1s' ? b.per1s : b.per60s);
-                                                    return bVal - aVal || a.account.localeCompare(b.account);
-                                                });
-                                            return (
-                                                <StatsTableShell
-                                                    expanded={false}
-                                                    animationKey={`noego-${activeOffenseStat}-${offenseViewMode}`}
-                                                    header={null}
-                                                    columns={
-                                                        <div className="grid grid-cols-[1.5fr_1fr_0.9fr] text-[10px] uppercase tracking-widest text-[color:var(--text-secondary)] px-3 py-2 border-b border-[color:var(--border-default)]">
-                                                            <div>Player</div>
-                                                            <div className="text-right">
-                                                                {offenseViewMode === 'total' ? 'Total' : offenseViewMode === 'per1s' ? 'Stat/1s' : 'Stat/60s'}
-                                                            </div>
-                                                            <div className="text-right">Fight Time</div>
-                                                        </div>
-                                                    }
-                                                    rows={
-                                                        <>
-                                                            {rows.map((row: any, idx: number) => (
-                                                                <div key={`noego-${metric.id}-${row.account}-${idx}`} className="grid grid-cols-[1.5fr_1fr_0.9fr] px-3 py-2 text-xs border-b border-[color:var(--border-subtle)] hover:bg-[var(--bg-hover)]" style={{ color: 'var(--text-primary)' }}>
-                                                                    <div className="flex items-center gap-2 min-w-0">
-                                                                        {renderProfessionIcon(row.profession, row.professionList, 'w-4 h-4')}
-                                                                        <span className="truncate">{row.account}</span>
-                                                                    </div>
-                                                                    <div className="text-right font-mono" style={{ color: 'var(--text-secondary)' }}>
-                                                                        {fmtVal(offenseViewMode === 'total' ? row.total : offenseViewMode === 'per1s' ? row.per1s : row.per60s)}
-                                                                    </div>
-                                                                    <div className="text-right font-mono" style={{ color: 'var(--text-secondary)' }}>
-                                                                        {row.totalFightMs ? `${(row.totalFightMs / 1000).toFixed(1)}s` : '-'}
-                                                                    </div>
-                                                                </div>
-                                                            ))}
-                                                        </>
-                                                    }
-                                                />
-                                            );
-                                        })()}
-                                    </div>
-                                )}
-                            </div>
-                        </div>
-                    }
-                />
-            </div>
+            <NoEgoMetricSection
+                title="Offense Detailed"
+                icon={<Swords className="w-4 h-4 shrink-0" style={{ color: 'var(--section-offense)' }} />}
+                accentColor="var(--section-offense)"
+                sidebarLabel="Offensive Tabs"
+                metrics={OFFENSE_METRICS}
+                filteredMetrics={filteredOffenseMetrics}
+                players={stats.offensePlayers}
+                roleClassifications={stats.roleClassifications}
+                activeStatId={activeOffenseStat}
+                setActiveStatId={setActiveOffenseStat}
+                search={offenseSearch}
+                setSearch={setOffenseSearch}
+                viewMode={offenseViewMode}
+                setViewMode={setOffenseViewMode}
+                detailOpen={detailOpen}
+                setDetailOpen={setDetailOpen}
+                higherIsBetter={(m) => !OFFENSE_LOWER_IS_BETTER.has(m.id)}
+                resolveTotal={(row, m) => totalValue(row, m as typeof OFFENSE_METRICS[number])}
+                isRateOrPercent={(m) => !!(m as any).isPercent || !!(m as any).isRate}
+                fightTimeMs={(row) => row.totalFightMs || 0}
+                formatValue={(m, val) => {
+                    const decimals = roundCountStats && !(m as any).isPercent && offenseViewMode === 'total' ? 0 : 2;
+                    const formatted = formatWithCommas(val, decimals);
+                    return (m as any).isPercent ? `${formatted}%` : formatted;
+                }}
+            />
         );
     }
 

--- a/src/renderer/stats/sections/OffenseSection.tsx
+++ b/src/renderer/stats/sections/OffenseSection.tsx
@@ -10,6 +10,7 @@ import { StatsTableShell } from '../ui/StatsTableShell';
 import { useStatsSharedContext } from '../StatsViewContext';
 import { OFFENSE_METRICS } from '../statsMetrics';
 import { MetricDistributionCard } from '../components/MetricDistributionCard';
+import type { RoleClassificationEntry } from '../statsTypes';
 
 // Metrics where lower is better (negatively oriented — your offense being negated)
 const OFFENSE_LOWER_IS_BETTER = new Set(['glanceRate', 'missed', 'evaded', 'blocked', 'invulned']);
@@ -57,9 +58,9 @@ export const OffenseSection = ({
     // ── No Ego mode: sidebar + one large MetricDistributionCard for active metric ──
     if (noEgoMode && stats.offensePlayers.length > 0) {
         const roleByAccount = new Map<string, 'support' | 'damage'>(
-          (Array.isArray((stats as any).roleClassifications) ? (stats as any).roleClassifications : [])
-            .filter((r: any) => r && (r.role === 'support' || r.role === 'damage'))
-            .map((r: any) => [String(r.account), r.role as 'support' | 'damage']),
+          ((stats.roleClassifications as RoleClassificationEntry[] | undefined) ?? [])
+            .filter((r): r is RoleClassificationEntry => !!r && (r.role === 'support' || r.role === 'damage'))
+            .map((r) => [String(r.account), r.role] as [string, 'support' | 'damage']),
         );
         const roleOf = (account: string): 'support' | 'damage' | undefined =>
           roleByAccount.get(account) ?? roleByAccount.get(String(account).split('::')[0]);

--- a/src/renderer/stats/sections/OffenseSection.tsx
+++ b/src/renderer/stats/sections/OffenseSection.tsx
@@ -56,6 +56,13 @@ export const OffenseSection = ({
 
     // ── No Ego mode: one MetricDistributionCard per OFFENSE_METRICS entry ──
     if (noEgoMode && stats.offensePlayers.length > 0) {
+        const roleByAccount = new Map<string, 'support' | 'damage'>(
+          (Array.isArray((stats as any).roleClassifications) ? (stats as any).roleClassifications : [])
+            .filter((r: any) => r && (r.role === 'support' || r.role === 'damage'))
+            .map((r: any) => [String(r.account), r.role as 'support' | 'damage']),
+        );
+        const roleOf = (account: string): 'support' | 'damage' | undefined =>
+          roleByAccount.get(account) ?? roleByAccount.get(String(account).split('::')[0]);
         const totalSeconds = (row: any) => Math.max(1, (row.totalFightMs || 0) / 1000);
         const totalValue = (row: any, metricEntry: typeof OFFENSE_METRICS[number]) => {
             if (metricEntry.id === 'downContributionPercent') {
@@ -92,6 +99,7 @@ export const OffenseSection = ({
                             value: resolvedValue(row, metricEntry),
                             profession: row.profession,
                             professionList: row.professionList,
+                            role: roleOf(row.account),
                         }));
                         const higherIsBetter = !OFFENSE_LOWER_IS_BETTER.has(metricEntry.id);
                         const makeFormatValue = () => (val: number) => {
@@ -108,6 +116,7 @@ export const OffenseSection = ({
                                 players={players}
                                 formatValue={makeFormatValue()}
                                 renderProfessionIcon={renderProfessionIcon}
+                                roleAware
                             />
                         );
                     })}

--- a/src/renderer/stats/sections/OffenseSection.tsx
+++ b/src/renderer/stats/sections/OffenseSection.tsx
@@ -75,6 +75,7 @@ export const OffenseSection = ({
                 icon={<Swords className="w-4 h-4 shrink-0" style={{ color: 'var(--section-offense)' }} />}
                 accentColor="var(--section-offense)"
                 sidebarLabel="Offensive Tabs"
+                keyPrefix="noego-offense"
                 metrics={OFFENSE_METRICS}
                 filteredMetrics={filteredOffenseMetrics}
                 players={stats.offensePlayers}

--- a/src/renderer/stats/sections/OffenseSection.tsx
+++ b/src/renderer/stats/sections/OffenseSection.tsx
@@ -11,8 +11,8 @@ import { useStatsSharedContext } from '../StatsViewContext';
 import { OFFENSE_METRICS } from '../statsMetrics';
 import { MetricDistributionCard } from '../components/MetricDistributionCard';
 
-// Metrics where lower is better (negatively oriented)
-const OFFENSE_LOWER_IS_BETTER = new Set(['glanceRate', 'missed', 'evaded', 'blocked', 'invulned', 'againstDownedDamage']);
+// Metrics where lower is better (negatively oriented — your offense being negated)
+const OFFENSE_LOWER_IS_BETTER = new Set(['glanceRate', 'missed', 'evaded', 'blocked', 'invulned']);
 
 type OffenseSectionProps = {
     offenseSearch: string;

--- a/src/renderer/stats/sections/OffenseSection.tsx
+++ b/src/renderer/stats/sections/OffenseSection.tsx
@@ -1,5 +1,6 @@
+import { useState } from 'react';
 import { useMetricSectionState } from '../hooks/useMetricSectionState';
-import { Maximize2, X, Columns, Users, Swords } from 'lucide-react';
+import { Maximize2, X, Columns, Users, Swords, ChevronDown, ChevronRight } from 'lucide-react';
 import { ColumnFilterDropdown } from '../ui/ColumnFilterDropdown';
 import { SearchSelectDropdown, SearchSelectOption } from '../ui/SearchSelectDropdown';
 import { DenseStatsTable } from '../ui/DenseStatsTable';
@@ -8,6 +9,10 @@ import { StatsTableLayout } from '../ui/StatsTableLayout';
 import { StatsTableShell } from '../ui/StatsTableShell';
 import { useStatsSharedContext } from '../StatsViewContext';
 import { OFFENSE_METRICS } from '../statsMetrics';
+import { MetricDistributionCard } from '../components/MetricDistributionCard';
+
+// Metrics where lower is better (negatively oriented)
+const OFFENSE_LOWER_IS_BETTER = new Set(['glanceRate', 'missed', 'evaded', 'blocked', 'invulned', 'againstDownedDamage']);
 
 type OffenseSectionProps = {
     offenseSearch: string;
@@ -16,6 +21,7 @@ type OffenseSectionProps = {
     setActiveOffenseStat: (value: string) => void;
     offenseViewMode: 'total' | 'per1s' | 'per60s';
     setOffenseViewMode: (value: 'total' | 'per1s' | 'per60s') => void;
+    noEgoMode?: boolean;
 };
 
 export const OffenseSection = ({
@@ -24,7 +30,8 @@ export const OffenseSection = ({
     activeOffenseStat,
     setActiveOffenseStat,
     offenseViewMode,
-    setOffenseViewMode
+    setOffenseViewMode,
+    noEgoMode = false,
 }: OffenseSectionProps) => {
     const { stats, roundCountStats, formatWithCommas, renderProfessionIcon, expandedSection, expandedSectionClosing, openExpandedSection, closeExpandedSection, sidebarListClass } = useStatsSharedContext();
     const {
@@ -45,6 +52,192 @@ export const OffenseSection = ({
         renderProfessionIcon,
     });
     const isExpanded = expandedSection === 'offense-detailed';
+    const [detailOpen, setDetailOpen] = useState(false);
+
+    // ── No Ego mode: one MetricDistributionCard per OFFENSE_METRICS entry ──
+    if (noEgoMode && stats.offensePlayers.length > 0) {
+        const totalSeconds = (row: any) => Math.max(1, (row.totalFightMs || 0) / 1000);
+        const totalValue = (row: any, metricEntry: typeof OFFENSE_METRICS[number]) => {
+            if (metricEntry.id === 'downContributionPercent') {
+                const downContribution = row.offenseTotals?.downContribution || 0;
+                const totalDamage = row.offenseTotals?.damage || 0;
+                return totalDamage > 0 ? (downContribution / totalDamage) * 100 : 0;
+            }
+            if (metricEntry.isRate) {
+                const denom = row.offenseRateWeights?.[metricEntry.id] || 0;
+                const numer = row.offenseTotals?.[metricEntry.id] || 0;
+                return denom > 0 ? (numer / denom) * 100 : 0;
+            }
+            return row.offenseTotals?.[metricEntry.id] || 0;
+        };
+        const resolvedValue = (row: any, metricEntry: typeof OFFENSE_METRICS[number]) => {
+            const total = totalValue(row, metricEntry);
+            if (metricEntry.isPercent || metricEntry.isRate) return total;
+            if (offenseViewMode === 'per1s') return total / totalSeconds(row);
+            if (offenseViewMode === 'per60s') return (total * 60) / totalSeconds(row);
+            return total;
+        };
+        return (
+            <div>
+                <div className="flex flex-wrap items-center gap-2 mb-3.5">
+                    <Swords className="w-4 h-4 shrink-0" style={{ color: 'var(--section-offense)' }} />
+                    <h3 className="text-[11px] font-semibold uppercase tracking-[0.05em]" style={{ color: 'var(--text-primary)' }}>
+                        Offense Detailed
+                    </h3>
+                </div>
+                <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4">
+                    {OFFENSE_METRICS.map((metricEntry) => {
+                        const players = stats.offensePlayers.map((row: any) => ({
+                            account: row.account,
+                            value: resolvedValue(row, metricEntry),
+                            profession: row.profession,
+                            professionList: row.professionList,
+                        }));
+                        const higherIsBetter = !OFFENSE_LOWER_IS_BETTER.has(metricEntry.id);
+                        const makeFormatValue = () => (val: number) => {
+                            const decimals = roundCountStats && !metricEntry.isPercent && offenseViewMode === 'total' ? 0 : 2;
+                            const formatted = formatWithCommas(val, decimals);
+                            return metricEntry.isPercent ? `${formatted}%` : formatted;
+                        };
+                        return (
+                            <MetricDistributionCard
+                                key={metricEntry.id}
+                                title={metricEntry.label}
+                                accentColor="var(--section-offense)"
+                                higherIsBetter={higherIsBetter}
+                                players={players}
+                                formatValue={makeFormatValue()}
+                                renderProfessionIcon={renderProfessionIcon}
+                            />
+                        );
+                    })}
+                </div>
+                <div className="mt-4">
+                    <button
+                        type="button"
+                        aria-expanded={detailOpen}
+                        onClick={() => setDetailOpen((v) => !v)}
+                        className="flex items-center gap-1 text-xs px-3 py-1.5 rounded-[var(--radius-md)]"
+                        style={{ border: '1px solid var(--border-default)', color: 'var(--text-secondary)', background: 'var(--bg-hover)' }}
+                    >
+                        {detailOpen ? <ChevronDown className="w-3 h-3" /> : <ChevronRight className="w-3 h-3" />}
+                        Per-player detail
+                    </button>
+                    {detailOpen && (
+                        <div className="mt-3">
+                            <StatsTableLayout
+                                expanded={false}
+                                sidebarClassName="pr-3 flex flex-col overflow-y-auto"
+                                sidebarStyle={undefined}
+                                contentClassName="overflow-hidden"
+                                contentStyle={undefined}
+                                sidebar={
+                                    <>
+                                        <div className="text-xs uppercase tracking-widest mb-2" style={{ color: 'var(--text-secondary)' }}>Offensive Tabs</div>
+                                        <input
+                                            value={offenseSearch}
+                                            onChange={(e) => setOffenseSearch(e.target.value)}
+                                            placeholder="Search..."
+                                            className="w-full px-2 py-1 text-xs focus:outline-none mb-2"
+                                            style={{ background: 'transparent', borderBottom: '1px solid var(--border-subtle)', color: 'var(--text-primary)' }}
+                                        />
+                                        <div className={sidebarListClass}>
+                                            {filteredOffenseMetrics.map((metric) => (
+                                                <button
+                                                    key={metric.id}
+                                                    onClick={() => setActiveOffenseStat(metric.id)}
+                                                    className={`w-full text-left px-3 py-1.5 rounded-[var(--radius-md)] text-xs transition-colors ${activeOffenseStat === metric.id
+                                                        ? 'bg-[var(--accent-bg-strong)] text-[color:var(--brand-primary)] font-semibold'
+                                                        : 'hover:bg-[var(--bg-hover)] hover:text-[color:var(--text-primary)]'
+                                                        }`}
+                                                    style={activeOffenseStat !== metric.id ? { color: 'var(--text-secondary)' } : undefined}
+                                                >
+                                                    {metric.label}
+                                                </button>
+                                            ))}
+                                        </div>
+                                    </>
+                                }
+                                content={
+                                    <>
+                                        {(() => {
+                                            const metric = OFFENSE_METRICS.find((entry) => entry.id === activeOffenseStat) || OFFENSE_METRICS[0];
+                                            const tsec = (row: any) => Math.max(1, (row.totalFightMs || 0) / 1000);
+                                            const tval = (row: any) => {
+                                                if (metric.id === 'downContributionPercent') {
+                                                    const dc = row.offenseTotals?.downContribution || 0;
+                                                    const td = row.offenseTotals?.damage || 0;
+                                                    return td > 0 ? (dc / td) * 100 : 0;
+                                                }
+                                                if (metric.isRate) {
+                                                    const denom = row.offenseRateWeights?.[metric.id] || 0;
+                                                    const numer = row.offenseTotals?.[metric.id] || 0;
+                                                    return denom > 0 ? (numer / denom) * 100 : 0;
+                                                }
+                                                return row.offenseTotals?.[metric.id] || 0;
+                                            };
+                                            const fmtVal = (val: number) => {
+                                                const decimals = roundCountStats && !metric.isPercent && offenseViewMode === 'total' ? 0 : 2;
+                                                const formatted = formatWithCommas(val, decimals);
+                                                return metric.isPercent ? `${formatted}%` : formatted;
+                                            };
+                                            const rows = [...stats.offensePlayers]
+                                                .map((row: any) => ({
+                                                    ...row,
+                                                    total: tval(row),
+                                                    per1s: metric.isPercent || metric.isRate ? tval(row) : tval(row) / tsec(row),
+                                                    per60s: metric.isPercent || metric.isRate ? tval(row) : (tval(row) * 60) / tsec(row)
+                                                }))
+                                                .sort((a, b) => {
+                                                    const aVal = Number(offenseViewMode === 'total' ? a.total : offenseViewMode === 'per1s' ? a.per1s : a.per60s);
+                                                    const bVal = Number(offenseViewMode === 'total' ? b.total : offenseViewMode === 'per1s' ? b.per1s : b.per60s);
+                                                    return bVal - aVal || a.account.localeCompare(b.account);
+                                                });
+                                            return (
+                                                <StatsTableShell
+                                                    expanded={false}
+                                                    animationKey={`noego-${activeOffenseStat}-${offenseViewMode}`}
+                                                    header={null}
+                                                    columns={
+                                                        <div className="grid grid-cols-[1.5fr_1fr_0.9fr] text-[10px] uppercase tracking-widest text-[color:var(--text-secondary)] px-3 py-2 border-b border-[color:var(--border-default)]">
+                                                            <div>Player</div>
+                                                            <div className="text-right">
+                                                                {offenseViewMode === 'total' ? 'Total' : offenseViewMode === 'per1s' ? 'Stat/1s' : 'Stat/60s'}
+                                                            </div>
+                                                            <div className="text-right">Fight Time</div>
+                                                        </div>
+                                                    }
+                                                    rows={
+                                                        <>
+                                                            {rows.map((row: any, idx: number) => (
+                                                                <div key={`noego-${metric.id}-${row.account}-${idx}`} className="grid grid-cols-[1.5fr_1fr_0.9fr] px-3 py-2 text-xs border-b border-[color:var(--border-subtle)] hover:bg-[var(--bg-hover)]" style={{ color: 'var(--text-primary)' }}>
+                                                                    <div className="flex items-center gap-2 min-w-0">
+                                                                        {renderProfessionIcon(row.profession, row.professionList, 'w-4 h-4')}
+                                                                        <span className="truncate">{row.account}</span>
+                                                                    </div>
+                                                                    <div className="text-right font-mono" style={{ color: 'var(--text-secondary)' }}>
+                                                                        {fmtVal(offenseViewMode === 'total' ? row.total : offenseViewMode === 'per1s' ? row.per1s : row.per60s)}
+                                                                    </div>
+                                                                    <div className="text-right font-mono" style={{ color: 'var(--text-secondary)' }}>
+                                                                        {row.totalFightMs ? `${(row.totalFightMs / 1000).toFixed(1)}s` : '-'}
+                                                                    </div>
+                                                                </div>
+                                                            ))}
+                                                        </>
+                                                    }
+                                                />
+                                            );
+                                        })()}
+                                    </>
+                                }
+                            />
+                        </div>
+                    )}
+                </div>
+            </div>
+        );
+    }
+
     return (
     <div
         className={`${

--- a/src/renderer/stats/sections/SupportSection.tsx
+++ b/src/renderer/stats/sections/SupportSection.tsx
@@ -12,6 +12,10 @@ import { useStatsSharedContext } from '../StatsViewContext';
 import { SUPPORT_METRICS } from '../statsMetrics';
 import { MetricDistributionCard } from '../components/MetricDistributionCard';
 
+// All current support metrics are higher-is-better. Add metric ids here if any
+// lower-is-better metric is introduced (e.g. a "deaths taken" type metric).
+const SUPPORT_LOWER_IS_BETTER = new Set<string>([]);
+
 type SupportSectionProps = {
     supportSearch: string;
     setSupportSearch: (value: string) => void;
@@ -100,7 +104,7 @@ export const SupportSection = ({
                                 key={metricEntry.id}
                                 title={metricEntry.label}
                                 accentColor="var(--section-support)"
-                                higherIsBetter={true}
+                                higherIsBetter={!SUPPORT_LOWER_IS_BETTER.has(metricEntry.id)}
                                 players={players}
                                 formatValue={makeFormatValue()}
                                 renderProfessionIcon={renderProfessionIcon}

--- a/src/renderer/stats/sections/SupportSection.tsx
+++ b/src/renderer/stats/sections/SupportSection.tsx
@@ -60,7 +60,7 @@ export const SupportSection = ({
     const isExpanded = expandedSection === 'support-detailed';
     const [detailOpen, setDetailOpen] = useState(false);
 
-    // ── No Ego mode: one MetricDistributionCard per SUPPORT_METRICS entry ──
+    // ── No Ego mode: sidebar + one large MetricDistributionCard for active metric ──
     if (noEgoMode && stats.supportPlayers.length > 0) {
         const roleByAccount = new Map<string, 'support' | 'damage'>(
           (Array.isArray((stats as any).roleClassifications) ? (stats as any).roleClassifications : [])
@@ -84,6 +84,21 @@ export const SupportSection = ({
             if (supportViewMode === 'per60s') return (total * 60) / totalSeconds(row);
             return total;
         };
+        const activeMetric = SUPPORT_METRICS.find((e) => e.id === activeSupportStat) || SUPPORT_METRICS[0];
+        const activePlayers = stats.supportPlayers.map((row: any) => ({
+            account: row.account,
+            value: resolvedValue(row, activeMetric),
+            profession: row.profession,
+            professionList: row.professionList,
+            role: roleOf(row.account),
+        }));
+        const activeHigherIsBetter = !SUPPORT_LOWER_IS_BETTER.has(activeMetric.id);
+        const activeFormatValue = (val: number) => {
+            const decimals = activeMetric.isTime
+                ? 1
+                : (roundCountStats && supportViewMode === 'total' ? 0 : 2);
+            return formatWithCommas(val, decimals);
+        };
         return (
             <div>
                 <div className="flex flex-wrap items-center gap-2 mb-3.5">
@@ -92,93 +107,67 @@ export const SupportSection = ({
                         Support Detailed
                     </h3>
                 </div>
-                <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4">
-                    {SUPPORT_METRICS.map((metricEntry) => {
-                        const players = stats.supportPlayers.map((row: any) => ({
-                            account: row.account,
-                            value: resolvedValue(row, metricEntry),
-                            profession: row.profession,
-                            professionList: row.professionList,
-                            role: roleOf(row.account),
-                        }));
-                        const makeFormatValue = () => (val: number) => {
-                            const decimals = metricEntry.isTime
-                                ? 1
-                                : (roundCountStats && supportViewMode === 'total' ? 0 : 2);
-                            return formatWithCommas(val, decimals);
-                        };
-                        return (
-                            <MetricDistributionCard
-                                key={metricEntry.id}
-                                title={metricEntry.label}
-                                accentColor="var(--section-support)"
-                                higherIsBetter={!SUPPORT_LOWER_IS_BETTER.has(metricEntry.id)}
-                                players={players}
-                                formatValue={makeFormatValue()}
-                                renderProfessionIcon={renderProfessionIcon}
-                                roleAware
+                <StatsTableLayout
+                    expanded={false}
+                    sidebarClassName="pr-3 flex flex-col overflow-y-auto"
+                    sidebarStyle={undefined}
+                    contentClassName="overflow-hidden"
+                    contentStyle={undefined}
+                    sidebar={
+                        <>
+                            <div className="text-xs uppercase tracking-widest mb-2" style={{ color: 'var(--text-secondary)' }}>Support Tabs</div>
+                            <input
+                                value={supportSearch}
+                                onChange={(e) => setSupportSearch(e.target.value)}
+                                placeholder="Search..."
+                                className="w-full px-2 py-1 text-xs focus:outline-none mb-2"
+                                style={{ background: 'transparent', borderBottom: '1px solid var(--border-subtle)', color: 'var(--text-primary)' }}
                             />
-                        );
-                    })}
-                </div>
-                <div className="mt-4">
-                    <button
-                        type="button"
-                        aria-expanded={detailOpen}
-                        onClick={() => setDetailOpen((v) => !v)}
-                        className="flex items-center gap-1 text-xs px-3 py-1.5 rounded-[var(--radius-md)]"
-                        style={{ border: '1px solid var(--border-default)', color: 'var(--text-secondary)', background: 'var(--bg-hover)' }}
-                    >
-                        {detailOpen ? <ChevronDown className="w-3 h-3" /> : <ChevronRight className="w-3 h-3" />}
-                        Per-player detail
-                    </button>
-                    {detailOpen && (
-                        <div className="mt-3">
-                            <StatsTableLayout
-                                expanded={false}
-                                sidebarClassName="pr-3 flex flex-col overflow-y-auto"
-                                sidebarStyle={undefined}
-                                contentClassName="overflow-hidden"
-                                contentStyle={undefined}
-                                sidebar={
-                                    <>
-                                        <div className="text-xs uppercase tracking-widest mb-2" style={{ color: 'var(--text-secondary)' }}>Support Tabs</div>
-                                        <input
-                                            value={supportSearch}
-                                            onChange={(e) => setSupportSearch(e.target.value)}
-                                            placeholder="Search..."
-                                            className="w-full px-2 py-1 text-xs focus:outline-none mb-2"
-                                            style={{ background: 'transparent', borderBottom: '1px solid var(--border-subtle)', color: 'var(--text-primary)' }}
-                                        />
-                                        <div className={sidebarListClass}>
-                                            {filteredSupportMetrics.map((metric) => (
-                                                <button
-                                                    key={metric.id}
-                                                    onClick={() => setActiveSupportStat(metric.id)}
-                                                    className={`w-full text-left px-3 py-1.5 rounded-[var(--radius-md)] text-xs transition-colors ${activeSupportStat === metric.id
-                                                        ? 'bg-[var(--accent-bg-strong)] text-[color:var(--brand-primary)] font-semibold'
-                                                        : 'hover:bg-[var(--bg-hover)] hover:text-[color:var(--text-primary)]'
-                                                        }`}
-                                                    style={activeSupportStat !== metric.id ? { color: 'var(--text-secondary)' } : undefined}
-                                                >
-                                                    {metric.label}
-                                                </button>
-                                            ))}
-                                        </div>
-                                    </>
-                                }
-                                content={
-                                    <>
+                            <div className={sidebarListClass}>
+                                {filteredSupportMetrics.map((metric) => (
+                                    <button
+                                        key={metric.id}
+                                        onClick={() => setActiveSupportStat(metric.id)}
+                                        className={`w-full text-left px-3 py-1.5 rounded-[var(--radius-md)] text-xs transition-colors ${activeSupportStat === metric.id
+                                            ? 'bg-[var(--accent-bg-strong)] text-[color:var(--brand-primary)] font-semibold'
+                                            : 'hover:bg-[var(--bg-hover)] hover:text-[color:var(--text-primary)]'
+                                            }`}
+                                        style={activeSupportStat !== metric.id ? { color: 'var(--text-secondary)' } : undefined}
+                                    >
+                                        {metric.label}
+                                    </button>
+                                ))}
+                            </div>
+                        </>
+                    }
+                    content={
+                        <div className="flex flex-col gap-4">
+                            <MetricDistributionCard
+                                large
+                                roleAware
+                                title={activeMetric.label}
+                                accentColor="var(--section-support)"
+                                higherIsBetter={activeHigherIsBetter}
+                                players={activePlayers}
+                                formatValue={activeFormatValue}
+                                renderProfessionIcon={renderProfessionIcon}
+                            />
+                            <div>
+                                <button
+                                    type="button"
+                                    aria-expanded={detailOpen}
+                                    onClick={() => setDetailOpen((v) => !v)}
+                                    className="flex items-center gap-1 text-xs px-3 py-1.5 rounded-[var(--radius-md)]"
+                                    style={{ border: '1px solid var(--border-default)', color: 'var(--text-secondary)', background: 'var(--bg-hover)' }}
+                                >
+                                    {detailOpen ? <ChevronDown className="w-3 h-3" /> : <ChevronRight className="w-3 h-3" />}
+                                    Per-player detail
+                                </button>
+                                {detailOpen && (
+                                    <div className="mt-3">
                                         {(() => {
-                                            const metric = SUPPORT_METRICS.find((entry) => entry.id === activeSupportStat) || SUPPORT_METRICS[0];
-                                            const resolveSupportTotal = (row: any) => {
-                                                if (metric.id === 'condiCleanse') {
-                                                    const squad = row.supportTotals?.condiCleanse || 0;
-                                                    const self = row.supportTotals?.condiCleanseSelf || 0;
-                                                    return cleanseScope === 'all' ? squad + self : squad;
-                                                }
-                                                return row.supportTotals?.[metric.id] || 0;
-                                            };
+                                            const metric = activeMetric;
+                                            const resolveSupportTotal = (row: any) => resolveSupportTotalForMetric(row, metric.id);
                                             const tsec = (row: any) => Math.max(1, (row.activeMs || 0) / 1000);
                                             const rows = [...stats.supportPlayers]
                                                 .map((row: any) => ({
@@ -227,12 +216,12 @@ export const SupportSection = ({
                                                 />
                                             );
                                         })()}
-                                    </>
-                                }
-                            />
+                                    </div>
+                                )}
+                            </div>
                         </div>
-                    )}
-                </div>
+                    }
+                />
             </div>
         );
     }

--- a/src/renderer/stats/sections/SupportSection.tsx
+++ b/src/renderer/stats/sections/SupportSection.tsx
@@ -62,6 +62,13 @@ export const SupportSection = ({
 
     // ── No Ego mode: one MetricDistributionCard per SUPPORT_METRICS entry ──
     if (noEgoMode && stats.supportPlayers.length > 0) {
+        const roleByAccount = new Map<string, 'support' | 'damage'>(
+          (Array.isArray((stats as any).roleClassifications) ? (stats as any).roleClassifications : [])
+            .filter((r: any) => r && (r.role === 'support' || r.role === 'damage'))
+            .map((r: any) => [String(r.account), r.role as 'support' | 'damage']),
+        );
+        const roleOf = (account: string): 'support' | 'damage' | undefined =>
+          roleByAccount.get(account) ?? roleByAccount.get(String(account).split('::')[0]);
         const totalSeconds = (row: any) => Math.max(1, (row.activeMs || 0) / 1000);
         const resolveSupportTotalForMetric = (row: any, metricId: string) => {
             if (metricId === 'condiCleanse') {
@@ -92,6 +99,7 @@ export const SupportSection = ({
                             value: resolvedValue(row, metricEntry),
                             profession: row.profession,
                             professionList: row.professionList,
+                            role: roleOf(row.account),
                         }));
                         const makeFormatValue = () => (val: number) => {
                             const decimals = metricEntry.isTime
@@ -108,6 +116,7 @@ export const SupportSection = ({
                                 players={players}
                                 formatValue={makeFormatValue()}
                                 renderProfessionIcon={renderProfessionIcon}
+                                roleAware
                             />
                         );
                     })}

--- a/src/renderer/stats/sections/SupportSection.tsx
+++ b/src/renderer/stats/sections/SupportSection.tsx
@@ -102,11 +102,24 @@ export const SupportSection = ({
         };
         return (
             <div>
-                <div className="flex flex-wrap items-center gap-2 mb-3.5">
-                    <span className="flex shrink-0" style={{ color: 'var(--section-support)' }}><SupportPlusIcon className="w-4 h-4" /></span>
-                    <h3 className="text-[11px] font-semibold uppercase tracking-[0.05em]" style={{ color: 'var(--text-primary)' }}>
-                        Support Detailed
-                    </h3>
+                <div className="flex flex-wrap items-center justify-between gap-2 mb-3.5">
+                    <div className="flex items-center gap-2">
+                        <span className="flex shrink-0" style={{ color: 'var(--section-support)' }}><SupportPlusIcon className="w-4 h-4" /></span>
+                        <h3 className="text-[11px] font-semibold uppercase tracking-[0.05em]" style={{ color: 'var(--text-primary)' }}>
+                            Support Detailed
+                        </h3>
+                    </div>
+                    <PillToggleGroup
+                        value={supportViewMode}
+                        onChange={setSupportViewMode}
+                        options={[
+                            { value: 'total', label: 'Total' },
+                            { value: 'per1s', label: 'Stat/1s' },
+                            { value: 'per60s', label: 'Stat/60s' }
+                        ]}
+                        activeClassName="bg-[var(--accent-bg-strong)] text-[color:var(--brand-primary)] border border-[color:var(--accent-border)]"
+                        inactiveClassName="text-[color:var(--text-secondary)]"
+                    />
                 </div>
                 <StatsTableLayout
                     expanded={false}

--- a/src/renderer/stats/sections/SupportSection.tsx
+++ b/src/renderer/stats/sections/SupportSection.tsx
@@ -1,5 +1,6 @@
+import { useState } from 'react';
 import { useMetricSectionState } from '../hooks/useMetricSectionState';
-import { Maximize2, X, Columns, Users } from 'lucide-react';
+import { Maximize2, X, Columns, Users, ChevronDown, ChevronRight } from 'lucide-react';
 import { SupportPlusIcon } from '../../ui/SupportPlusIcon';
 import { ColumnFilterDropdown } from '../ui/ColumnFilterDropdown';
 import { SearchSelectDropdown, SearchSelectOption } from '../ui/SearchSelectDropdown';
@@ -9,6 +10,7 @@ import { StatsTableLayout } from '../ui/StatsTableLayout';
 import { StatsTableShell } from '../ui/StatsTableShell';
 import { useStatsSharedContext } from '../StatsViewContext';
 import { SUPPORT_METRICS } from '../statsMetrics';
+import { MetricDistributionCard } from '../components/MetricDistributionCard';
 
 type SupportSectionProps = {
     supportSearch: string;
@@ -19,6 +21,7 @@ type SupportSectionProps = {
     setSupportViewMode: (value: 'total' | 'per1s' | 'per60s') => void;
     cleanseScope: 'all' | 'squad';
     setCleanseScope: (value: 'all' | 'squad') => void;
+    noEgoMode?: boolean;
 };
 
 export const SupportSection = ({
@@ -29,7 +32,8 @@ export const SupportSection = ({
     supportViewMode,
     setSupportViewMode,
     cleanseScope,
-    setCleanseScope
+    setCleanseScope,
+    noEgoMode = false,
 }: SupportSectionProps) => {
     const { stats, roundCountStats, formatWithCommas, renderProfessionIcon, expandedSection, expandedSectionClosing, openExpandedSection, closeExpandedSection, sidebarListClass } = useStatsSharedContext();
     const {
@@ -50,6 +54,176 @@ export const SupportSection = ({
         renderProfessionIcon,
     });
     const isExpanded = expandedSection === 'support-detailed';
+    const [detailOpen, setDetailOpen] = useState(false);
+
+    // ── No Ego mode: one MetricDistributionCard per SUPPORT_METRICS entry ──
+    if (noEgoMode && stats.supportPlayers.length > 0) {
+        const totalSeconds = (row: any) => Math.max(1, (row.activeMs || 0) / 1000);
+        const resolveSupportTotalForMetric = (row: any, metricId: string) => {
+            if (metricId === 'condiCleanse') {
+                const squad = row.supportTotals?.condiCleanse || 0;
+                const self = row.supportTotals?.condiCleanseSelf || 0;
+                return cleanseScope === 'all' ? squad + self : squad;
+            }
+            return row.supportTotals?.[metricId] || 0;
+        };
+        const resolvedValue = (row: any, metricEntry: typeof SUPPORT_METRICS[number]) => {
+            const total = resolveSupportTotalForMetric(row, metricEntry.id);
+            if (supportViewMode === 'per1s') return total / totalSeconds(row);
+            if (supportViewMode === 'per60s') return (total * 60) / totalSeconds(row);
+            return total;
+        };
+        return (
+            <div>
+                <div className="flex flex-wrap items-center gap-2 mb-3.5">
+                    <span className="flex shrink-0" style={{ color: 'var(--section-support)' }}><SupportPlusIcon className="w-4 h-4" /></span>
+                    <h3 className="text-[11px] font-semibold uppercase tracking-[0.05em]" style={{ color: 'var(--text-primary)' }}>
+                        Support Detailed
+                    </h3>
+                </div>
+                <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4">
+                    {SUPPORT_METRICS.map((metricEntry) => {
+                        const players = stats.supportPlayers.map((row: any) => ({
+                            account: row.account,
+                            value: resolvedValue(row, metricEntry),
+                            profession: row.profession,
+                            professionList: row.professionList,
+                        }));
+                        const makeFormatValue = () => (val: number) => {
+                            const decimals = metricEntry.isTime
+                                ? 1
+                                : (roundCountStats && supportViewMode === 'total' ? 0 : 2);
+                            return formatWithCommas(val, decimals);
+                        };
+                        return (
+                            <MetricDistributionCard
+                                key={metricEntry.id}
+                                title={metricEntry.label}
+                                accentColor="var(--section-support)"
+                                higherIsBetter={true}
+                                players={players}
+                                formatValue={makeFormatValue()}
+                                renderProfessionIcon={renderProfessionIcon}
+                            />
+                        );
+                    })}
+                </div>
+                <div className="mt-4">
+                    <button
+                        type="button"
+                        aria-expanded={detailOpen}
+                        onClick={() => setDetailOpen((v) => !v)}
+                        className="flex items-center gap-1 text-xs px-3 py-1.5 rounded-[var(--radius-md)]"
+                        style={{ border: '1px solid var(--border-default)', color: 'var(--text-secondary)', background: 'var(--bg-hover)' }}
+                    >
+                        {detailOpen ? <ChevronDown className="w-3 h-3" /> : <ChevronRight className="w-3 h-3" />}
+                        Per-player detail
+                    </button>
+                    {detailOpen && (
+                        <div className="mt-3">
+                            <StatsTableLayout
+                                expanded={false}
+                                sidebarClassName="pr-3 flex flex-col overflow-y-auto"
+                                sidebarStyle={undefined}
+                                contentClassName="overflow-hidden"
+                                contentStyle={undefined}
+                                sidebar={
+                                    <>
+                                        <div className="text-xs uppercase tracking-widest mb-2" style={{ color: 'var(--text-secondary)' }}>Support Tabs</div>
+                                        <input
+                                            value={supportSearch}
+                                            onChange={(e) => setSupportSearch(e.target.value)}
+                                            placeholder="Search..."
+                                            className="w-full px-2 py-1 text-xs focus:outline-none mb-2"
+                                            style={{ background: 'transparent', borderBottom: '1px solid var(--border-subtle)', color: 'var(--text-primary)' }}
+                                        />
+                                        <div className={sidebarListClass}>
+                                            {filteredSupportMetrics.map((metric) => (
+                                                <button
+                                                    key={metric.id}
+                                                    onClick={() => setActiveSupportStat(metric.id)}
+                                                    className={`w-full text-left px-3 py-1.5 rounded-[var(--radius-md)] text-xs transition-colors ${activeSupportStat === metric.id
+                                                        ? 'bg-[var(--accent-bg-strong)] text-[color:var(--brand-primary)] font-semibold'
+                                                        : 'hover:bg-[var(--bg-hover)] hover:text-[color:var(--text-primary)]'
+                                                        }`}
+                                                    style={activeSupportStat !== metric.id ? { color: 'var(--text-secondary)' } : undefined}
+                                                >
+                                                    {metric.label}
+                                                </button>
+                                            ))}
+                                        </div>
+                                    </>
+                                }
+                                content={
+                                    <>
+                                        {(() => {
+                                            const metric = SUPPORT_METRICS.find((entry) => entry.id === activeSupportStat) || SUPPORT_METRICS[0];
+                                            const resolveSupportTotal = (row: any) => {
+                                                if (metric.id === 'condiCleanse') {
+                                                    const squad = row.supportTotals?.condiCleanse || 0;
+                                                    const self = row.supportTotals?.condiCleanseSelf || 0;
+                                                    return cleanseScope === 'all' ? squad + self : squad;
+                                                }
+                                                return row.supportTotals?.[metric.id] || 0;
+                                            };
+                                            const tsec = (row: any) => Math.max(1, (row.activeMs || 0) / 1000);
+                                            const rows = [...stats.supportPlayers]
+                                                .map((row: any) => ({
+                                                    ...row,
+                                                    total: resolveSupportTotal(row),
+                                                    per1s: resolveSupportTotal(row) / tsec(row),
+                                                    per60s: (resolveSupportTotal(row) * 60) / tsec(row)
+                                                }))
+                                                .sort((a, b) => {
+                                                    const aVal = Number(supportViewMode === 'total' ? a.total : supportViewMode === 'per1s' ? a.per1s : a.per60s);
+                                                    const bVal = Number(supportViewMode === 'total' ? b.total : supportViewMode === 'per1s' ? b.per1s : b.per60s);
+                                                    return bVal - aVal || a.account.localeCompare(b.account);
+                                                });
+                                            return (
+                                                <StatsTableShell
+                                                    expanded={false}
+                                                    animationKey={`noego-support-${activeSupportStat}-${supportViewMode}`}
+                                                    header={null}
+                                                    columns={
+                                                        <div className="grid grid-cols-[1.5fr_1fr_0.9fr] text-[10px] uppercase tracking-widest text-[color:var(--text-secondary)] px-3 py-2 border-b border-[color:var(--border-default)]">
+                                                            <div>Player</div>
+                                                            <div className="text-right">
+                                                                {supportViewMode === 'total' ? 'Total' : supportViewMode === 'per1s' ? 'Stat/1s' : 'Stat/60s'}
+                                                            </div>
+                                                            <div className="text-right">Fight Time</div>
+                                                        </div>
+                                                    }
+                                                    rows={
+                                                        <>
+                                                            {rows.map((row: any, idx: number) => (
+                                                                <div key={`noego-support-${metric.id}-${row.account}-${idx}`} className="grid grid-cols-[1.5fr_1fr_0.9fr] px-3 py-2 text-xs border-b border-[color:var(--border-subtle)] hover:bg-[var(--bg-hover)]" style={{ color: 'var(--text-primary)' }}>
+                                                                    <div className="flex items-center gap-2 min-w-0">
+                                                                        {renderProfessionIcon(row.profession, row.professionList, 'w-4 h-4')}
+                                                                        <span className="truncate">{row.account}</span>
+                                                                    </div>
+                                                                    <div className="text-right font-mono" style={{ color: 'var(--text-secondary)' }}>
+                                                                        {formatWithCommas(supportViewMode === 'total' ? row.total : supportViewMode === 'per1s' ? row.per1s : row.per60s, metric.isTime ? 1 : (roundCountStats && supportViewMode === 'total' ? 0 : 2))}
+                                                                    </div>
+                                                                    <div className="text-right font-mono" style={{ color: 'var(--text-secondary)' }}>
+                                                                        {row.activeMs ? `${(row.activeMs / 1000).toFixed(1)}s` : '-'}
+                                                                    </div>
+                                                                </div>
+                                                            ))}
+                                                        </>
+                                                    }
+                                                />
+                                            );
+                                        })()}
+                                    </>
+                                }
+                            />
+                        </div>
+                    )}
+                </div>
+            </div>
+        );
+    }
+
     return (
     <div
         className={`${

--- a/src/renderer/stats/sections/SupportSection.tsx
+++ b/src/renderer/stats/sections/SupportSection.tsx
@@ -76,6 +76,7 @@ export const SupportSection = ({
                 icon={<span className="flex shrink-0" style={{ color: 'var(--section-support)' }}><SupportPlusIcon className="w-4 h-4" /></span>}
                 accentColor="var(--section-support)"
                 sidebarLabel="Support Tabs"
+                keyPrefix="noego-support"
                 metrics={SUPPORT_METRICS}
                 filteredMetrics={filteredSupportMetrics}
                 players={stats.supportPlayers}

--- a/src/renderer/stats/sections/SupportSection.tsx
+++ b/src/renderer/stats/sections/SupportSection.tsx
@@ -11,6 +11,7 @@ import { StatsTableShell } from '../ui/StatsTableShell';
 import { useStatsSharedContext } from '../StatsViewContext';
 import { SUPPORT_METRICS } from '../statsMetrics';
 import { MetricDistributionCard } from '../components/MetricDistributionCard';
+import type { RoleClassificationEntry } from '../statsTypes';
 
 // All current support metrics are higher-is-better. Add metric ids here if any
 // lower-is-better metric is introduced (e.g. a "deaths taken" type metric).
@@ -63,9 +64,9 @@ export const SupportSection = ({
     // ── No Ego mode: sidebar + one large MetricDistributionCard for active metric ──
     if (noEgoMode && stats.supportPlayers.length > 0) {
         const roleByAccount = new Map<string, 'support' | 'damage'>(
-          (Array.isArray((stats as any).roleClassifications) ? (stats as any).roleClassifications : [])
-            .filter((r: any) => r && (r.role === 'support' || r.role === 'damage'))
-            .map((r: any) => [String(r.account), r.role as 'support' | 'damage']),
+          ((stats.roleClassifications as RoleClassificationEntry[] | undefined) ?? [])
+            .filter((r): r is RoleClassificationEntry => !!r && (r.role === 'support' || r.role === 'damage'))
+            .map((r) => [String(r.account), r.role] as [string, 'support' | 'damage']),
         );
         const roleOf = (account: string): 'support' | 'damage' | undefined =>
           roleByAccount.get(account) ?? roleByAccount.get(String(account).split('::')[0]);

--- a/src/renderer/stats/sections/SupportSection.tsx
+++ b/src/renderer/stats/sections/SupportSection.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { useMetricSectionState } from '../hooks/useMetricSectionState';
-import { Maximize2, X, Columns, Users, ChevronDown, ChevronRight } from 'lucide-react';
+import { Maximize2, X, Columns, Users } from 'lucide-react';
 import { SupportPlusIcon } from '../../ui/SupportPlusIcon';
 import { ColumnFilterDropdown } from '../ui/ColumnFilterDropdown';
 import { SearchSelectDropdown, SearchSelectOption } from '../ui/SearchSelectDropdown';
@@ -10,8 +10,7 @@ import { StatsTableLayout } from '../ui/StatsTableLayout';
 import { StatsTableShell } from '../ui/StatsTableShell';
 import { useStatsSharedContext } from '../StatsViewContext';
 import { SUPPORT_METRICS } from '../statsMetrics';
-import { MetricDistributionCard } from '../components/MetricDistributionCard';
-import type { RoleClassificationEntry } from '../statsTypes';
+import { NoEgoMetricSection } from './NoEgoMetricSection';
 
 // All current support metrics are higher-is-better. Add metric ids here if any
 // lower-is-better metric is introduced (e.g. a "deaths taken" type metric).
@@ -63,14 +62,6 @@ export const SupportSection = ({
 
     // ── No Ego mode: sidebar + one large MetricDistributionCard for active metric ──
     if (noEgoMode && stats.supportPlayers.length > 0) {
-        const roleByAccount = new Map<string, 'support' | 'damage'>(
-          ((stats.roleClassifications as RoleClassificationEntry[] | undefined) ?? [])
-            .filter((r): r is RoleClassificationEntry => !!r && (r.role === 'support' || r.role === 'damage'))
-            .map((r) => [String(r.account), r.role] as [string, 'support' | 'damage']),
-        );
-        const roleOf = (account: string): 'support' | 'damage' | undefined =>
-          roleByAccount.get(account) ?? roleByAccount.get(String(account).split('::')[0]);
-        const totalSeconds = (row: any) => Math.max(1, (row.activeMs || 0) / 1000);
         const resolveSupportTotalForMetric = (row: any, metricId: string) => {
             if (metricId === 'condiCleanse') {
                 const squad = row.supportTotals?.condiCleanse || 0;
@@ -79,164 +70,35 @@ export const SupportSection = ({
             }
             return row.supportTotals?.[metricId] || 0;
         };
-        const resolvedValue = (row: any, metricEntry: typeof SUPPORT_METRICS[number]) => {
-            const total = resolveSupportTotalForMetric(row, metricEntry.id);
-            if (supportViewMode === 'per1s') return total / totalSeconds(row);
-            if (supportViewMode === 'per60s') return (total * 60) / totalSeconds(row);
-            return total;
-        };
-        const activeMetric = SUPPORT_METRICS.find((e) => e.id === activeSupportStat) || SUPPORT_METRICS[0];
-        const activePlayers = stats.supportPlayers.map((row: any) => ({
-            account: row.account,
-            value: resolvedValue(row, activeMetric),
-            profession: row.profession,
-            professionList: row.professionList,
-            role: roleOf(row.account),
-        }));
-        const activeHigherIsBetter = !SUPPORT_LOWER_IS_BETTER.has(activeMetric.id);
-        const activeFormatValue = (val: number) => {
-            const decimals = activeMetric.isTime
-                ? 1
-                : (roundCountStats && supportViewMode === 'total' ? 0 : 2);
-            return formatWithCommas(val, decimals);
-        };
         return (
-            <div>
-                <div className="flex flex-wrap items-center justify-between gap-2 mb-3.5">
-                    <div className="flex items-center gap-2">
-                        <span className="flex shrink-0" style={{ color: 'var(--section-support)' }}><SupportPlusIcon className="w-4 h-4" /></span>
-                        <h3 className="text-[11px] font-semibold uppercase tracking-[0.05em]" style={{ color: 'var(--text-primary)' }}>
-                            Support Detailed
-                        </h3>
-                    </div>
-                    <PillToggleGroup
-                        value={supportViewMode}
-                        onChange={setSupportViewMode}
-                        options={[
-                            { value: 'total', label: 'Total' },
-                            { value: 'per1s', label: 'Stat/1s' },
-                            { value: 'per60s', label: 'Stat/60s' }
-                        ]}
-                        activeClassName="bg-[var(--accent-bg-strong)] text-[color:var(--brand-primary)] border border-[color:var(--accent-border)]"
-                        inactiveClassName="text-[color:var(--text-secondary)]"
-                    />
-                </div>
-                <StatsTableLayout
-                    expanded={false}
-                    sidebarClassName="pr-3 flex flex-col overflow-y-auto"
-                    sidebarStyle={undefined}
-                    contentClassName="overflow-hidden"
-                    contentStyle={undefined}
-                    sidebar={
-                        <>
-                            <div className="text-xs uppercase tracking-widest mb-2" style={{ color: 'var(--text-secondary)' }}>Support Tabs</div>
-                            <input
-                                value={supportSearch}
-                                onChange={(e) => setSupportSearch(e.target.value)}
-                                placeholder="Search..."
-                                className="w-full px-2 py-1 text-xs focus:outline-none mb-2"
-                                style={{ background: 'transparent', borderBottom: '1px solid var(--border-subtle)', color: 'var(--text-primary)' }}
-                            />
-                            <div className={sidebarListClass}>
-                                {filteredSupportMetrics.map((metric) => (
-                                    <button
-                                        key={metric.id}
-                                        onClick={() => setActiveSupportStat(metric.id)}
-                                        className={`w-full text-left px-3 py-1.5 rounded-[var(--radius-md)] text-xs transition-colors ${activeSupportStat === metric.id
-                                            ? 'bg-[var(--accent-bg-strong)] text-[color:var(--brand-primary)] font-semibold'
-                                            : 'hover:bg-[var(--bg-hover)] hover:text-[color:var(--text-primary)]'
-                                            }`}
-                                        style={activeSupportStat !== metric.id ? { color: 'var(--text-secondary)' } : undefined}
-                                    >
-                                        {metric.label}
-                                    </button>
-                                ))}
-                            </div>
-                        </>
-                    }
-                    content={
-                        <div className="flex flex-col gap-4">
-                            <MetricDistributionCard
-                                large
-                                roleAware
-                                title={activeMetric.label}
-                                accentColor="var(--section-support)"
-                                higherIsBetter={activeHigherIsBetter}
-                                players={activePlayers}
-                                formatValue={activeFormatValue}
-                                renderProfessionIcon={renderProfessionIcon}
-                            />
-                            <div>
-                                <button
-                                    type="button"
-                                    aria-expanded={detailOpen}
-                                    onClick={() => setDetailOpen((v) => !v)}
-                                    className="flex items-center gap-1 text-xs px-3 py-1.5 rounded-[var(--radius-md)]"
-                                    style={{ border: '1px solid var(--border-default)', color: 'var(--text-secondary)', background: 'var(--bg-hover)' }}
-                                >
-                                    {detailOpen ? <ChevronDown className="w-3 h-3" /> : <ChevronRight className="w-3 h-3" />}
-                                    Per-player detail
-                                </button>
-                                {detailOpen && (
-                                    <div className="mt-3">
-                                        {(() => {
-                                            const metric = activeMetric;
-                                            const resolveSupportTotal = (row: any) => resolveSupportTotalForMetric(row, metric.id);
-                                            const tsec = (row: any) => Math.max(1, (row.activeMs || 0) / 1000);
-                                            const rows = [...stats.supportPlayers]
-                                                .map((row: any) => ({
-                                                    ...row,
-                                                    total: resolveSupportTotal(row),
-                                                    per1s: resolveSupportTotal(row) / tsec(row),
-                                                    per60s: (resolveSupportTotal(row) * 60) / tsec(row)
-                                                }))
-                                                .sort((a, b) => {
-                                                    const aVal = Number(supportViewMode === 'total' ? a.total : supportViewMode === 'per1s' ? a.per1s : a.per60s);
-                                                    const bVal = Number(supportViewMode === 'total' ? b.total : supportViewMode === 'per1s' ? b.per1s : b.per60s);
-                                                    return bVal - aVal || a.account.localeCompare(b.account);
-                                                });
-                                            return (
-                                                <StatsTableShell
-                                                    expanded={false}
-                                                    animationKey={`noego-support-${activeSupportStat}-${supportViewMode}`}
-                                                    header={null}
-                                                    columns={
-                                                        <div className="grid grid-cols-[1.5fr_1fr_0.9fr] text-[10px] uppercase tracking-widest text-[color:var(--text-secondary)] px-3 py-2 border-b border-[color:var(--border-default)]">
-                                                            <div>Player</div>
-                                                            <div className="text-right">
-                                                                {supportViewMode === 'total' ? 'Total' : supportViewMode === 'per1s' ? 'Stat/1s' : 'Stat/60s'}
-                                                            </div>
-                                                            <div className="text-right">Fight Time</div>
-                                                        </div>
-                                                    }
-                                                    rows={
-                                                        <>
-                                                            {rows.map((row: any, idx: number) => (
-                                                                <div key={`noego-support-${metric.id}-${row.account}-${idx}`} className="grid grid-cols-[1.5fr_1fr_0.9fr] px-3 py-2 text-xs border-b border-[color:var(--border-subtle)] hover:bg-[var(--bg-hover)]" style={{ color: 'var(--text-primary)' }}>
-                                                                    <div className="flex items-center gap-2 min-w-0">
-                                                                        {renderProfessionIcon(row.profession, row.professionList, 'w-4 h-4')}
-                                                                        <span className="truncate">{row.account}</span>
-                                                                    </div>
-                                                                    <div className="text-right font-mono" style={{ color: 'var(--text-secondary)' }}>
-                                                                        {formatWithCommas(supportViewMode === 'total' ? row.total : supportViewMode === 'per1s' ? row.per1s : row.per60s, metric.isTime ? 1 : (roundCountStats && supportViewMode === 'total' ? 0 : 2))}
-                                                                    </div>
-                                                                    <div className="text-right font-mono" style={{ color: 'var(--text-secondary)' }}>
-                                                                        {row.activeMs ? `${(row.activeMs / 1000).toFixed(1)}s` : '-'}
-                                                                    </div>
-                                                                </div>
-                                                            ))}
-                                                        </>
-                                                    }
-                                                />
-                                            );
-                                        })()}
-                                    </div>
-                                )}
-                            </div>
-                        </div>
-                    }
-                />
-            </div>
+            <NoEgoMetricSection
+                title="Support Detailed"
+                icon={<span className="flex shrink-0" style={{ color: 'var(--section-support)' }}><SupportPlusIcon className="w-4 h-4" /></span>}
+                accentColor="var(--section-support)"
+                sidebarLabel="Support Tabs"
+                metrics={SUPPORT_METRICS}
+                filteredMetrics={filteredSupportMetrics}
+                players={stats.supportPlayers}
+                roleClassifications={stats.roleClassifications}
+                activeStatId={activeSupportStat}
+                setActiveStatId={setActiveSupportStat}
+                search={supportSearch}
+                setSearch={setSupportSearch}
+                viewMode={supportViewMode}
+                setViewMode={setSupportViewMode}
+                detailOpen={detailOpen}
+                setDetailOpen={setDetailOpen}
+                higherIsBetter={(m) => !SUPPORT_LOWER_IS_BETTER.has(m.id)}
+                resolveTotal={(row, m) => resolveSupportTotalForMetric(row, m.id)}
+                isRateOrPercent={() => false}
+                fightTimeMs={(row) => row.activeMs || 0}
+                formatValue={(m, val) => {
+                    const decimals = (m as any).isTime
+                        ? 1
+                        : (roundCountStats && supportViewMode === 'total' ? 0 : 2);
+                    return formatWithCommas(val, decimals);
+                }}
+            />
         );
     }
 

--- a/src/renderer/stats/sections/TopPlayersSection.tsx
+++ b/src/renderer/stats/sections/TopPlayersSection.tsx
@@ -3,6 +3,7 @@ import { TOP_STATS_CATALOG, DEFAULT_ENABLED_TOP_STATS, type TopStatDef } from '.
 import { TOP_STAT_ICONS } from '../topStatIcons';
 import { BoonGlyph } from '../../ui/BoonGlyph';
 import { useStatsSharedContext } from '../StatsViewContext';
+import { MetricDistributionCard } from '../components/MetricDistributionCard';
 
 type TopPlayersSectionProps = {
     showTopStats: boolean;
@@ -13,6 +14,7 @@ type TopPlayersSectionProps = {
     formatTopStatValue: (value: number) => string;
     isMvpStatEnabled: (name: string) => boolean;
     enabledTopStats?: string[];
+    noEgoMode?: boolean;
 };
 
 const LeaderCard = ({ icon: Icon, title, data, isBoon = false, accentColor, unit = '', onClick, active, rows, formatValue, renderProfessionIcon }: any) => {
@@ -141,6 +143,7 @@ export const TopPlayersSection = ({
     formatTopStatValue,
     isMvpStatEnabled,
     enabledTopStats = DEFAULT_ENABLED_TOP_STATS,
+    noEgoMode = false,
 }: TopPlayersSectionProps) => {
     const { stats, formatWithCommas, renderProfessionIcon } = useStatsSharedContext();
     if (!showTopStats) return null;
@@ -177,6 +180,45 @@ export const TopPlayersSection = ({
         }
         return formatTopStatValue(value);
     };
+
+    if (noEgoMode) {
+        return (
+            <div data-testid="squad-summary">
+                <div className="flex items-center gap-2 mb-3.5">
+                    <Trophy className="w-4 h-4 shrink-0" style={{ color: 'var(--brand-primary)' }} />
+                    <h3 className="text-[11px] font-semibold uppercase tracking-[0.05em]" style={{ color: 'var(--text-primary)' }}>
+                        Squad Summary
+                    </h3>
+                </div>
+                <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4">
+                    {enabledDefs.map((def) => {
+                        const rows =
+                            def.source.kind === 'boon'
+                                ? (stats.boonLeaderboards?.[def.source.boonId] ?? [])
+                                : (topStatsLeaderboards?.[def.source.key] ?? []);
+                        const players = (Array.isArray(rows) ? rows : []).map((r: any) => ({
+                            account: r.account,
+                            value: Number(r.value ?? 0),
+                            profession: r.profession,
+                            professionList: r.professionList,
+                        }));
+                        return (
+                            <MetricDistributionCard
+                                key={def.id}
+                                title={getCardTitle(def, isPerSecond, isPerMinute)}
+                                accentColor={def.color}
+                                higherIsBetter={def.higherIsBetter}
+                                players={players}
+                                unit={def.unit ?? ''}
+                                formatValue={(n) => formatValue(def, n)}
+                                renderProfessionIcon={renderProfessionIcon}
+                            />
+                        );
+                    })}
+                </div>
+            </div>
+        );
+    }
 
     return (
         <div>

--- a/src/renderer/stats/sections/TopPlayersSection.tsx
+++ b/src/renderer/stats/sections/TopPlayersSection.tsx
@@ -4,6 +4,7 @@ import { TOP_STAT_ICONS } from '../topStatIcons';
 import { BoonGlyph } from '../../ui/BoonGlyph';
 import { useStatsSharedContext } from '../StatsViewContext';
 import { MetricDistributionCard } from '../components/MetricDistributionCard';
+import type { RoleClassificationEntry } from '../statsTypes';
 
 type TopPlayersSectionProps = {
     showTopStats: boolean;
@@ -183,9 +184,9 @@ export const TopPlayersSection = ({
 
     if (noEgoMode) {
         const roleByAccount = new Map<string, 'support' | 'damage'>(
-            (Array.isArray((stats as any).roleClassifications) ? (stats as any).roleClassifications : [])
-                .filter((r: any) => r && (r.role === 'support' || r.role === 'damage'))
-                .map((r: any) => [String(r.account), r.role as 'support' | 'damage']),
+            ((stats.roleClassifications as RoleClassificationEntry[] | undefined) ?? [])
+                .filter((r): r is RoleClassificationEntry => !!r && (r.role === 'support' || r.role === 'damage'))
+                .map((r) => [String(r.account), r.role] as [string, 'support' | 'damage']),
         );
         const roleOf = (account: string): 'support' | 'damage' | undefined =>
             roleByAccount.get(account) ?? roleByAccount.get(String(account).split('::')[0]);

--- a/src/renderer/stats/sections/TopPlayersSection.tsx
+++ b/src/renderer/stats/sections/TopPlayersSection.tsx
@@ -182,6 +182,14 @@ export const TopPlayersSection = ({
     };
 
     if (noEgoMode) {
+        const roleByAccount = new Map<string, 'support' | 'damage'>(
+            (Array.isArray((stats as any).roleClassifications) ? (stats as any).roleClassifications : [])
+                .filter((r: any) => r && (r.role === 'support' || r.role === 'damage'))
+                .map((r: any) => [String(r.account), r.role as 'support' | 'damage']),
+        );
+        const roleOf = (account: string): 'support' | 'damage' | undefined =>
+            roleByAccount.get(account) ?? roleByAccount.get(String(account).split('::')[0]);
+
         return (
             <div data-testid="squad-summary">
                 <div className="flex items-center gap-2 mb-3.5">
@@ -201,6 +209,7 @@ export const TopPlayersSection = ({
                             value: Number(r.value ?? 0),
                             profession: r.profession,
                             professionList: r.professionList,
+                            role: roleOf(r.account),
                         }));
                         return (
                             <MetricDistributionCard
@@ -210,6 +219,7 @@ export const TopPlayersSection = ({
                                 higherIsBetter={def.higherIsBetter}
                                 players={players}
                                 unit={def.unit ?? ''}
+                                roleAware
                                 formatValue={(n) => formatValue(def, n)}
                                 renderProfessionIcon={renderProfessionIcon}
                             />

--- a/src/renderer/stats/sections/__tests__/DefenseSection.noego.test.tsx
+++ b/src/renderer/stats/sections/__tests__/DefenseSection.noego.test.tsx
@@ -13,11 +13,11 @@ const makeDefensePlayer = (account: string, damageBarrier: number) => ({
     defenseRateWeights: {},
 });
 
-// Role-aware fixture: 10 damage players tightly clustered at high damageBarrier (10000),
+// Role-aware fixture: 9 damage players at high damageBarrier (10000) + 1 at 1500 (DmgLow.9999),
 // and 3 support players tightly clustered at very low damageBarrier (100).
-// Squad math: 13 players, mean = (10*10000 + 3*100)/13 ≈ 7715, σ ≈ 4171
-// cutoff (mean - 1.5σ) ≈ 7715 - 6257 ≈ 1458. Support players at 100 are < 1458 → FLAGGED squad-wide.
-// With roleAware: support cohort has stdDev=0 → NOT flagged within cohort.
+// Damage cohort math: mean = (9*10000 + 1500)/10 = 9150, σ ≈ 2549.
+// cutoff (mean - 1.5σ) ≈ 9150 - 3824 ≈ 5326. DmgLow.9999 at 1500 < 5326 → FLAGGED within damage cohort.
+// Support cohort: stdDev=0 → NOT flagged within cohort.
 const roleAwarePlayers = [
     makeDefensePlayer('Damage1.1111', 10000),
     makeDefensePlayer('Damage2.2222', 10000),
@@ -28,7 +28,7 @@ const roleAwarePlayers = [
     makeDefensePlayer('Damage7.7777', 10000),
     makeDefensePlayer('Damage8.8888', 10000),
     makeDefensePlayer('Damage9.9999', 10000),
-    makeDefensePlayer('Damage10.0001', 10000),
+    makeDefensePlayer('DmgLow.9999', 1500),
     makeDefensePlayer('Support1.6666', 100),
     makeDefensePlayer('Support2.7777', 100),
     makeDefensePlayer('Support3.8888', 100),
@@ -44,7 +44,7 @@ const roleClassifications = [
     { account: 'Damage7.7777', role: 'damage' },
     { account: 'Damage8.8888', role: 'damage' },
     { account: 'Damage9.9999', role: 'damage' },
-    { account: 'Damage10.0001', role: 'damage' },
+    { account: 'DmgLow.9999', role: 'damage' },
     { account: 'Support1.6666', role: 'support' },
     { account: 'Support2.7777', role: 'support' },
     { account: 'Support3.8888', role: 'support' },
@@ -107,6 +107,9 @@ describe('DefenseSection — No Ego', () => {
 
         const outlierEls = screen.queryAllByTestId('metric-card-outliers');
         const outlierText = outlierEls.map((el) => el.textContent).join(' ');
+        // POSITIVE: DmgLow.9999 is ~3σ below the damage cohort mean → must appear as outlier
+        expect(outlierText).toContain('DmgLow.9999');
+        // NEGATIVE: support players judged within their own zero-variance cohort → NOT flagged
         expect(outlierText).not.toContain('Support1.6666');
         expect(outlierText).not.toContain('Support2.7777');
         expect(outlierText).not.toContain('Support3.8888');

--- a/src/renderer/stats/sections/__tests__/DefenseSection.noego.test.tsx
+++ b/src/renderer/stats/sections/__tests__/DefenseSection.noego.test.tsx
@@ -1,0 +1,114 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { DefenseSection } from '../DefenseSection';
+import { StatsSharedContext } from '../../StatsViewContext';
+
+const makeDefensePlayer = (account: string, damageBarrier: number) => ({
+    account,
+    profession: 'Guardian',
+    professionList: ['Guardian'],
+    totalFightMs: 120000,
+    activeMs: 120000,
+    defenseTotals: { damageBarrier },
+    defenseRateWeights: {},
+});
+
+// Role-aware fixture: 10 damage players tightly clustered at high damageBarrier (10000),
+// and 3 support players tightly clustered at very low damageBarrier (100).
+// Squad math: 13 players, mean = (10*10000 + 3*100)/13 ≈ 7715, σ ≈ 4171
+// cutoff (mean - 1.5σ) ≈ 7715 - 6257 ≈ 1458. Support players at 100 are < 1458 → FLAGGED squad-wide.
+// With roleAware: support cohort has stdDev=0 → NOT flagged within cohort.
+const roleAwarePlayers = [
+    makeDefensePlayer('Damage1.1111', 10000),
+    makeDefensePlayer('Damage2.2222', 10000),
+    makeDefensePlayer('Damage3.3333', 10000),
+    makeDefensePlayer('Damage4.4444', 10000),
+    makeDefensePlayer('Damage5.5555', 10000),
+    makeDefensePlayer('Damage6.6666', 10000),
+    makeDefensePlayer('Damage7.7777', 10000),
+    makeDefensePlayer('Damage8.8888', 10000),
+    makeDefensePlayer('Damage9.9999', 10000),
+    makeDefensePlayer('Damage10.0001', 10000),
+    makeDefensePlayer('Support1.6666', 100),
+    makeDefensePlayer('Support2.7777', 100),
+    makeDefensePlayer('Support3.8888', 100),
+];
+
+const roleClassifications = [
+    { account: 'Damage1.1111', role: 'damage' },
+    { account: 'Damage2.2222', role: 'damage' },
+    { account: 'Damage3.3333', role: 'damage' },
+    { account: 'Damage4.4444', role: 'damage' },
+    { account: 'Damage5.5555', role: 'damage' },
+    { account: 'Damage6.6666', role: 'damage' },
+    { account: 'Damage7.7777', role: 'damage' },
+    { account: 'Damage8.8888', role: 'damage' },
+    { account: 'Damage9.9999', role: 'damage' },
+    { account: 'Damage10.0001', role: 'damage' },
+    { account: 'Support1.6666', role: 'support' },
+    { account: 'Support2.7777', role: 'support' },
+    { account: 'Support3.8888', role: 'support' },
+];
+
+const ctx: any = {
+    stats: {
+        defensePlayers: roleAwarePlayers,
+        roleClassifications,
+    },
+    expandedSection: null,
+    expandedSectionClosing: false,
+    openExpandedSection: () => {},
+    closeExpandedSection: () => {},
+    isSectionVisible: () => true,
+    isFirstVisibleSection: () => false,
+    sectionClass: (_id: string, base: string) => base,
+    sidebarListClass: '',
+    formatWithCommas: (n: number, d: number) => n.toFixed(d),
+    renderProfessionIcon: () => null,
+    roundCountStats: false,
+    expandedPortalRef: { current: null },
+};
+
+describe('DefenseSection — No Ego', () => {
+    it('renders mean card and per-player detail expander in No Ego mode', () => {
+        render(
+            <StatsSharedContext.Provider value={ctx}>
+                <DefenseSection
+                    defenseSearch=""
+                    setDefenseSearch={() => {}}
+                    activeDefenseStat="damageBarrier"
+                    setActiveDefenseStat={() => {}}
+                    defenseViewMode="total"
+                    setDefenseViewMode={() => {}}
+                    noEgoMode
+                />
+            </StatsSharedContext.Provider>,
+        );
+        // One mean readout for the active metric
+        expect(screen.getAllByTestId('metric-card-mean').length).toBe(1);
+        // Per-player detail expander exists
+        expect(screen.getByRole('button', { name: /per-player detail/i })).toBeInTheDocument();
+    });
+
+    it('role-aware: support players are NOT outliers on damageBarrier (higher-is-better) when roleAware is active', () => {
+        render(
+            <StatsSharedContext.Provider value={ctx}>
+                <DefenseSection
+                    defenseSearch=""
+                    setDefenseSearch={() => {}}
+                    activeDefenseStat="damageBarrier"
+                    setActiveDefenseStat={() => {}}
+                    defenseViewMode="total"
+                    setDefenseViewMode={() => {}}
+                    noEgoMode
+                />
+            </StatsSharedContext.Provider>,
+        );
+
+        const outlierEls = screen.queryAllByTestId('metric-card-outliers');
+        const outlierText = outlierEls.map((el) => el.textContent).join(' ');
+        expect(outlierText).not.toContain('Support1.6666');
+        expect(outlierText).not.toContain('Support2.7777');
+        expect(outlierText).not.toContain('Support3.8888');
+    });
+});

--- a/src/renderer/stats/sections/__tests__/OffenseSection.noego.test.tsx
+++ b/src/renderer/stats/sections/__tests__/OffenseSection.noego.test.tsx
@@ -35,6 +35,62 @@ const ctx: any = {
     expandedPortalRef: { current: null },
 };
 
+// Role-aware fixture: 10 damage players tightly clustered at high damage,
+// and 3 support players tightly clustered at very low damage.
+// Without roleAware: squad stdDev is moderate; supports at ~100 are well below
+// mean - 1.5σ (squad cutoff ≈ 1459 given squad mean ≈ 7715, σ ≈ 4171) → FLAGGED.
+// With roleAware: supports form their own cohort (all at 100 → stdDev = 0) → NOT flagged.
+const makeRoleAwarePlayer = (account: string, damage: number) => ({
+    account,
+    profession: 'Guardian',
+    professionList: ['Guardian'],
+    totalFightMs: 120000,
+    offenseTotals: { damage },
+    offenseRateWeights: {},
+});
+
+const roleAwarePlayers = [
+    // 10 damage players at 10000
+    makeRoleAwarePlayer('Damage1.1111', 10000),
+    makeRoleAwarePlayer('Damage2.2222', 10000),
+    makeRoleAwarePlayer('Damage3.3333', 10000),
+    makeRoleAwarePlayer('Damage4.4444', 10000),
+    makeRoleAwarePlayer('Damage5.5555', 10000),
+    makeRoleAwarePlayer('Damage6.6666', 10000),
+    makeRoleAwarePlayer('Damage7.7777', 10000),
+    makeRoleAwarePlayer('Damage8.8888', 10000),
+    makeRoleAwarePlayer('Damage9.9999', 10000),
+    makeRoleAwarePlayer('Damage10.0001', 10000),
+    // 3 support players all at 100 (squad-wide outliers: value < cutoff ~1459; cohort stdDev=0 → not flagged within cohort)
+    makeRoleAwarePlayer('Support1.6666', 100),
+    makeRoleAwarePlayer('Support2.7777', 100),
+    makeRoleAwarePlayer('Support3.8888', 100),
+];
+
+const roleClassifications = [
+    { account: 'Damage1.1111', role: 'damage' },
+    { account: 'Damage2.2222', role: 'damage' },
+    { account: 'Damage3.3333', role: 'damage' },
+    { account: 'Damage4.4444', role: 'damage' },
+    { account: 'Damage5.5555', role: 'damage' },
+    { account: 'Damage6.6666', role: 'damage' },
+    { account: 'Damage7.7777', role: 'damage' },
+    { account: 'Damage8.8888', role: 'damage' },
+    { account: 'Damage9.9999', role: 'damage' },
+    { account: 'Damage10.0001', role: 'damage' },
+    { account: 'Support1.6666', role: 'support' },
+    { account: 'Support2.7777', role: 'support' },
+    { account: 'Support3.8888', role: 'support' },
+];
+
+const roleAwareCtx: any = {
+    ...ctx,
+    stats: {
+        offensePlayers: roleAwarePlayers,
+        roleClassifications,
+    },
+};
+
 describe('OffenseSection — No Ego', () => {
     it('renders metric distribution cards and expander button', () => {
         render(
@@ -56,5 +112,29 @@ describe('OffenseSection — No Ego', () => {
         expect(
             screen.getByRole('button', { name: /per-player detail|show detail|detailed/i }),
         ).toBeInTheDocument();
+    });
+
+    it('role-aware: support player is NOT an outlier on damage metric when roleAware is active', () => {
+        render(
+            <StatsSharedContext.Provider value={roleAwareCtx}>
+                <OffenseSection
+                    offenseSearch=""
+                    setOffenseSearch={() => {}}
+                    activeOffenseStat="damage"
+                    setActiveOffenseStat={() => {}}
+                    offenseViewMode="total"
+                    setOffenseViewMode={() => {}}
+                    noEgoMode
+                />
+            </StatsSharedContext.Provider>,
+        );
+
+        // Find the outliers list (low performers) in the damage card
+        const outlierEls = screen.queryAllByTestId('metric-card-outliers');
+        // Support players should NOT appear in any outlier list
+        const outlierText = outlierEls.map((el) => el.textContent).join(' ');
+        expect(outlierText).not.toContain('Support1.6666');
+        expect(outlierText).not.toContain('Support2.7777');
+        expect(outlierText).not.toContain('Support3.8888');
     });
 });

--- a/src/renderer/stats/sections/__tests__/OffenseSection.noego.test.tsx
+++ b/src/renderer/stats/sections/__tests__/OffenseSection.noego.test.tsx
@@ -92,7 +92,7 @@ const roleAwareCtx: any = {
 };
 
 describe('OffenseSection — No Ego', () => {
-    it('renders metric distribution cards and expander button', () => {
+    it('renders sidebar + single large card + expander button', () => {
         render(
             <StatsSharedContext.Provider value={ctx}>
                 <OffenseSection
@@ -106,12 +106,14 @@ describe('OffenseSection — No Ego', () => {
                 />
             </StatsSharedContext.Provider>,
         );
-        // At least one distribution card present
-        expect(screen.getAllByTestId('metric-card-mean').length).toBeGreaterThan(0);
-        // Full grid collapsed behind an expander
-        expect(
-            screen.getByRole('button', { name: /per-player detail|show detail|detailed/i }),
-        ).toBeInTheDocument();
+        // Sidebar metric selector is present
+        expect(screen.getByText('Offensive Tabs')).toBeInTheDocument();
+        // Exactly one large card (one mean readout) is shown for the active metric
+        expect(screen.getAllByTestId('metric-card-mean').length).toBe(1);
+        // The large dot-plot is rendered (h-14 from large prop)
+        expect(document.querySelector('[data-testid="metric-card-plot"]')?.className).toContain('h-14');
+        // The per-player detail expander still exists
+        expect(screen.getByRole('button', { name: /per-player detail/i })).toBeInTheDocument();
     });
 
     it('role-aware: support player is NOT an outlier on damage metric when roleAware is active', () => {

--- a/src/renderer/stats/sections/__tests__/OffenseSection.noego.test.tsx
+++ b/src/renderer/stats/sections/__tests__/OffenseSection.noego.test.tsx
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { OffenseSection } from '../OffenseSection';
+import { StatsSharedContext } from '../../StatsViewContext';
+
+const makeOffensePlayer = (account: string, damage: number) => ({
+    account,
+    profession: 'Guardian',
+    professionList: ['Guardian'],
+    totalFightMs: 120000,
+    offenseTotals: { damage },
+    offenseRateWeights: {},
+});
+
+const ctx: any = {
+    stats: {
+        offensePlayers: [
+            makeOffensePlayer('Alpha.1234', 50000),
+            makeOffensePlayer('Beta.5678', 40000),
+            makeOffensePlayer('Gamma.9012', 60000),
+            makeOffensePlayer('Delta.3456', 30000),
+        ],
+    },
+    expandedSection: null,
+    expandedSectionClosing: false,
+    openExpandedSection: () => {},
+    closeExpandedSection: () => {},
+    isSectionVisible: () => true,
+    isFirstVisibleSection: () => false,
+    sectionClass: (_id: string, base: string) => base,
+    sidebarListClass: '',
+    formatWithCommas: (n: number, d: number) => n.toFixed(d),
+    renderProfessionIcon: () => null,
+    roundCountStats: false,
+    expandedPortalRef: { current: null },
+};
+
+describe('OffenseSection — No Ego', () => {
+    it('renders metric distribution cards and expander button', () => {
+        render(
+            <StatsSharedContext.Provider value={ctx}>
+                <OffenseSection
+                    offenseSearch=""
+                    setOffenseSearch={() => {}}
+                    activeOffenseStat="damage"
+                    setActiveOffenseStat={() => {}}
+                    offenseViewMode="total"
+                    setOffenseViewMode={() => {}}
+                    noEgoMode
+                />
+            </StatsSharedContext.Provider>,
+        );
+        // At least one distribution card present
+        expect(screen.getAllByTestId('metric-card-mean').length).toBeGreaterThan(0);
+        // Full grid collapsed behind an expander
+        expect(
+            screen.getByRole('button', { name: /per-player detail|show detail|detailed/i }),
+        ).toBeInTheDocument();
+    });
+});

--- a/src/renderer/stats/sections/__tests__/OffenseSection.noego.test.tsx
+++ b/src/renderer/stats/sections/__tests__/OffenseSection.noego.test.tsx
@@ -49,8 +49,12 @@ const makeRoleAwarePlayer = (account: string, damage: number) => ({
     offenseRateWeights: {},
 });
 
+// Damage cohort: 9 players at 10000 + 1 at 1500 (DmgLow.9999).
+// Within-cohort math: mean = (9*10000 + 1500)/10 = 9150, σ ≈ 2549.
+// cutoff (mean - 1.5σ) ≈ 9150 - 3824 ≈ 5326. 1500 < 5326 → flagged as outlier.
+// Support cohort: all at 100 → stdDev=0 → NOT flagged within cohort.
 const roleAwarePlayers = [
-    // 10 damage players at 10000
+    // 9 damage players at 10000
     makeRoleAwarePlayer('Damage1.1111', 10000),
     makeRoleAwarePlayer('Damage2.2222', 10000),
     makeRoleAwarePlayer('Damage3.3333', 10000),
@@ -60,8 +64,9 @@ const roleAwarePlayers = [
     makeRoleAwarePlayer('Damage7.7777', 10000),
     makeRoleAwarePlayer('Damage8.8888', 10000),
     makeRoleAwarePlayer('Damage9.9999', 10000),
-    makeRoleAwarePlayer('Damage10.0001', 10000),
-    // 3 support players all at 100 (squad-wide outliers: value < cutoff ~1459; cohort stdDev=0 → not flagged within cohort)
+    // 1 damage player at 1500 — should be flagged as within-cohort outlier (~3σ below mean)
+    makeRoleAwarePlayer('DmgLow.9999', 1500),
+    // 3 support players all at 100 (cohort stdDev=0 → not flagged within cohort)
     makeRoleAwarePlayer('Support1.6666', 100),
     makeRoleAwarePlayer('Support2.7777', 100),
     makeRoleAwarePlayer('Support3.8888', 100),
@@ -77,7 +82,7 @@ const roleClassifications = [
     { account: 'Damage7.7777', role: 'damage' },
     { account: 'Damage8.8888', role: 'damage' },
     { account: 'Damage9.9999', role: 'damage' },
-    { account: 'Damage10.0001', role: 'damage' },
+    { account: 'DmgLow.9999', role: 'damage' },
     { account: 'Support1.6666', role: 'support' },
     { account: 'Support2.7777', role: 'support' },
     { account: 'Support3.8888', role: 'support' },
@@ -136,8 +141,10 @@ describe('OffenseSection — No Ego', () => {
 
         // Find the outliers list (low performers) in the damage card
         const outlierEls = screen.queryAllByTestId('metric-card-outliers');
-        // Support players should NOT appear in any outlier list
         const outlierText = outlierEls.map((el) => el.textContent).join(' ');
+        // POSITIVE: DmgLow.9999 is ~3σ below the damage cohort mean → must appear as outlier
+        expect(outlierText).toContain('DmgLow.9999');
+        // NEGATIVE: support players judged within their own zero-variance cohort → NOT flagged
         expect(outlierText).not.toContain('Support1.6666');
         expect(outlierText).not.toContain('Support2.7777');
         expect(outlierText).not.toContain('Support3.8888');

--- a/src/renderer/stats/sections/__tests__/OffenseSection.noego.test.tsx
+++ b/src/renderer/stats/sections/__tests__/OffenseSection.noego.test.tsx
@@ -114,6 +114,9 @@ describe('OffenseSection — No Ego', () => {
         expect(document.querySelector('[data-testid="metric-card-plot"]')?.className).toContain('h-14');
         // The per-player detail expander still exists
         expect(screen.getByRole('button', { name: /per-player detail/i })).toBeInTheDocument();
+        // view-mode toggle present in No Ego mode
+        expect(screen.getByText('Stat/1s')).toBeInTheDocument();
+        expect(screen.getByText('Stat/60s')).toBeInTheDocument();
     });
 
     it('role-aware: support player is NOT an outlier on damage metric when roleAware is active', () => {

--- a/src/renderer/stats/sections/__tests__/SupportSection.noego.test.tsx
+++ b/src/renderer/stats/sections/__tests__/SupportSection.noego.test.tsx
@@ -1,0 +1,121 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { SupportSection } from '../SupportSection';
+import { StatsSharedContext } from '../../StatsViewContext';
+
+// condiCleanse: uses supportTotals.condiCleanse (squad) + supportTotals.condiCleanseSelf (self)
+// cleanseScope='all' → squad + self; 'squad' → squad only
+// We use cleanseScope='squad' so value = row.supportTotals.condiCleanse directly.
+const makeSupportPlayer = (account: string, condiCleanse: number) => ({
+    account,
+    profession: 'Druid',
+    professionList: ['Druid'],
+    totalFightMs: 120000,
+    activeMs: 120000,
+    supportTotals: { condiCleanse, condiCleanseSelf: 0 },
+    supportRateWeights: {},
+});
+
+// Role-aware fixture: 10 damage players tightly clustered at high condiCleanse (10000),
+// and 3 support players tightly clustered at very low condiCleanse (100).
+// Squad math: mean ≈ 7715, σ ≈ 4171, cutoff (mean - 1.5σ) ≈ 1458.
+// Support players at 100 are < 1458 → FLAGGED squad-wide.
+// With roleAware: support cohort has stdDev=0 → NOT flagged within cohort.
+const roleAwarePlayers = [
+    makeSupportPlayer('Damage1.1111', 10000),
+    makeSupportPlayer('Damage2.2222', 10000),
+    makeSupportPlayer('Damage3.3333', 10000),
+    makeSupportPlayer('Damage4.4444', 10000),
+    makeSupportPlayer('Damage5.5555', 10000),
+    makeSupportPlayer('Damage6.6666', 10000),
+    makeSupportPlayer('Damage7.7777', 10000),
+    makeSupportPlayer('Damage8.8888', 10000),
+    makeSupportPlayer('Damage9.9999', 10000),
+    makeSupportPlayer('Damage10.0001', 10000),
+    makeSupportPlayer('Support1.6666', 100),
+    makeSupportPlayer('Support2.7777', 100),
+    makeSupportPlayer('Support3.8888', 100),
+];
+
+const roleClassifications = [
+    { account: 'Damage1.1111', role: 'damage' },
+    { account: 'Damage2.2222', role: 'damage' },
+    { account: 'Damage3.3333', role: 'damage' },
+    { account: 'Damage4.4444', role: 'damage' },
+    { account: 'Damage5.5555', role: 'damage' },
+    { account: 'Damage6.6666', role: 'damage' },
+    { account: 'Damage7.7777', role: 'damage' },
+    { account: 'Damage8.8888', role: 'damage' },
+    { account: 'Damage9.9999', role: 'damage' },
+    { account: 'Damage10.0001', role: 'damage' },
+    { account: 'Support1.6666', role: 'support' },
+    { account: 'Support2.7777', role: 'support' },
+    { account: 'Support3.8888', role: 'support' },
+];
+
+const ctx: any = {
+    stats: {
+        supportPlayers: roleAwarePlayers,
+        roleClassifications,
+    },
+    expandedSection: null,
+    expandedSectionClosing: false,
+    openExpandedSection: () => {},
+    closeExpandedSection: () => {},
+    isSectionVisible: () => true,
+    isFirstVisibleSection: () => false,
+    sectionClass: (_id: string, base: string) => base,
+    sidebarListClass: '',
+    formatWithCommas: (n: number, d: number) => n.toFixed(d),
+    renderProfessionIcon: () => null,
+    roundCountStats: false,
+    expandedPortalRef: { current: null },
+};
+
+describe('SupportSection — No Ego', () => {
+    it('renders mean card and per-player detail expander in No Ego mode', () => {
+        render(
+            <StatsSharedContext.Provider value={ctx}>
+                <SupportSection
+                    supportSearch=""
+                    setSupportSearch={() => {}}
+                    activeSupportStat="condiCleanse"
+                    setActiveSupportStat={() => {}}
+                    supportViewMode="total"
+                    setSupportViewMode={() => {}}
+                    cleanseScope="squad"
+                    setCleanseScope={() => {}}
+                    noEgoMode
+                />
+            </StatsSharedContext.Provider>,
+        );
+        // One mean readout for the active metric
+        expect(screen.getAllByTestId('metric-card-mean').length).toBe(1);
+        // Per-player detail expander exists
+        expect(screen.getByRole('button', { name: /per-player detail/i })).toBeInTheDocument();
+    });
+
+    it('role-aware: support players are NOT outliers on condiCleanse (higher-is-better) when roleAware is active', () => {
+        render(
+            <StatsSharedContext.Provider value={ctx}>
+                <SupportSection
+                    supportSearch=""
+                    setSupportSearch={() => {}}
+                    activeSupportStat="condiCleanse"
+                    setActiveSupportStat={() => {}}
+                    supportViewMode="total"
+                    setSupportViewMode={() => {}}
+                    cleanseScope="squad"
+                    setCleanseScope={() => {}}
+                    noEgoMode
+                />
+            </StatsSharedContext.Provider>,
+        );
+
+        const outlierEls = screen.queryAllByTestId('metric-card-outliers');
+        const outlierText = outlierEls.map((el) => el.textContent).join(' ');
+        expect(outlierText).not.toContain('Support1.6666');
+        expect(outlierText).not.toContain('Support2.7777');
+        expect(outlierText).not.toContain('Support3.8888');
+    });
+});

--- a/src/renderer/stats/sections/__tests__/SupportSection.noego.test.tsx
+++ b/src/renderer/stats/sections/__tests__/SupportSection.noego.test.tsx
@@ -6,6 +6,16 @@ import { StatsSharedContext } from '../../StatsViewContext';
 // condiCleanse: uses supportTotals.condiCleanse (squad) + supportTotals.condiCleanseSelf (self)
 // cleanseScope='all' → squad + self; 'squad' → squad only
 // We use cleanseScope='squad' so value = row.supportTotals.condiCleanse directly.
+const makeDamagePlayer = (account: string, condiCleanse: number) => ({
+    account,
+    profession: 'Guardian',
+    professionList: ['Guardian'],
+    totalFightMs: 120000,
+    activeMs: 120000,
+    supportTotals: { condiCleanse, condiCleanseSelf: 0 },
+    supportRateWeights: {},
+});
+
 const makeSupportPlayer = (account: string, condiCleanse: number) => ({
     account,
     profession: 'Druid',
@@ -16,22 +26,22 @@ const makeSupportPlayer = (account: string, condiCleanse: number) => ({
     supportRateWeights: {},
 });
 
-// Role-aware fixture: 10 damage players tightly clustered at high condiCleanse (10000),
+// Role-aware fixture: 9 damage players at high condiCleanse (10000) + 1 at 1500 (DmgLow.9999),
 // and 3 support players tightly clustered at very low condiCleanse (100).
-// Squad math: mean ≈ 7715, σ ≈ 4171, cutoff (mean - 1.5σ) ≈ 1458.
-// Support players at 100 are < 1458 → FLAGGED squad-wide.
-// With roleAware: support cohort has stdDev=0 → NOT flagged within cohort.
+// Damage cohort math: mean = (9*10000 + 1500)/10 = 9150, σ ≈ 2549.
+// cutoff (mean - 1.5σ) ≈ 9150 - 3824 ≈ 5326. DmgLow.9999 at 1500 < 5326 → FLAGGED within damage cohort.
+// Support cohort: stdDev=0 → NOT flagged within cohort.
 const roleAwarePlayers = [
-    makeSupportPlayer('Damage1.1111', 10000),
-    makeSupportPlayer('Damage2.2222', 10000),
-    makeSupportPlayer('Damage3.3333', 10000),
-    makeSupportPlayer('Damage4.4444', 10000),
-    makeSupportPlayer('Damage5.5555', 10000),
-    makeSupportPlayer('Damage6.6666', 10000),
-    makeSupportPlayer('Damage7.7777', 10000),
-    makeSupportPlayer('Damage8.8888', 10000),
-    makeSupportPlayer('Damage9.9999', 10000),
-    makeSupportPlayer('Damage10.0001', 10000),
+    makeDamagePlayer('Damage1.1111', 10000),
+    makeDamagePlayer('Damage2.2222', 10000),
+    makeDamagePlayer('Damage3.3333', 10000),
+    makeDamagePlayer('Damage4.4444', 10000),
+    makeDamagePlayer('Damage5.5555', 10000),
+    makeDamagePlayer('Damage6.6666', 10000),
+    makeDamagePlayer('Damage7.7777', 10000),
+    makeDamagePlayer('Damage8.8888', 10000),
+    makeDamagePlayer('Damage9.9999', 10000),
+    makeDamagePlayer('DmgLow.9999', 1500),
     makeSupportPlayer('Support1.6666', 100),
     makeSupportPlayer('Support2.7777', 100),
     makeSupportPlayer('Support3.8888', 100),
@@ -47,7 +57,7 @@ const roleClassifications = [
     { account: 'Damage7.7777', role: 'damage' },
     { account: 'Damage8.8888', role: 'damage' },
     { account: 'Damage9.9999', role: 'damage' },
-    { account: 'Damage10.0001', role: 'damage' },
+    { account: 'DmgLow.9999', role: 'damage' },
     { account: 'Support1.6666', role: 'support' },
     { account: 'Support2.7777', role: 'support' },
     { account: 'Support3.8888', role: 'support' },
@@ -114,6 +124,9 @@ describe('SupportSection — No Ego', () => {
 
         const outlierEls = screen.queryAllByTestId('metric-card-outliers');
         const outlierText = outlierEls.map((el) => el.textContent).join(' ');
+        // POSITIVE: DmgLow.9999 is ~3σ below the damage cohort mean → must appear as outlier
+        expect(outlierText).toContain('DmgLow.9999');
+        // NEGATIVE: support players judged within their own zero-variance cohort → NOT flagged
         expect(outlierText).not.toContain('Support1.6666');
         expect(outlierText).not.toContain('Support2.7777');
         expect(outlierText).not.toContain('Support3.8888');

--- a/src/renderer/stats/sections/__tests__/TopPlayersSection.noego.test.tsx
+++ b/src/renderer/stats/sections/__tests__/TopPlayersSection.noego.test.tsx
@@ -51,25 +51,36 @@ describe('TopPlayersSection — No Ego', () => {
   });
 
   it('does not flag a support player on a damage-style leaderboard (role-aware)', () => {
+    // Fixture: 10 damage players tightly at 45, 4 supports at 3/4/5/6.
+    // Squad mean ≈ 33.4, squad σ ≈ 18.3 → Healer1 (3) is ≈1.66σ below mean (WOULD be flagged squad-wide).
+    // Support cohort mean = 4.5, σ ≈ 1.12 → Healer1 is only ≈1.34σ below cohort mean (NOT flagged, < 1.5σ).
+    // Role-awareness flips Healer1 (and Healer2) from flagged → not-flagged.
     const ctxRole: any = {
       stats: {
         leaderboards: {
           downContrib: [
-            { account: 'D1', value: 40, profession: 'Guardian' },
-            { account: 'D2', value: 42, profession: 'Guardian' },
-            { account: 'D3', value: 44, profession: 'Guardian' },
-            { account: 'D4', value: 46, profession: 'Guardian' },
-            { account: 'D5', value: 48, profession: 'Guardian' },
+            { account: 'D1', value: 45, profession: 'Guardian' },
+            { account: 'D2', value: 45, profession: 'Guardian' },
+            { account: 'D3', value: 45, profession: 'Guardian' },
+            { account: 'D4', value: 45, profession: 'Guardian' },
+            { account: 'D5', value: 45, profession: 'Guardian' },
+            { account: 'D6', value: 45, profession: 'Guardian' },
+            { account: 'D7', value: 45, profession: 'Guardian' },
+            { account: 'D8', value: 45, profession: 'Guardian' },
+            { account: 'D9', value: 45, profession: 'Guardian' },
+            { account: 'D10', value: 45, profession: 'Guardian' },
             { account: 'Healer1', value: 3, profession: 'Druid' },
             { account: 'Healer2', value: 4, profession: 'Druid' },
             { account: 'Healer3', value: 5, profession: 'Druid' },
-            { account: 'Healer4', value: 4, profession: 'Druid' },
+            { account: 'Healer4', value: 6, profession: 'Druid' },
           ],
         },
         roleClassifications: [
           { account: 'D1', role: 'damage' }, { account: 'D2', role: 'damage' },
           { account: 'D3', role: 'damage' }, { account: 'D4', role: 'damage' },
-          { account: 'D5', role: 'damage' },
+          { account: 'D5', role: 'damage' }, { account: 'D6', role: 'damage' },
+          { account: 'D7', role: 'damage' }, { account: 'D8', role: 'damage' },
+          { account: 'D9', role: 'damage' }, { account: 'D10', role: 'damage' },
           { account: 'Healer1', role: 'support' }, { account: 'Healer2', role: 'support' },
           { account: 'Healer3', role: 'support' }, { account: 'Healer4', role: 'support' },
         ],
@@ -84,5 +95,6 @@ describe('TopPlayersSection — No Ego', () => {
     );
     const outliers = screen.getByTestId('metric-card-outliers');
     expect(outliers).not.toHaveTextContent('Healer1');
+    expect(outliers).not.toHaveTextContent('Healer2');
   });
 });

--- a/src/renderer/stats/sections/__tests__/TopPlayersSection.noego.test.tsx
+++ b/src/renderer/stats/sections/__tests__/TopPlayersSection.noego.test.tsx
@@ -49,4 +49,40 @@ describe('TopPlayersSection — No Ego', () => {
     renderWith({ ...base, noEgoMode: false });
     expect(screen.queryByTestId('squad-summary')).toBeNull();
   });
+
+  it('does not flag a support player on a damage-style leaderboard (role-aware)', () => {
+    const ctxRole: any = {
+      stats: {
+        leaderboards: {
+          downContrib: [
+            { account: 'D1', value: 40, profession: 'Guardian' },
+            { account: 'D2', value: 42, profession: 'Guardian' },
+            { account: 'D3', value: 44, profession: 'Guardian' },
+            { account: 'D4', value: 46, profession: 'Guardian' },
+            { account: 'D5', value: 48, profession: 'Guardian' },
+            { account: 'Healer1', value: 3, profession: 'Druid' },
+            { account: 'Healer2', value: 4, profession: 'Druid' },
+            { account: 'Healer3', value: 5, profession: 'Druid' },
+            { account: 'Healer4', value: 4, profession: 'Druid' },
+          ],
+        },
+        roleClassifications: [
+          { account: 'D1', role: 'damage' }, { account: 'D2', role: 'damage' },
+          { account: 'D3', role: 'damage' }, { account: 'D4', role: 'damage' },
+          { account: 'D5', role: 'damage' },
+          { account: 'Healer1', role: 'support' }, { account: 'Healer2', role: 'support' },
+          { account: 'Healer3', role: 'support' }, { account: 'Healer4', role: 'support' },
+        ],
+      },
+      formatWithCommas: (n: number) => String(n),
+      renderProfessionIcon: () => null,
+    };
+    render(
+      <StatsSharedContext.Provider value={ctxRole}>
+        <TopPlayersSection {...base} noEgoMode enabledTopStats={['downContrib']} />
+      </StatsSharedContext.Provider>,
+    );
+    const outliers = screen.getByTestId('metric-card-outliers');
+    expect(outliers).not.toHaveTextContent('Healer1');
+  });
 });

--- a/src/renderer/stats/sections/__tests__/TopPlayersSection.noego.test.tsx
+++ b/src/renderer/stats/sections/__tests__/TopPlayersSection.noego.test.tsx
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { TopPlayersSection } from '../TopPlayersSection';
+import { StatsSharedContext } from '../../StatsViewContext';
+
+// Minimal context value; fill required fields per StatsSharedContextValue.
+const ctx: any = {
+  stats: {
+    leaderboards: {
+      cleanses: [
+        { account: 'A', value: 100, profession: 'Guardian' },
+        { account: 'B', value: 100, profession: 'Guardian' },
+        { account: 'C', value: 100, profession: 'Guardian' },
+        { account: 'LowGuy', value: 0, profession: 'Guardian' },
+      ],
+    },
+  },
+  formatWithCommas: (n: number) => String(n),
+  renderProfessionIcon: () => null,
+};
+
+const renderWith = (props: any) =>
+  render(
+    <StatsSharedContext.Provider value={ctx}>
+      <TopPlayersSection {...props} />
+    </StatsSharedContext.Provider>,
+  );
+
+const base = {
+  showTopStats: true,
+  showMvp: false,
+  topStatsMode: 'total' as const,
+  expandedLeader: null,
+  setExpandedLeader: () => {},
+  formatTopStatValue: (n: number) => String(Math.round(n)),
+  isMvpStatEnabled: () => true,
+  enabledTopStats: ['cleanses'],
+};
+
+describe('TopPlayersSection — No Ego', () => {
+  it('shows squad-summary cards and no podium when noEgoMode', () => {
+    renderWith({ ...base, noEgoMode: true });
+    expect(screen.getByTestId('squad-summary')).toBeInTheDocument();
+    expect(screen.queryByText('Offensive MVP')).toBeNull();
+    expect(screen.getByTestId('metric-card-outliers')).toHaveTextContent('LowGuy');
+  });
+
+  it('shows the normal leaderboard layout when noEgoMode is off', () => {
+    renderWith({ ...base, noEgoMode: false });
+    expect(screen.queryByTestId('squad-summary')).toBeNull();
+  });
+});

--- a/src/renderer/stats/statsTypes.ts
+++ b/src/renderer/stats/statsTypes.ts
@@ -104,3 +104,14 @@ export interface PlayerHealingBreakdown {
     barrierSkills: PlayerHealingSkillEntry[];
     hasHealAddon: boolean;
 }
+
+export interface RoleClassificationEntry {
+    account: string;
+    profession?: string;
+    professionList?: string[];
+    role: 'support' | 'damage';
+    supportScore?: number;
+    confidenceScore?: number;
+    threshold?: number;
+    factors?: unknown[];
+}

--- a/src/shared/__tests__/squadStats.cohort.test.ts
+++ b/src/shared/__tests__/squadStats.cohort.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from 'vitest';
+import { computeCohortStat, type CohortStatPlayer } from '../squadStats';
+
+// 5 damage players with high down-contrib, 4 support players with low down-contrib.
+const downContribSquad: CohortStatPlayer[] = [
+  { account: 'D1', value: 40, role: 'damage' },
+  { account: 'D2', value: 42, role: 'damage' },
+  { account: 'D3', value: 44, role: 'damage' },
+  { account: 'D4', value: 46, role: 'damage' },
+  { account: 'D5', value: 48, role: 'damage' },
+  { account: 'Healer1', value: 3, role: 'support' },
+  { account: 'Healer2', value: 4, role: 'support' },
+  { account: 'Healer3', value: 5, role: 'support' },
+  { account: 'Healer4', value: 4, role: 'support' },
+];
+
+describe('computeCohortStat', () => {
+  it('does NOT flag a support player on a damage-metric just for being below the squad', () => {
+    const s = computeCohortStat(downContribSquad, true);
+    const flagged = s.needsImprovementOutliers.map((o) => o.account);
+    // None of the healers should be flagged: their low down-contrib is normal AMONG supports.
+    expect(flagged).not.toContain('Healer1');
+    expect(flagged).not.toContain('Healer2');
+    expect(flagged).not.toContain('Healer3');
+    expect(flagged).not.toContain('Healer4');
+  });
+
+  it('flags a support player who is genuinely low among supports', () => {
+    const squad: CohortStatPlayer[] = [
+      { account: 'S1', value: 100, role: 'support' },
+      { account: 'S2', value: 100, role: 'support' },
+      { account: 'S3', value: 100, role: 'support' },
+      { account: 'SLow', value: 0, role: 'support' },
+    ];
+    const s = computeCohortStat(squad, true);
+    const low = s.needsImprovementOutliers.find((o) => o.account === 'SLow');
+    expect(low).toBeTruthy();
+    expect(low!.baseline).toBe('support');
+    expect(low!.sigmaGap).toBeGreaterThanOrEqual(1.5);
+  });
+
+  it('falls back to squad baseline when a cohort has fewer than 3 players', () => {
+    const squad: CohortStatPlayer[] = [
+      { account: 'D1', value: 10, role: 'damage' },
+      { account: 'D2', value: 10, role: 'damage' },
+      { account: 'D3', value: 10, role: 'damage' },
+      { account: 'D4', value: 10, role: 'damage' },
+      { account: 'S1', value: 9, role: 'support' },   // support cohort size 2 -> fallback
+      { account: 'S2', value: 11, role: 'support' },
+    ];
+    const s = computeCohortStat(squad, true);
+    expect(s.support).toBeUndefined();          // too small to be its own baseline
+    expect(s.damage).toBeDefined();
+    // Every flagged player (if any) must be judged against 'squad' or 'damage', never 'support'.
+    for (const o of s.needsImprovementOutliers) expect(o.baseline).not.toBe('support');
+  });
+
+  it('uses squad baseline for players with no role', () => {
+    const squad: CohortStatPlayer[] = [
+      { account: 'A', value: 100 },
+      { account: 'B', value: 100 },
+      { account: 'C', value: 100 },
+      { account: 'NoRoleLow', value: 0 },
+    ];
+    const s = computeCohortStat(squad, true);
+    const low = s.needsImprovementOutliers.find((o) => o.account === 'NoRoleLow');
+    expect(low?.baseline).toBe('squad');
+  });
+
+  it('flags the HIGH end for lower-is-better metrics (deaths) within cohort', () => {
+    const squad: CohortStatPlayer[] = [
+      { account: 'D1', value: 1, role: 'damage' },
+      { account: 'D2', value: 1, role: 'damage' },
+      { account: 'D3', value: 1, role: 'damage' },
+      { account: 'DHigh', value: 9, role: 'damage' },
+    ];
+    const s = computeCohortStat(squad, false); // lower is better
+    const hi = s.needsImprovementOutliers.find((o) => o.account === 'DHigh');
+    expect(hi).toBeTruthy();
+    expect(hi!.baseline).toBe('damage');
+  });
+
+  it('populates squad always and both cohort summaries when both are large enough', () => {
+    const s = computeCohortStat(downContribSquad, true);
+    expect(s.squad.count).toBe(9);
+    expect(s.damage?.count).toBe(5);
+    expect(s.support?.count).toBe(4);
+  });
+
+  it('is safe on empty input', () => {
+    const s = computeCohortStat([], true);
+    expect(s.squad.count).toBe(0);
+    expect(s.needsImprovementOutliers).toEqual([]);
+    expect(s.support).toBeUndefined();
+    expect(s.damage).toBeUndefined();
+  });
+});

--- a/src/shared/__tests__/squadStats.test.ts
+++ b/src/shared/__tests__/squadStats.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest';
+import { computeSquadStat } from '../squadStats';
+
+const players = (vals: number[]) =>
+  vals.map((value, i) => ({ account: `P${i}`, value, profession: 'Guardian' }));
+
+describe('computeSquadStat', () => {
+  it('computes mean, population stdDev, min, max, count', () => {
+    const s = computeSquadStat(players([2, 4, 4, 4, 5, 5, 7, 9]), true);
+    expect(s.mean).toBe(5);
+    expect(s.stdDev).toBeCloseTo(2, 5);
+    expect(s.min).toBe(2);
+    expect(s.max).toBe(9);
+    expect(s.count).toBe(8);
+  });
+
+  it('sorts players ascending for the dot-plot', () => {
+    const s = computeSquadStat(players([9, 1, 5]), true);
+    expect(s.players.map((p) => p.value)).toEqual([1, 5, 9]);
+  });
+
+  it('flags LOW outliers when higherIsBetter (low end needs improvement)', () => {
+    // mean 100, one player far below
+    const s = computeSquadStat(players([100, 100, 100, 100, 0]), true, 1.5);
+    expect(s.needsImprovementOutliers.map((p) => p.value)).toEqual([0]);
+  });
+
+  it('flags HIGH outliers when NOT higherIsBetter (e.g. deaths/damage taken)', () => {
+    const s = computeSquadStat(players([0, 0, 0, 0, 100]), false, 1.5);
+    expect(s.needsImprovementOutliers.map((p) => p.value)).toEqual([100]);
+  });
+
+  it('never flags the celebrated end as needs-improvement', () => {
+    // higherIsBetter: a single very HIGH player must NOT be an outlier
+    const s = computeSquadStat(players([0, 0, 0, 0, 100]), true, 1.5);
+    expect(s.needsImprovementOutliers).toEqual([]);
+  });
+
+  it('returns no outliers when stdDev is 0 (all equal)', () => {
+    const s = computeSquadStat(players([3, 3, 3]), true);
+    expect(s.stdDev).toBe(0);
+    expect(s.needsImprovementOutliers).toEqual([]);
+  });
+
+  it('handles single player and empty input safely', () => {
+    const single = computeSquadStat(players([42]), true);
+    expect(single.mean).toBe(42);
+    expect(single.stdDev).toBe(0);
+    expect(single.needsImprovementOutliers).toEqual([]);
+
+    const empty = computeSquadStat([], true);
+    expect(empty.count).toBe(0);
+    expect(empty.mean).toBe(0);
+    expect(empty.players).toEqual([]);
+    expect(empty.needsImprovementOutliers).toEqual([]);
+  });
+
+  it('ignores non-finite values', () => {
+    const s = computeSquadStat(
+      [{ account: 'A', value: 10 }, { account: 'B', value: NaN }, { account: 'C', value: 20 }],
+      true,
+    );
+    expect(s.count).toBe(2);
+    expect(s.mean).toBe(15);
+  });
+});

--- a/src/shared/squadStats.ts
+++ b/src/shared/squadStats.ts
@@ -47,3 +47,71 @@ export function computeSquadStat(
 
   return { mean, stdDev, min, max, count, players: sorted, needsImprovementOutliers };
 }
+
+export type PlayerRole = 'support' | 'damage';
+
+export interface CohortStatPlayer extends SquadStatPlayer {
+  role?: PlayerRole;
+}
+
+export interface CohortOutlier extends SquadStatPlayer {
+  role?: PlayerRole;
+  baseline: 'support' | 'damage' | 'squad';
+  sigmaGap: number;
+}
+
+export interface CohortStatSummary {
+  support?: SquadStatSummary;
+  damage?: SquadStatSummary;
+  squad: SquadStatSummary;
+  needsImprovementOutliers: CohortOutlier[];
+}
+
+export function computeCohortStat(
+  players: CohortStatPlayer[],
+  higherIsBetter: boolean,
+  sigmaThreshold = 1.5,
+  minCohortSize = 3,
+): CohortStatSummary {
+  const valid = (Array.isArray(players) ? players : [])
+    .map((p) => ({ ...p, value: Number(p?.value) }))
+    .filter((p) => Number.isFinite(p.value));
+
+  const squad = computeSquadStat(valid, higherIsBetter, sigmaThreshold);
+  const supportPlayers = valid.filter((p) => p.role === 'support');
+  const damagePlayers = valid.filter((p) => p.role === 'damage');
+  const support = supportPlayers.length >= minCohortSize
+    ? computeSquadStat(supportPlayers, higherIsBetter, sigmaThreshold)
+    : undefined;
+  const damage = damagePlayers.length >= minCohortSize
+    ? computeSquadStat(damagePlayers, higherIsBetter, sigmaThreshold)
+    : undefined;
+
+  const baselineFor = (role?: PlayerRole): { summary: SquadStatSummary; label: 'support' | 'damage' | 'squad' } => {
+    if (role === 'support' && support) return { summary: support, label: 'support' };
+    if (role === 'damage' && damage) return { summary: damage, label: 'damage' };
+    return { summary: squad, label: 'squad' };
+  };
+
+  const needsImprovementOutliers: CohortOutlier[] = [];
+  for (const p of valid) {
+    const { summary, label } = baselineFor(p.role);
+    if (summary.stdDev <= 0) continue;
+    const diff = higherIsBetter ? summary.mean - p.value : p.value - summary.mean;
+    const sigmaGap = diff / summary.stdDev;
+    if (sigmaGap >= sigmaThreshold) {
+      needsImprovementOutliers.push({
+        account: p.account,
+        value: p.value,
+        profession: p.profession,
+        professionList: p.professionList,
+        role: p.role,
+        baseline: label,
+        sigmaGap,
+      });
+    }
+  }
+  needsImprovementOutliers.sort((a, b) => b.sigmaGap - a.sigmaGap);
+
+  return { support, damage, squad, needsImprovementOutliers };
+}

--- a/src/shared/squadStats.ts
+++ b/src/shared/squadStats.ts
@@ -1,0 +1,49 @@
+export interface SquadStatPlayer {
+  account: string;
+  value: number;
+  profession?: string;
+  professionList?: string[];
+}
+
+export interface SquadStatSummary {
+  mean: number;
+  stdDev: number;
+  min: number;
+  max: number;
+  count: number;
+  players: SquadStatPlayer[];
+  needsImprovementOutliers: SquadStatPlayer[];
+}
+
+export function computeSquadStat(
+  players: SquadStatPlayer[],
+  higherIsBetter: boolean,
+  sigmaThreshold = 1.5,
+): SquadStatSummary {
+  const valid = (Array.isArray(players) ? players : [])
+    .map((p) => ({ ...p, value: Number(p?.value) }))
+    .filter((p) => Number.isFinite(p.value));
+
+  const count = valid.length;
+  if (count === 0) {
+    return { mean: 0, stdDev: 0, min: 0, max: 0, count: 0, players: [], needsImprovementOutliers: [] };
+  }
+
+  const sorted = [...valid].sort((a, b) => a.value - b.value);
+  const values = sorted.map((p) => p.value);
+  const mean = values.reduce((sum, v) => sum + v, 0) / count;
+  const variance = values.reduce((sum, v) => sum + (v - mean) ** 2, 0) / count;
+  const stdDev = Math.sqrt(variance);
+  const min = values[0];
+  const max = values[values.length - 1];
+
+  let needsImprovementOutliers: SquadStatPlayer[] = [];
+  if (stdDev > 0) {
+    const cutoff = sigmaThreshold * stdDev;
+    needsImprovementOutliers = sorted.filter((p) =>
+      higherIsBetter ? p.value < mean - cutoff : p.value > mean + cutoff,
+    );
+  }
+
+  return { mean, stdDev, min, max, count, players: sorted, needsImprovementOutliers };
+}

--- a/src/web/__tests__/rollup.noego.test.ts
+++ b/src/web/__tests__/rollup.noego.test.ts
@@ -1,0 +1,18 @@
+/**
+ * No Ego Mode rollup tests.
+ *
+ * The full behavioral suite lives in packages/bridge-metrics/src/__tests__/rollup.noego.test.ts
+ * where it can import the TypeScript source directly.  This file validates that the
+ * re-export in src/web/rollup.ts exposes the noEgoMode field on RollupData so that
+ * reportApp can read rollupData.noEgoMode for display gating.
+ */
+import { describe, expect, it } from 'vitest';
+import { buildRollupData } from '../rollup';
+
+describe('rollup.noego – re-export surface', () => {
+    it('buildRollupData returns a noEgoMode boolean field', () => {
+        const result = buildRollupData([]);
+        // noEgoMode must be a boolean (false for empty list) – not undefined
+        expect(typeof result.noEgoMode).toBe('boolean');
+    });
+});

--- a/src/web/__tests__/rollup.noego.test.tsx
+++ b/src/web/__tests__/rollup.noego.test.tsx
@@ -1,0 +1,107 @@
+/**
+ * No Ego Mode rollup display tests.
+ *
+ * Tests the NoEgoRollup component (exported from reportApp.tsx) which renders
+ * MetricDistributionCard grids instead of ranked tables when noEgoMode is true.
+ *
+ * Strategy: we import and render NoEgoRollup directly rather than spinning up
+ * the full ReportApp (which requires network/fetch mocks). This keeps tests fast
+ * and isolated. The re-export surface check (noEgoMode field) lives in
+ * rollup.noego.test.ts alongside the plain TypeScript tests.
+ */
+import { describe, expect, it } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { NoEgoRollup } from '../reportApp';
+import type { RollupCommanderRow, RollupPlayerRow } from '../rollup';
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+function makeCommanderRow(account: string): RollupCommanderRow {
+    return {
+        account,
+        characterNames: [],
+        profession: 'Guardian',
+        professionBreakdown: [],
+        runs: 5,
+        fightsLed: 20,
+        kills: 100,
+        downs: 5,
+        commanderDeaths: 2,
+        alliesDead: 10,
+        wins: 15,
+        losses: 5,
+        kdr: 50,
+        lastSeenTs: Date.now(),
+    };
+}
+
+function makePlayerRow(account: string): RollupPlayerRow {
+    return {
+        account,
+        characterNames: [],
+        profession: 'Mesmer',
+        professionBreakdown: [],
+        runs: 8,
+        combatTimeMs: 3_600_000, // 60 min
+        squadTimeMs: 0,
+        lastSeenTs: Date.now(),
+    };
+}
+
+const commanderRows: RollupCommanderRow[] = [
+    makeCommanderRow('Alpha.1234'),
+    makeCommanderRow('Bravo.5678'),
+    makeCommanderRow('Charlie.9012'),
+    makeCommanderRow('Delta.3456'),
+];
+
+const playerRows: RollupPlayerRow[] = [
+    makePlayerRow('Player.0001'),
+    makePlayerRow('Player.0002'),
+    makePlayerRow('Player.0003'),
+    makePlayerRow('Player.0004'),
+];
+
+// ── NoEgoRollup component tests ───────────────────────────────────────────────
+describe('NoEgoRollup', () => {
+    it('renders rollup-no-ego-commanders container with MetricDistributionCard mean values', () => {
+        render(<NoEgoRollup commanderRows={commanderRows} playerRows={[]} />);
+
+        const commanderSection = screen.getByTestId('rollup-no-ego-commanders');
+        expect(commanderSection).toBeInTheDocument();
+
+        // MetricDistributionCard renders metric-card-mean elements inside
+        const meanEls = commanderSection.querySelectorAll('[data-testid="metric-card-mean"]');
+        expect(meanEls.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it('renders rollup-no-ego-players container with MetricDistributionCard mean values', () => {
+        render(<NoEgoRollup commanderRows={[]} playerRows={playerRows} />);
+
+        const playerSection = screen.getByTestId('rollup-no-ego-players');
+        expect(playerSection).toBeInTheDocument();
+
+        const meanEls = playerSection.querySelectorAll('[data-testid="metric-card-mean"]');
+        expect(meanEls.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it('renders both sections when both row arrays are populated', () => {
+        render(<NoEgoRollup commanderRows={commanderRows} playerRows={playerRows} />);
+
+        expect(screen.getByTestId('rollup-no-ego-commanders')).toBeInTheDocument();
+        expect(screen.getByTestId('rollup-no-ego-players')).toBeInTheDocument();
+    });
+
+    it('omits commanders section when commanderRows is empty', () => {
+        render(<NoEgoRollup commanderRows={[]} playerRows={playerRows} />);
+
+        expect(screen.queryByTestId('rollup-no-ego-commanders')).not.toBeInTheDocument();
+        expect(screen.getByTestId('rollup-no-ego-players')).toBeInTheDocument();
+    });
+
+    it('omits players section when playerRows is empty', () => {
+        render(<NoEgoRollup commanderRows={commanderRows} playerRows={[]} />);
+
+        expect(screen.getByTestId('rollup-no-ego-commanders')).toBeInTheDocument();
+        expect(screen.queryByTestId('rollup-no-ego-players')).not.toBeInTheDocument();
+    });
+});

--- a/src/web/__tests__/rollup.noego.test.tsx
+++ b/src/web/__tests__/rollup.noego.test.tsx
@@ -71,7 +71,7 @@ describe('NoEgoRollup', () => {
 
         // MetricDistributionCard renders metric-card-mean elements inside
         const meanEls = commanderSection.querySelectorAll('[data-testid="metric-card-mean"]');
-        expect(meanEls.length).toBeGreaterThanOrEqual(1);
+        expect(meanEls.length).toBe(5);
     });
 
     it('renders rollup-no-ego-players container with MetricDistributionCard mean values', () => {
@@ -81,7 +81,7 @@ describe('NoEgoRollup', () => {
         expect(playerSection).toBeInTheDocument();
 
         const meanEls = playerSection.querySelectorAll('[data-testid="metric-card-mean"]');
-        expect(meanEls.length).toBeGreaterThanOrEqual(1);
+        expect(meanEls.length).toBe(2);
     });
 
     it('renders both sections when both row arrays are populated', () => {

--- a/src/web/reportApp.tsx
+++ b/src/web/reportApp.tsx
@@ -16,8 +16,10 @@ import { Gw2BoonIcon } from '../renderer/ui/Gw2BoonIcon';
 import { Gw2DamMitIcon } from '../renderer/ui/Gw2DamMitIcon';
 import { Gw2FuryIcon } from '../renderer/ui/Gw2FuryIcon';
 import { Gw2SigilIcon } from '../renderer/ui/Gw2SigilIcon';
-import { buildRollupData, parseRollupSourcesFile, RollupData, RollupProfessionUsage } from './rollup';
+import { buildRollupData, parseRollupSourcesFile, RollupData, RollupProfessionUsage, RollupCommanderRow, RollupPlayerRow } from './rollup';
 import { getProfessionColor } from '../shared/professionUtils';
+import { MetricDistributionCard } from '../renderer/stats/components/MetricDistributionCard';
+import type { SquadStatPlayer } from '../shared/squadStats';
 import type { ReportPayload, ReportIndexEntry } from '../shared/reportTypes';
 import { expandIconIndex, normalizeCommanderDistance, normalizeTopDownContribution } from '../shared/reportNormalization';
 import {
@@ -201,6 +203,122 @@ const BorderlandsPie = ({ value }: { value: number | null | undefined }) => {
         </svg>
     );
 };
+
+// ── No Ego Rollup ──────────────────────────────────────────────────────────────
+// Exported for unit tests. Renders MetricDistributionCard grids instead of
+// ranked tables when noEgoMode is true.
+export interface NoEgoRollupProps {
+    commanderRows: RollupCommanderRow[];
+    playerRows: RollupPlayerRow[];
+}
+
+export function NoEgoRollup({ commanderRows, playerRows }: NoEgoRollupProps) {
+    const fmtInt = (n: number) => Math.round(n).toString();
+    const fmtDecimal1 = (n: number) => n.toFixed(1);
+    const fmtDecimal2 = (n: number) => n.toFixed(2);
+
+    const commanderCards: Array<{
+        title: string;
+        players: SquadStatPlayer[];
+        higherIsBetter: boolean;
+        formatValue: (n: number) => string;
+        unit?: string;
+    }> = [
+        {
+            title: 'Raids Led',
+            players: commanderRows.map((r) => ({ account: r.account, value: r.runs, profession: r.profession })),
+            higherIsBetter: true,
+            formatValue: fmtInt,
+        },
+        {
+            title: 'Fights Led',
+            players: commanderRows.map((r) => ({ account: r.account, value: r.fightsLed, profession: r.profession })),
+            higherIsBetter: true,
+            formatValue: fmtInt,
+        },
+        {
+            title: 'Kills',
+            players: commanderRows.map((r) => ({ account: r.account, value: r.kills, profession: r.profession })),
+            higherIsBetter: true,
+            formatValue: fmtInt,
+        },
+        {
+            title: 'Commander Deaths',
+            players: commanderRows.map((r) => ({ account: r.account, value: r.commanderDeaths, profession: r.profession })),
+            higherIsBetter: false,
+            formatValue: fmtInt,
+        },
+        {
+            title: 'KDR',
+            players: commanderRows.map((r) => ({ account: r.account, value: r.kdr, profession: r.profession })),
+            higherIsBetter: true,
+            formatValue: fmtDecimal2,
+        },
+    ];
+
+    const playerCards: Array<{
+        title: string;
+        players: SquadStatPlayer[];
+        higherIsBetter: boolean;
+        formatValue: (n: number) => string;
+        unit?: string;
+    }> = [
+        {
+            title: 'Raids Attended',
+            players: playerRows.map((r) => ({ account: r.account, value: r.runs, profession: r.profession })),
+            higherIsBetter: true,
+            formatValue: fmtInt,
+        },
+        {
+            title: 'Combat Time',
+            players: playerRows.map((r) => ({ account: r.account, value: r.combatTimeMs / 60000, profession: r.profession })),
+            higherIsBetter: true,
+            formatValue: fmtDecimal1,
+            unit: 'min',
+        },
+    ];
+
+    return (
+        <>
+            {commanderRows.length > 0 && (
+                <div
+                    data-testid="rollup-no-ego-commanders"
+                    className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4"
+                >
+                    {commanderCards.map((card) => (
+                        <MetricDistributionCard
+                            key={card.title}
+                            title={card.title}
+                            accentColor="#fb923c"
+                            higherIsBetter={card.higherIsBetter}
+                            players={card.players}
+                            formatValue={card.formatValue}
+                            unit={card.unit}
+                        />
+                    ))}
+                </div>
+            )}
+            {playerRows.length > 0 && (
+                <div
+                    data-testid="rollup-no-ego-players"
+                    className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4"
+                >
+                    {playerCards.map((card) => (
+                        <MetricDistributionCard
+                            key={card.title}
+                            title={card.title}
+                            accentColor="#34d399"
+                            higherIsBetter={card.higherIsBetter}
+                            players={card.players}
+                            formatValue={card.formatValue}
+                            unit={card.unit}
+                        />
+                    ))}
+                </div>
+            )}
+        </>
+    );
+}
 
 export function ReportApp() {
     const initialSearchParams = useMemo(() => new URLSearchParams(window.location.search), []);
@@ -1975,9 +2093,7 @@ export function ReportApp() {
                                             {rollupData.commanderRows.length === 0 ? (
                                                 <div className="text-sm text-gray-400">No commander data found yet.</div>
                                             ) : rollupData.noEgoMode ? (
-                                                <div className="rounded-2xl border border-white/5 bg-black/25 px-5 py-6 text-sm text-gray-400" data-testid="rollup-no-ego-commanders">
-                                                    Individual rankings are hidden — No Ego Mode is enabled. {rollupData.commanderRows.length} commander{rollupData.commanderRows.length === 1 ? '' : 's'} contributed across {rollupData.uniqueRaids} raid{rollupData.uniqueRaids === 1 ? '' : 's'}.
-                                                </div>
+                                                <NoEgoRollup commanderRows={rollupData.commanderRows} playerRows={[]} />
                                             ) : (
                                                 <div className="rounded-2xl border border-white/5 bg-black/25 overflow-hidden">
                                                     <div className="border-b border-white/5 px-3 py-3 sm:px-4">
@@ -2088,9 +2204,7 @@ export function ReportApp() {
                                             {rollupData.playerRows.length === 0 ? (
                                                 <div className="text-sm text-gray-400">No attendance data found yet.</div>
                                             ) : rollupData.noEgoMode ? (
-                                                <div className="rounded-2xl border border-white/5 bg-black/25 px-5 py-6 text-sm text-gray-400" data-testid="rollup-no-ego-players">
-                                                    Individual rankings are hidden — No Ego Mode is enabled. {rollupData.playerRows.length} player{rollupData.playerRows.length === 1 ? '' : 's'} attended across {rollupData.uniqueRaids} raid{rollupData.uniqueRaids === 1 ? '' : 's'}.
-                                                </div>
+                                                <NoEgoRollup commanderRows={[]} playerRows={rollupData.playerRows} />
                                             ) : (
                                                 <div className="rounded-2xl border border-white/5 bg-black/25 overflow-hidden">
                                                     <div className="border-b border-white/5 px-3 py-3 sm:px-4">

--- a/src/web/reportApp.tsx
+++ b/src/web/reportApp.tsx
@@ -1974,6 +1974,10 @@ export function ReportApp() {
                                             </div>
                                             {rollupData.commanderRows.length === 0 ? (
                                                 <div className="text-sm text-gray-400">No commander data found yet.</div>
+                                            ) : rollupData.noEgoMode ? (
+                                                <div className="rounded-2xl border border-white/5 bg-black/25 px-5 py-6 text-sm text-gray-400" data-testid="rollup-no-ego-commanders">
+                                                    Individual rankings are hidden — No Ego Mode is enabled. {rollupData.commanderRows.length} commander{rollupData.commanderRows.length === 1 ? '' : 's'} contributed across {rollupData.uniqueRaids} raid{rollupData.uniqueRaids === 1 ? '' : 's'}.
+                                                </div>
                                             ) : (
                                                 <div className="rounded-2xl border border-white/5 bg-black/25 overflow-hidden">
                                                     <div className="border-b border-white/5 px-3 py-3 sm:px-4">
@@ -2083,6 +2087,10 @@ export function ReportApp() {
                                             </div>
                                             {rollupData.playerRows.length === 0 ? (
                                                 <div className="text-sm text-gray-400">No attendance data found yet.</div>
+                                            ) : rollupData.noEgoMode ? (
+                                                <div className="rounded-2xl border border-white/5 bg-black/25 px-5 py-6 text-sm text-gray-400" data-testid="rollup-no-ego-players">
+                                                    Individual rankings are hidden — No Ego Mode is enabled. {rollupData.playerRows.length} player{rollupData.playerRows.length === 1 ? '' : 's'} attended across {rollupData.uniqueRaids} raid{rollupData.uniqueRaids === 1 ? '' : 's'}.
+                                                </div>
                                             ) : (
                                                 <div className="rounded-2xl border border-white/5 bg-black/25 overflow-hidden">
                                                     <div className="border-b border-white/5 px-3 py-3 sm:px-4">


### PR DESCRIPTION
## What

Adds **No Ego mode** — a single master toggle that removes competitive/ranking framing across the desktop app **and** the web report, replacing it with squad-level distribution readouts focused on areas to improve. Plus **role-aware comparisons** so players are judged against their own role cohort.

### No Ego mode
- New `noEgoMode` setting + Settings toggle; when on it overrides `showMvp`/`showTopStats` everywhere. Default off → existing behavior byte-for-byte unchanged.
- New `computeSquadStat` util (population σ, 1.5σ outliers, needs-improvement end chosen by each metric's `higherIsBetter`) and a `MetricDistributionCard` (dot-plot + avg/σ/range + neutral "most room to improve" callouts). **High performers are never celebrated.**
- Top Players → **Squad Summary**; Offense/Defense/Support tables → metric cards with the per-player grid collapsed behind an expander; Top Skills and Player Comparison hidden.
- Web report honors the baked `report.json` flag; the cross-report rollup **computes all aggregates unconditionally** and only reframes its display to distribution cards.

### Role-aware comparisons
- New pure `computeCohortStat` partitions players by the existing binary support/damage classifier and flags outliers against the **role cohort** (≥3 players) or falls back to squad-wide. Fixes healers being flagged for low down-contribution.
- `MetricDistributionCard` gains a `roleAware` mode: role-colored dots, per-cohort headline averages, and `value · −Xσ` outlier rows.
- Wired into the Squad Summary and Offense/Defense/Support cards. Rollup unchanged.

## Notes
- No Ego is display-only: all data is still computed and still sent to `report.json`; the flag only changes presentation (toggling back restores the full ranked view with no recompute).

## Testing
- 1097/1097 unit tests pass (new coverage for `computeSquadStat`, `computeCohortStat`, `MetricDistributionCard`, role-aware sections, StatsView integration, web rollup).
- `npm run validate` (typecheck + lint, 0 warnings) and `npm run build:web` both pass.
- Two independent whole-branch reviews (base feature + role-aware increment): both READY TO MERGE, no Critical/Important findings.

Design docs and plans under `docs/superpowers/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)