### PR TITLE
fix(stats): correct Total DPS and per-second Damage/DPS stat cards

### DIFF
--- a/src/renderer/stats/__tests__/dpsDamageAggregation.test.ts
+++ b/src/renderer/stats/__tests__/dpsDamageAggregation.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from 'vitest';
+import { computeStatsSync } from '../incrementalAggregation';
+
+// Mignon feedback (Discord): "Total DPS" summed each fight's DPS rate (meaningless,
+// ~22x a real number), and the per-second Damage/DPS top-stat CARDS showed 0 / "No
+// data" because the per-second card leaderboards omitted dps/damage.
+//
+// Expected model:
+//   DPS    = total damage / total fight time (a true aggregate rate)
+//   Damage = cumulative total; Damage /1s == DPS, Damage /60s == DPS*60
+
+const makePlayer = (overrides: any) => ({
+    name: overrides.name,
+    account: overrides.account,
+    group: 1,
+    profession: 'Guardian',
+    notInSquad: false,
+    activeTimes: [overrides.durationMS ?? 10000],
+    dpsAll: [{ dps: overrides.dps, damage: overrides.damage }],
+    statsAll: [{}],
+    defenses: [{ damageTaken: 0, downCount: 0, deadCount: 0 }],
+    support: [{ condiCleanse: 0, condiCleanseSelf: 0, boonStrips: 0, resurrects: 0 }],
+});
+
+const makeLog = (id: number, durationMS: number, player: any) => ({
+    id: `log-${id}`,
+    filePath: `test-${id}.zevtc`,
+    details: {
+        durationMS,
+        timeStart: `2026-06-23T00:0${id}:00Z`,
+        success: true,
+        players: [player],
+        targets: [],
+        phases: [{ start: 0, end: durationMS, name: 'All' }],
+        buffMap: {},
+        skillMap: {},
+    },
+});
+
+describe('DPS / Damage aggregation (Mignon feedback)', () => {
+    // 2 fights for one player: 1000 dmg over 10s (100 dps) + 1000 dmg over 20s (50 dps).
+    // Total damage 2000, total time 30s -> aggregate DPS = 66.67. Naive sum = 150.
+    const logs = [
+        makeLog(1, 10000, makePlayer({ name: 'A', account: 'A.1', durationMS: 10000, damage: 1000, dps: 100 })),
+        makeLog(2, 20000, makePlayer({ name: 'A', account: 'A.1', durationMS: 20000, damage: 1000, dps: 50 })),
+    ];
+
+    const result = computeStatsSync({ logs });
+    const lbs = result.stats.leaderboards;
+    const perSec = result.stats.topStatsLeaderboardsPerSecond;
+    const perMin = result.stats.topStatsLeaderboardsPerMinute;
+    const aggDps = 2000 / 30; // 66.666...
+
+    it('Total DPS is aggregate damage/time, not the sum of per-fight DPS rates', () => {
+        const dpsTop = lbs.dps?.[0];
+        expect(dpsTop).toBeTruthy();
+        expect(dpsTop.value).toBeCloseTo(aggDps, 1);
+        expect(dpsTop.value).not.toBeCloseTo(150, 0); // the old, meaningless sum
+    });
+
+    it('Total Damage remains the cumulative sum', () => {
+        expect(lbs.damage?.[0]?.value).toBe(2000);
+    });
+
+    it('per-second card leaderboards include damage and dps (no longer 0 / "No data")', () => {
+        expect(Array.isArray(perSec?.damage)).toBe(true);
+        expect(perSec.damage.length).toBeGreaterThan(0);
+        expect(Array.isArray(perSec?.dps)).toBe(true);
+        expect(perSec.dps.length).toBeGreaterThan(0);
+    });
+
+    it('Damage /1s equals aggregate DPS, and /60s equals DPS*60', () => {
+        expect(perSec.damage[0].value).toBeCloseTo(aggDps, 1);
+        expect(perMin.damage[0].value).toBeCloseTo(aggDps * 60, 0);
+    });
+
+    it('DPS is already a rate, so it reads the same across modes', () => {
+        expect(perSec.dps[0].value).toBeCloseTo(aggDps, 1);
+        expect(perMin.dps[0].value).toBeCloseTo(aggDps, 1);
+    });
+});

