### PR TITLE
fix(stats): restore Distance to Tag broken by EI v3.24 combat-replay gating

### DIFF
--- a/src/main/__tests__/detailsProcessing.test.ts
+++ b/src/main/__tests__/detailsProcessing.test.ts
@@ -213,6 +213,50 @@ describe('pruneDetailsForStats', () => {
         expect(crd.extra).toBeUndefined();
     });
 
+    // EI v3.24 requires combat-replay parsing to emit distToCom/stackDist, so we
+    // always parse replay — but the `parseCombatReplay` setting controls whether
+    // the heavy position arrays are kept. keepReplayPositions=false retains the
+    // coarse statsAll scalars (and combatReplayMetaData as a "has-scalars" marker)
+    // while dropping per-actor positions, matching the old low-cost behavior.
+    describe('combat replay position retention', () => {
+        const makeDetails = () => ({
+            combatReplayMetaData: { inchToPixel: 0.01, pollingRate: 150 },
+            players: [{
+                name: 'Alice',
+                statsAll: [{ distToCom: 188, stackDist: 1266 }],
+                combatReplayData: { start: 0, down: [], dead: [], positions: [[1, 2], [3, 4]] },
+            }],
+            targets: [{
+                id: 1,
+                combatReplayData: [{ start: 0, down: 100, dead: 200, positions: [[5, 6]] }],
+            }],
+        });
+
+        it('keeps positions and metadata by default', () => {
+            const pruned = pruneDetailsForStats(makeDetails());
+            expect(pruned.combatReplayMetaData).toBeDefined();
+            expect(pruned.players[0].combatReplayData.positions).toEqual([[1, 2], [3, 4]]);
+            expect(pruned.targets[0].combatReplayData[0].positions).toEqual([[5, 6]]);
+        });
+
+        it('keeps positions when keepReplayPositions=true', () => {
+            const pruned = pruneDetailsForStats(makeDetails(), { keepReplayPositions: true });
+            expect(pruned.players[0].combatReplayData.positions).toEqual([[1, 2], [3, 4]]);
+        });
+
+        it('drops positions but keeps statsAll scalars and metadata when keepReplayPositions=false', () => {
+            const pruned = pruneDetailsForStats(makeDetails(), { keepReplayPositions: false });
+            // Coarse distance scalars survive — Closest to Tag still works.
+            expect(pruned.players[0].statsAll[0].distToCom).toBe(188);
+            expect(pruned.players[0].statsAll[0].stackDist).toBe(1266);
+            // Marker that the log was parsed with replay (so cache isn't treated stale).
+            expect(pruned.combatReplayMetaData).toBeDefined();
+            // Heavy position arrays are gone.
+            expect(pruned.players[0].combatReplayData?.positions).toBeUndefined();
+            expect(pruned.targets[0].combatReplayData?.[0]?.positions).toBeUndefined();
+        });
+    });
+
     it('handles missing players / targets arrays gracefully', () => {
         const pruned = pruneDetailsForStats({ fightName: 'Test' });
         expect(pruned.players).toBeUndefined();

--- a/src/main/__tests__/eiParser.test.ts
+++ b/src/main/__tests__/eiParser.test.ts
@@ -121,6 +121,21 @@ describe('generateEiConf', () => {
         expect(conf).toContain('SaveAtOut=False');
         expect(conf).toContain('OutLocation=/my/output/dir');
     });
+
+    // EI v3.24 only emits the distToCom/stackDist distance-to-tag scalars when
+    // combat replay is parsed (older EI computed them for free). So we always
+    // parse replay to keep "Closest to Tag" working; the `parseCombatReplay`
+    // setting instead controls whether the heavy position arrays are RETAINED
+    // after parse (see pruneDetailsForStats). The EI flag is therefore forced on.
+    it('always parses combat replay even when the setting is off', () => {
+        const conf = generateEiConf({ ...DEFAULT_EI_SETTINGS, parseCombatReplay: false }, '/tmp/out');
+        expect(conf).toContain('ParseCombatReplay=True');
+    });
+
+    it('parses combat replay when the setting is on', () => {
+        const conf = generateEiConf({ ...DEFAULT_EI_SETTINGS, parseCombatReplay: true }, '/tmp/out');
+        expect(conf).toContain('ParseCombatReplay=True');
+    });
 });
 
 describe('isNewerVersion', () => {

--- a/src/main/detailsProcessing.ts
+++ b/src/main/detailsProcessing.ts
@@ -71,10 +71,13 @@ const omit = (obj: any, keys: string[]): any => {
     return out;
 };
 
-const pruneCombatReplayData = (value: any): any => {
+const pruneCombatReplayData = (value: any, keepPositions: boolean): any => {
+    const fields = keepPositions
+        ? ['start', 'down', 'dead', 'positions']
+        : ['start', 'down', 'dead'];
     const pruneEntry = (entry: any) => {
         if (!entry || typeof entry !== 'object') return null;
-        return pick(entry, ['start', 'down', 'dead', 'positions']);
+        return pick(entry, fields);
     };
     if (Array.isArray(value)) {
         return value
@@ -134,27 +137,49 @@ export const countBoonApplications = (boonsStates: any): number => {
     return applied;
 };
 
+export interface PruneDetailsOptions {
+    /**
+     * Whether to retain per-actor combat-replay `positions` arrays (the dominant
+     * payload). EI v3.24+ only emits the distToCom/stackDist distance scalars when
+     * replay is parsed, so we always parse it — but when the user's
+     * `parseCombatReplay` setting is off we drop the positions here, keeping only
+     * the coarse statsAll scalars (and `combatReplayMetaData` as a marker that the
+     * log was parsed with replay). Defaults to true (keep everything).
+     */
+    keepReplayPositions?: boolean;
+}
+
 /**
  * Strip fields not needed by the stats pipeline from a full EI JSON payload.
  * Reduces memory footprint and IPC transfer size.
  * Pure — no I/O, no side effects.
  */
-export const pruneDetailsForStats = (details: any): any => {
+export const pruneDetailsForStats = (details: any, options: PruneDetailsOptions = {}): any => {
     if (!details || typeof details !== 'object') return details;
+    const keepReplayPositions = options.keepReplayPositions !== false;
     const pruned: any = omit(details, TOP_LEVEL_DENY);
     if (Array.isArray(pruned.players)) {
         // Precompute the boon-application count before the heavy `boonsStates`
         // timeline is stripped, so the stats pipeline gets the count without the
         // per-log memory/IPC cost of the full timeline.
-        pruned.players = pruned.players.map((player: any) => ({
-            ...omit(player, PLAYER_DENY),
-            boonsAppliedCount: countBoonApplications(player?.boonsStates),
-        }));
+        pruned.players = pruned.players.map((player: any) => {
+            const out: any = {
+                ...omit(player, PLAYER_DENY),
+                boonsAppliedCount: countBoonApplications(player?.boonsStates),
+            };
+            // Drop the heavy per-player replay positions in coarse mode. The
+            // distToCom/stackDist scalars in statsAll are untouched, so Closest to
+            // Tag still resolves (just without precise per-tick distance).
+            if (!keepReplayPositions && out.combatReplayData) {
+                delete out.combatReplayData;
+            }
+            return out;
+        });
     }
     if (Array.isArray(pruned.targets)) {
         pruned.targets = pruned.targets.map((target: any) => {
             const out = { ...target };
-            out.combatReplayData = pruneCombatReplayData(target?.combatReplayData);
+            out.combatReplayData = pruneCombatReplayData(target?.combatReplayData, keepReplayPositions);
             return out;
         });
     }

--- a/src/main/eiParser.ts
+++ b/src/main/eiParser.ts
@@ -53,7 +53,11 @@ export function generateEiConf(settings: EiParserSettings, outLocation: string):
         `DetailledWvW=${boolToConf(settings.detailledWvW)}`,
         `RawTimelineArrays=${boolToConf(settings.rawTimelineArrays)}`,
         `ComputeDamageModifiers=${boolToConf(settings.computeDamageModifiers)}`,
-        `ParseCombatReplay=${boolToConf(settings.parseCombatReplay)}`,
+        // Always parse combat replay: EI v3.24+ only emits the distToCom/stackDist
+        // distance-to-tag scalars when replay is parsed (older EI computed them for
+        // free). The `parseCombatReplay` setting instead controls whether the heavy
+        // position arrays are RETAINED post-parse — see pruneDetailsForStats.
+        `ParseCombatReplay=True`,
         `ParsePhases=${boolToConf(settings.parsePhases)}`,
         `SingleThreaded=${boolToConf(settings.singleThreaded)}`,
         `SkipFailedTries=${boolToConf(settings.skipFailedTries)}`,

--- a/src/main/handlers/uploadHandlers.ts
+++ b/src/main/handlers/uploadHandlers.ts
@@ -159,7 +159,11 @@ export function registerUploadHandlers(opts: UploadHandlerOptions) {
                     const refreshed = await fetchDetailsFromPermalinkWithRetry(permalink);
                     if (!refreshed.details) return refreshed;
                     attachConditionMetrics(refreshed.details);
-                    const resolved = pruneDetailsForStats(refreshed.details);
+                    // Retain combat-replay positions only when the user's
+                    // parseCombatReplay setting is on; otherwise keep just the
+                    // coarse statsAll distance scalars (see pruneDetailsForStats).
+                    const keepReplayPositions = Boolean(store.get('eiParserSettings')?.parseCombatReplay);
+                    const resolved = pruneDetailsForStats(refreshed.details, { keepReplayPositions });
                     setBulkLogDetails(filePath, resolved);
                     const knownHash = getKnownFileHash(filePath);
                     if (knownHash) {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -230,6 +230,14 @@ let watcher: LogWatcher | null = null
 let uploader: Uploader | null = null
 let discord: DiscordNotifier | null = null
 let eiManager: EiManager | null = null
+
+// We always parse combat replay (EI v3.24+ only emits the distToCom/stackDist
+// distance scalars when it does), but only RETAIN the heavy position arrays when
+// the user's `parseCombatReplay` setting is on. Off = coarse mode: keep the
+// scalars (Closest to Tag still works), drop positions to keep payloads small.
+const statsPruneOptions = (): { keepReplayPositions: boolean } => ({
+    keepReplayPositions: Boolean(eiManager?.getSettings().parseCombatReplay),
+});
 let autoUpdateRetryAttempts = 0;
 let autoUpdateRetryTimer: NodeJS.Timeout | null = null;
 let resolvedRetryCount = 0;
@@ -471,7 +479,7 @@ const processLogFile = async (filePath: string, options?: { retry?: boolean }) =
             }
 
             const hasUsableDetails = Boolean(jsonDetails && !jsonDetails.error && hasUsableFightDetails(jsonDetails));
-            const prunedDetails = hasUsableDetails ? pruneDetailsForStats(jsonDetails) : null;
+            const prunedDetails = hasUsableDetails ? pruneDetailsForStats(jsonDetails, statsPruneOptions()) : null;
             jsonDetails = null; // Release full JSON for GC
 
             const playerCount = Array.isArray(prunedDetails?.players) ? prunedDetails.players.length : undefined;
@@ -540,11 +548,15 @@ const processLogFile = async (filePath: string, options?: { retry?: boolean }) =
 
     // If we have a full cache hit (permalink + usable details), use it directly
     // regardless of EI availability — no need to re-parse or re-upload.
-    // Exception: when local EI is installed with parseCombatReplay enabled, treat
-    // the cache as stale if it lacks combatReplayMetaData. Without this, fights
-    // first parsed before replay was enabled would never re-acquire replay data.
-    const eiReplayEnabled = Boolean(eiManager?.isInstalled() && eiManager.getSettings().parseCombatReplay);
-    const cachedDetailsLackReplay = eiReplayEnabled
+    // Exception: when local EI is installed, treat the cache as stale if it lacks
+    // combatReplayMetaData. We now always parse replay (EI v3.24+ only emits the
+    // distToCom/stackDist distance scalars when it does), so a cache without
+    // combatReplayMetaData was produced by the old replay-off path and has
+    // distToCom/stackDist == 0 — i.e. Closest to Tag stuck at 0. Re-parsing heals
+    // those histories. (Independent of the parseCombatReplay retention setting,
+    // which only controls whether positions are kept.)
+    const eiInstalled = Boolean(eiManager?.isInstalled());
+    const cachedDetailsLackReplay = eiInstalled
         && cached?.jsonDetails
         && !cached.jsonDetails.combatReplayMetaData;
     const cachedHasUsableDetails = Boolean(
@@ -587,7 +599,7 @@ const processLogFile = async (filePath: string, options?: { retry?: boolean }) =
                 eiJson = attachConditionMetrics(eiJson);
             }
             const hasUsableDetails = Boolean(eiJson && !eiJson.error && hasUsableFightDetails(eiJson));
-            const prunedDetails = hasUsableDetails ? pruneDetailsForStats(eiJson) : null;
+            const prunedDetails = hasUsableDetails ? pruneDetailsForStats(eiJson, statsPruneOptions()) : null;
             eiJson = null; // Release full JSON for GC
 
             const playerCount = Array.isArray(prunedDetails?.players) ? prunedDetails.players.length : undefined;
@@ -801,7 +813,7 @@ const processLogFile = async (filePath: string, options?: { retry?: boolean }) =
                 || (hasJsonPayload && !hasUsableDetails);
             // Prune immediately after enrichment so the full JSON can be GC'd.
             // Discord embeds only read fields that survive pruning.
-            const prunedDetails = hasUsableDetails ? pruneDetailsForStats(jsonDetails) : null;
+            const prunedDetails = hasUsableDetails ? pruneDetailsForStats(jsonDetails, statsPruneOptions()) : null;
             // Release full JSON reference — pruned version is sufficient for all
             // downstream consumers (disk cache, Discord, in-memory cache, IPC).
             jsonDetails = null;

--- a/src/renderer/SettingsView.tsx
+++ b/src/renderer/SettingsView.tsx
@@ -2877,7 +2877,7 @@ export function SettingsView({ onBack: _onBack, onEmbedStatSettingsSaved, onOpen
                                             onChange={(v) => saveEiSetting('saveOutHTML', v)}
                                         />
                                         <Toggle
-                                            label="Combat Replay (required for Map Replay)"
+                                            label="Detailed Combat Replay (required for Map Replay)"
                                             enabled={eiSettings.parseCombatReplay}
                                             onChange={(v) => saveEiSetting('parseCombatReplay', v)}
                                         />

--- a/src/renderer/stats/map/FightPicker.tsx
+++ b/src/renderer/stats/map/FightPicker.tsx
@@ -79,7 +79,7 @@ export const FightPicker: React.FC<FightPickerProps> = ({ fights, onSelect }) =>
                     No replay data available
                 </div>
                 <div style={{ fontSize: 12, maxWidth: 340, lineHeight: 1.6 }}>
-                    Enable <strong style={{ color: 'var(--text-primary, #e2e8f0)' }}>Combat Replay</strong> in{' '}
+                    Enable <strong style={{ color: 'var(--text-primary, #e2e8f0)' }}>Detailed Combat Replay</strong> in{' '}
                     <code style={{ fontSize: 11, background: 'rgba(255,255,255,0.07)', padding: '1px 5px', borderRadius: 3 }}>Settings</code>
                     {' › '}
                     <code style={{ fontSize: 11, background: 'rgba(255,255,255,0.07)', padding: '1px 5px', borderRadius: 3 }}>EI Parser</code>


### PR DESCRIPTION
## Problem
"Closest to Tag" / distance-to-commander shows **0 for every player** on v2.12.2, in both the desktop app and published web reports (issue #31, Discord report from Mignon).

## Root cause
EI **v3.24** stopped emitting the `statsAll[0].distToCom` / `stackDist` distance scalars unless combat replay is parsed — EI ≤v3.21 computed them for free. The app defaults `parseCombatReplay: false`, so once EI auto-updated (~1–2 weeks ago) those scalars became `0` and every distance path resolved to 0. The v2.12.2 `-1` sentinel fix was a different scenario (commander-less fights) and never touched this.

Proven on Mignon's own log:
| EI version | replay | distToCom |
|---|---|---|
| v3.21 | off | 188, 158… ✅ |
| v3.24 | off | **0** ❌ |
| v3.24 | on | 188, 158… ✅ |

## Fix
Always parse combat replay (only way to get the scalars in v3.24); repurpose the `parseCombatReplay` setting to control whether the heavy **positions** are retained:
- `eiParser.generateEiConf` → force `ParseCombatReplay=True`.
- `detailsProcessing.pruneDetailsForStats` → `keepReplayPositions` option: always keep `statsAll` scalars + `combatReplayMetaData`; drop per-actor positions in coarse mode. **`report.json` size unchanged in both modes.**
- `index.ts` / `uploadHandlers.ts` → thread the setting into every prune call.
- Cache staleness → re-parse cached logs lacking `combatReplayMetaData` whenever EI is installed, so existing zero-distance histories self-heal.
- UI → relabel toggle **"Detailed Combat Replay"** (setting key unchanged, no migration).

## Verification
- Regression tests added (conf forces replay; position retention).
- `typecheck` ✅, `lint` ✅, main + stats suites ✅.
- End-to-end on a real v3.24 log: coarse mode resolves Closest to Tag to real values (159/179/189 dist) instead of 0.

Closes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)