### PR TITLE
fix(linux): don't trust an inherited $APPIMAGE; keep the desktop entry canonical

### DIFF
--- a/src/main/__tests__/integration.test.ts
+++ b/src/main/__tests__/integration.test.ts
@@ -3,15 +3,16 @@ import os from 'node:os';
 import path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-// integration.ts imports `app` from electron at module load.
-vi.mock('electron', () => ({ app: { name: 'AxiBridge' } }));
+// electron's `app` reports name 'axibridge' (the package name) even when
+// packaged, so integration.ts must not source the display name from it.
+vi.mock('electron', () => ({ app: { name: 'axibridge' } }));
 
-import { buildDesktopEntry, normalizeHomePath, writeDesktopEntry } from '../integration';
+import { APP_NAME, MIME_TYPES, buildDesktopEntry, normalizeHomePath, resolveOwnAppImage, writeDesktopEntry } from '../integration';
 
 // This MUST stay byte-for-byte identical to AxiOM's writeLinuxDesktopEntry
 // output (../axiom/electron/desktopEntry.ts). If the two writers disagree they
 // rewrite each other's entry on every launch.
-const axiomTemplate = (name: string, appImagePath: string, iconLine: string) =>
+const axiomTemplate = (name: string, appImagePath: string, iconLine: string, mimeTypes: readonly string[] = []) =>
     `[Desktop Entry]
 Type=Application
 Name=${name}
@@ -22,7 +23,7 @@ Terminal=false
 Categories=Utility;
 StartupWMClass=${name}
 X-AppImage-Name=${name}
-`;
+${mimeTypes.length ? `MimeType=${mimeTypes.map((m) => `${m};`).join('')}\n` : ''}`;
 
 let tmp: string;
 
@@ -36,9 +37,32 @@ afterEach(() => {
 describe('buildDesktopEntry', () => {
     it('matches the AxiOM desktop-entry template byte-for-byte', () => {
         const p = '/home/u/AppImages/AxiBridge-2.13.5.AppImage';
-        expect(buildDesktopEntry('AxiBridge', p, 'Icon=axibridge')).toBe(
+        expect(buildDesktopEntry('AxiBridge', p, 'Icon=axibridge', [])).toBe(
             axiomTemplate('AxiBridge', p, 'Icon=axibridge')
         );
+    });
+
+    it('emits a MimeType line matching AxiOM when scheme handlers are declared', () => {
+        const p = '/home/u/AppImages/AxiBridge-2.13.5.AppImage';
+        expect(buildDesktopEntry('AxiBridge', p, 'Icon=axibridge', MIME_TYPES)).toBe(
+            axiomTemplate('AxiBridge', p, 'Icon=axibridge', MIME_TYPES)
+        );
+    });
+});
+
+describe('registry parity with AxiOM', () => {
+    // AxiOM's APP_META.axibridge.name is 'AxiBridge'. Sourcing the name from
+    // electron's app.name yielded 'axibridge', so the two writers produced
+    // different files and clobbered each other on every launch.
+    it('uses the same display name as AxiOM, not the lowercase package name', () => {
+        expect(APP_NAME).toBe('AxiBridge');
+    });
+
+    // app.setAsDefaultProtocolClient('axibridge') is pointless unless the
+    // desktop entry declares the scheme, so every rewrite that omitted this
+    // line silently dropped the axibridge:// registration.
+    it('declares the axibridge:// scheme handler', () => {
+        expect(MIME_TYPES).toEqual(['x-scheme-handler/axibridge']);
     });
 });
 
@@ -66,12 +90,47 @@ describe('normalizeHomePath', () => {
     });
 });
 
+describe('resolveOwnAppImage', () => {
+    it('accepts $APPIMAGE when our executable lives inside the mounted $APPDIR', () => {
+        const env = {
+            APPIMAGE: '/home/u/AppImages/AxiBridge-2.18.0.AppImage',
+            APPDIR: '/tmp/.mount_AxiBrAbc123'
+        };
+        expect(resolveOwnAppImage(env, '/tmp/.mount_AxiBrAbc123/axibridge')).toBe(env.APPIMAGE);
+    });
+
+    it('ignores an $APPIMAGE inherited from a parent AppImage', () => {
+        // A dev/unpackaged run launched from a terminal inside another AppImage
+        // (e.g. SAI) inherits that app's $APPIMAGE/$APPDIR. Trusting it made us
+        // rewrite axibridge.desktop to launch SAI.
+        const env = {
+            APPIMAGE: '/home/u/AppImages/sai.appimage',
+            APPDIR: '/tmp/.mount_sai.apUXTvCc'
+        };
+        expect(resolveOwnAppImage(env, '/home/u/src/axibridge/node_modules/electron/dist/electron')).toBeUndefined();
+    });
+
+    it('ignores $APPIMAGE when $APPDIR is absent', () => {
+        expect(resolveOwnAppImage({ APPIMAGE: '/home/u/AppImages/sai.appimage' }, '/usr/bin/electron')).toBeUndefined();
+    });
+
+    it('returns undefined when not running from an AppImage at all', () => {
+        expect(resolveOwnAppImage({}, '/usr/bin/electron')).toBeUndefined();
+    });
+
+    it('does not treat a sibling mount with a shared prefix as ours', () => {
+        const env = { APPIMAGE: '/home/u/AppImages/sai.appimage', APPDIR: '/tmp/.mount_sai' };
+        expect(resolveOwnAppImage(env, '/tmp/.mount_sai2/axibridge')).toBeUndefined();
+    });
+});
+
 describe('writeDesktopEntry', () => {
     const opts = (over: Partial<Parameters<typeof writeDesktopEntry>[0]> = {}) => ({
         appId: 'axibridge',
         name: 'AxiBridge',
         appImagePath: '/home/u/AppImages/AxiBridge-2.13.5.AppImage',
         homeDir: tmp,
+        mimeTypes: MIME_TYPES,
         ...over
     });
     const desktopFile = () => path.join(tmp, '.local', 'share', 'applications', 'axibridge.desktop');
@@ -80,8 +139,18 @@ describe('writeDesktopEntry', () => {
         expect(writeDesktopEntry(opts())).toBe('written');
         const content = fs.readFileSync(desktopFile(), 'utf8');
         expect(content).toContain('TryExec=/home/u/AppImages/AxiBridge-2.13.5.AppImage');
-        expect(content).toBe(axiomTemplate('AxiBridge', '/home/u/AppImages/AxiBridge-2.13.5.AppImage', 'Icon=axibridge'));
+        expect(content).toBe(axiomTemplate('AxiBridge', '/home/u/AppImages/AxiBridge-2.13.5.AppImage', 'Icon=axibridge', MIME_TYPES));
         expect(writeDesktopEntry(opts())).toBe('unchanged');
+    });
+
+    // Regression: an earlier template had no MimeType line, so each rewrite
+    // wiped the axibridge:// handler registration off the entry.
+    it('restores a MimeType line that a previous rewrite dropped', () => {
+        const appsDir = path.join(tmp, '.local', 'share', 'applications');
+        fs.mkdirSync(appsDir, { recursive: true });
+        fs.writeFileSync(path.join(appsDir, 'axibridge.desktop'), axiomTemplate('AxiBridge', '/home/u/AppImages/AxiBridge-2.13.5.AppImage', 'Icon=axibridge'));
+        expect(writeDesktopEntry(opts())).toBe('written');
+        expect(fs.readFileSync(desktopFile(), 'utf8')).toContain('MimeType=x-scheme-handler/axibridge;');
     });
 
     it('rewrites a stale entry pointing at a deleted version', () => {

--- a/src/main/integration.ts
+++ b/src/main/integration.ts
@@ -1,12 +1,19 @@
-import { app } from 'electron';
 import fs from 'fs';
 import path from 'node:path';
 import os from 'node:os';
 
 // Kept in sync with AxiOM's app registry (../axiom/electron/apps.ts) so both
-// writers target the same file and produce identical content.
+// writers target the same file and produce identical content. Note APP_NAME is
+// deliberately not electron's app.name — that reports the lowercase package
+// name 'axibridge' even in a packaged build, which made our entry differ from
+// AxiOM's and the two rewrote each other on every launch.
 const APP_ID = 'axibridge';
-const APP_NAME = 'AxiBridge';
+export const APP_NAME = 'AxiBridge';
+
+// Schemes registered at runtime via app.setAsDefaultProtocolClient. xdg-settings
+// resolves a handler through this desktop entry, so omitting the line drops the
+// registration every time the file is rewritten.
+export const MIME_TYPES: readonly string[] = ['x-scheme-handler/axibridge'];
 
 // Express an absolute path under os.homedir() when it resolves inside the home
 // tree. On Fedora Atomic/Silverblue, $APPIMAGE is /var/home/... while
@@ -26,7 +33,13 @@ export function normalizeHomePath(absPath: string, homeDir: string): string {
 
 // Byte-for-byte identical to AxiOM's writeLinuxDesktopEntry template
 // (../axiom/electron/desktopEntry.ts). Do not reformat.
-export function buildDesktopEntry(name: string, appImagePath: string, iconLine: string): string {
+export function buildDesktopEntry(
+    name: string,
+    appImagePath: string,
+    iconLine: string,
+    mimeTypes: readonly string[]
+): string {
+    const mimeLine = mimeTypes.length ? `MimeType=${mimeTypes.map((m) => `${m};`).join('')}\n` : '';
     return `[Desktop Entry]
 Type=Application
 Name=${name}