--- a/src/renderer/stats/incrementalAggregation.ts
+++ b/src/renderer/stats/incrementalAggregation.ts
@@ -1053,7 +1053,10 @@ export class IncrementalAggregator {
                 case 'stability': return s.stab;
                 case 'revives': return s.revives;
                 case 'downedHealing': return s.healingTotals['downedHealing'] || 0;
-                case 'dps': return s.dps;
+                // DPS is a rate: aggregate as total damage / total fight time across
+                // all fights. (s.dps is a sum of per-fight DPS rates — meaningless to
+                // surface directly; that produced the inflated "Total DPS" number.)
+                case 'dps': return s.totalFightMs > 0 ? s.damage / (s.totalFightMs / 1000) : 0;
                 case 'damage': return s.damage;
                 case 'participation': return s.logsJoined;
                 case 'closestToTag': return (!s.isCommander && s.distCount > 0) ? s.totalDist / s.distCount : Number.POSITIVE_INFINITY;
@@ -1115,6 +1118,10 @@ export class IncrementalAggregator {
             interrupts: 'interrupts',
             ccAndInterrupts: 'ccAndInterrupts',
             stability: 'stability',
+            // dps/damage are needed so the per-second/per-minute top-stat CARDS have
+            // data (Damage /1s == DPS). Without these the cards showed 0 / "No data".
+            dps: 'dps',
+            damage: 'damage',
             closestToTag: 'closestToTag'
         } as const;
 
@@ -1158,13 +1165,16 @@ export class IncrementalAggregator {
 
         const perSecondLeaderboards: Record<string, any[]> = {};
         const perMinuteLeaderboards: Record<string, any[]> = {};
+        // closestToTag is a distance and dps is already a rate (damage/time): both
+        // read the same value regardless of the per-second/per-minute mode.
+        const isAlreadyRate = (k: string) => k === 'closestToTag' || k === 'dps';
         const getPerSecondVal = (s: PlayerStats, k: string) => {
-            if (k === 'closestToTag') return getVal(s, k);
+            if (isAlreadyRate(k)) return getVal(s, k);
             const seconds = Math.max(1, (s.totalFightMs || 0) / 1000);
             return getVal(s, k) / seconds;
         };
         const getPerMinuteVal = (s: PlayerStats, k: string) => {
-            if (k === 'closestToTag') return getVal(s, k);
+            if (isAlreadyRate(k)) return getVal(s, k);
             return getPerSecondVal(s, k) * 60;
         };
         Object.values(statKeys).forEach((k) => {

--- a/src/renderer/stats/topStatsCatalog.ts
+++ b/src/renderer/stats/topStatsCatalog.ts
@@ -37,7 +37,10 @@ const boon = (boonId: string, stacking: boolean): TopStatSource => ({ kind: 'boo
 
 export const TOP_STATS_CATALOG: TopStatDef[] = [
   // Offense
-  { id: 'dps', label: 'DPS', category: 'offense', color: CAT_COLOR.offense, icon: 'Swords', higherIsBetter: true, source: lb('dps'), defaultOn: false, supportsRate: true },
+  // DPS is already a rate (total damage / total fight time), so it reads the same in
+  // every mode — supportsRate:false keeps the card from showing a "DPS /s" title.
+  // Use the Damage stat with the per-second toggle for a damage-rate over time.
+  { id: 'dps', label: 'DPS', category: 'offense', color: CAT_COLOR.offense, icon: 'Swords', higherIsBetter: true, source: lb('dps'), defaultOn: false, supportsRate: false },
   { id: 'damage', label: 'Damage', category: 'offense', color: CAT_COLOR.offense, icon: 'Flame', higherIsBetter: true, source: lb('damage'), defaultOn: false, supportsRate: true },
   { id: 'downContrib', label: 'Down Contribution', category: 'offense', color: '#f87171', icon: 'HelpingHand', higherIsBetter: true, source: lb('downContrib'), defaultOn: true, supportsRate: true },
   { id: 'kills', label: 'Kills', category: 'offense', color: '#fb923c', icon: 'Swords', higherIsBetter: true, source: lb('kills'), defaultOn: false, supportsRate: false },


### PR DESCRIPTION
## Feedback (Discord, from Mignon)
1. **"Total DPS" = 69,281** — far too high. It was summing each fight's DPS *rate* across all 25 logs, which is meaningless.
2. **Damage /1s card = "0.00 / No data available"** — switching the Damage (or DPS) top-stat card to per-second showed nothing, even though the expanded Offense table correctly showed ~3,067.

## Root cause
- `s.dps += dpsAll.dps` accumulates a **sum of per-fight DPS rates**; the DPS leaderboard surfaced that sum directly.
- The per-second/per-minute **card** leaderboards (`statKeys` in `incrementalAggregation.ts`) were built for a hardcoded subset that **omitted `dps`/`damage`**, so those cards had no rate data. (The Offense table computes its own per-second, hence the inconsistency.)

## Fix
- `getVal('dps')` → **total damage ÷ total fight time** (a true aggregate rate).
- Add `dps` + `damage` to the per-second/per-minute card leaderboards → **Damage /1s == DPS**, **/60s == DPS×60**.
- Treat `dps` as already-a-rate (like `closestToTag`) so it reads the same in every mode; catalog `supportsRate=false` for DPS (no misleading "DPS /s" title).

## Verification
- New `dpsDamageAggregation` regression test (synthetic: 2 fights → aggregate DPS, not the sum; per-second cards populated).
- `typecheck` ✅, `lint` ✅, 288 stats tests ✅.
- Against Mignon's real log: aggregate DPS (`damage/time`) matches EI's own per-fight DPS; the old sum is what produced 69,281.

🤖 Generated with [Claude Code](https://claude.com/claude-code)