@@ -37,7 +50,7 @@ Terminal=false
 Categories=Utility;
 StartupWMClass=${name}
 X-AppImage-Name=${name}
-`;
+${mimeLine}`;
 }
 
 // Preserve an existing Icon= line if it's a bare name or points at a real file,
@@ -64,12 +77,13 @@ export function writeDesktopEntry(opts: {
     name: string;
     appImagePath: string;
     homeDir: string;
+    mimeTypes: readonly string[];
 }): 'written' | 'unchanged' | 'skipped' {
     if (process.platform !== 'linux') return 'skipped';
     const appsDir = path.join(opts.homeDir, '.local', 'share', 'applications');
     const desktopPath = path.join(appsDir, `${opts.appId}.desktop`);
     const iconLine = resolveIconLine(opts.appId, desktopPath);
-    const contents = buildDesktopEntry(opts.name, opts.appImagePath, iconLine);
+    const contents = buildDesktopEntry(opts.name, opts.appImagePath, iconLine, opts.mimeTypes);
     try {
         fs.mkdirSync(appsDir, { recursive: true });
         if (fs.existsSync(desktopPath) && fs.readFileSync(desktopPath, 'utf8') === contents) {
@@ -83,11 +97,28 @@ export function writeDesktopEntry(opts: {
     }
 }
 
+// $APPIMAGE and $APPDIR are ordinary environment variables, so every child
+// process of an AppImage inherits them — including a dev run of this app
+// started from a terminal inside another AppImage. Acting on an inherited
+// $APPIMAGE rewrote axibridge.desktop to launch *that* app instead. We are only
+// really the AppImage when our own executable lives inside the mounted $APPDIR;
+// a nested packaged AppImage gets its own values from its AppRun, so it passes.
+export function resolveOwnAppImage(
+    env: Record<string, string | undefined>,
+    execPath: string
+): string | undefined {
+    if (!env.APPIMAGE || !env.APPDIR) return undefined;
+    const appDir = path.resolve(env.APPDIR);
+    const exe = path.resolve(execPath);
+    if (exe !== appDir && !exe.startsWith(appDir + path.sep)) return undefined;
+    return env.APPIMAGE;
+}
+
 export class DesktopIntegrator {
     private appImage: string | undefined;
 
     constructor() {
-        this.appImage = process.env.APPIMAGE;
+        this.appImage = resolveOwnAppImage(process.env, process.execPath);
     }
 
     public async integrate() {
@@ -106,9 +137,10 @@ export class DesktopIntegrator {
         const appImagePath = normalizeHomePath(this.appImage, homeDir);
         const result = writeDesktopEntry({
             appId: APP_ID,
-            name: app.name || APP_NAME,
+            name: APP_NAME,
             appImagePath,
-            homeDir
+            homeDir,
+            mimeTypes: MIME_TYPES
         });
         if (result === 'written') {
             console.log(`[Integration] Refreshed desktop entry → ${appImagePath}`);


### PR DESCRIPTION
## Why

Opening AxiBridge from the desktop launcher opened a completely different app. `axibridge.desktop` had been rewritten to:

```
Exec=env DESKTOPINTEGRATION=1 /home/u/AppImages/sai.appimage --no-sandbox %U
```

`DesktopIntegrator` takes its target straight from `process.env.APPIMAGE`. `$APPIMAGE`/`$APPDIR` are ordinary environment variables, so **every child process of an AppImage inherits them** — a dev run started from a terminal inside another AppImage sees that app's `$APPIMAGE` and "self-heals" our launcher onto it.

Confirmed on a live parent process:

```
APPDIR=/tmp/.mount_sai.apUXTvCc
APPIMAGE=/var/home/u/AppImages/sai.appimage
```

## What

- `resolveOwnAppImage()` — only treat `$APPIMAGE` as ours when our own executable lives inside the mounted `$APPDIR`. A nested *packaged* AppImage gets its own values from its AppRun, so it still passes.
- Use the `APP_NAME` constant instead of electron's `app.name`. `app.name` reports the lowercase package name `axibridge` even in a packaged build, while AxiOM's registry says `AxiBridge` — so the two writers produced different files and clobbered each other on every launch. This also drops the now-unused `electron` import.
- Emit `MimeType=x-scheme-handler/axibridge`, which the template omitted. Nothing currently consumes the URL (`open-url` only `preventDefault`s and `second-instance` reads `commandLine` solely for `--headless`), so this is a correctness fix rather than a functional repair.

## Notes

Pairs with **darkharasho/axiom#3**. Both are needed for the two writers to agree; either alone is harmless but accomplishes nothing.

User impact is low — the guard only affects dev runs, and the remaining symptom for normal users is the launcher name flipping between `AxiBridge` and `axibridge`. Doesn't warrant a release on its own.

## Testing

`npm run typecheck` clean; full suite 1379/1379. New tests cover the inherited-`$APPIMAGE` case, registry parity with AxiOM, and restoring a dropped `MimeType` line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)