### PR TITLE
fix(mobile): stack the action bar so four items fit at phone widths

### DIFF
--- a/src/web/reportApp.tsx
+++ b/src/web/reportApp.tsx
@@ -1790,34 +1790,41 @@ export function ReportApp() {
                     </div>
                 </div>
                 <div className={`fixed bottom-4 left-4 right-4 z-30 mobile-action-bar ${isNarrowViewport ? '' : 'hidden'}`}>
-                    <div className="flex items-center justify-between gap-2 rounded-2xl bg-slate-950/70 border border-white/15 backdrop-blur-xl px-3 py-2 shadow-[0_20px_50px_rgba(0,0,0,0.45)]">
+                    {/* Icon-over-label, each item flex-1 min-w-0. A row of four
+                        side-by-side icon+label pills needs 387px of the 337px
+                        available at 393px wide, and every label is a single
+                        unbreakable word (min-content == max-content), so
+                        flex-shrink has nothing to give and the last item runs
+                        off-screen. Stacking drops the row to ~291px and the
+                        flex-1/truncate pair keeps it bounded on narrower phones. */}
+                    <div className="flex items-stretch gap-1.5 rounded-2xl bg-slate-950/70 border border-white/15 backdrop-blur-xl px-3 py-2 shadow-[0_20px_50px_rgba(0,0,0,0.45)]">
                         <a
                             href={themedIndexHref}
-                            className="flex items-center gap-2 px-3 py-2 rounded-xl bg-white/5 border border-white/10 text-[10px] uppercase tracking-widest text-gray-200"
+                            className="flex flex-1 min-w-0 flex-col items-center justify-center gap-1 px-1.5 py-1.5 rounded-xl bg-white/5 border border-white/10 text-[10px] uppercase tracking-widest text-gray-200"
                         >
                             <ArrowLeft className="w-4 h-4 shrink-0 text-[color:var(--brand-primary)]" />
-                            Back
+                            <span className="max-w-full truncate">Back</span>
                         </a>
                         <button
                             onClick={() => setTocOpen(true)}
-                            className="flex items-center gap-2 px-3 py-2 rounded-xl bg-white/5 border border-white/10 text-[10px] uppercase tracking-widest text-gray-200"
+                            className="flex flex-1 min-w-0 flex-col items-center justify-center gap-1 px-1.5 py-1.5 rounded-xl bg-white/5 border border-white/10 text-[10px] uppercase tracking-widest text-gray-200"
                         >
                             <PanelLeft className="w-4 h-4 shrink-0 text-[color:var(--brand-primary)]" />
-                            Contents
+                            <span className="max-w-full truncate">Contents</span>
                         </button>
                         <button
                             onClick={() => searchOpenRef.current?.()}
-                            className="flex items-center gap-2 px-3 py-2 rounded-xl bg-white/5 border border-white/10 text-[10px] uppercase tracking-widest text-gray-200"
+                            className="flex flex-1 min-w-0 flex-col items-center justify-center gap-1 px-1.5 py-1.5 rounded-xl bg-white/5 border border-white/10 text-[10px] uppercase tracking-widest text-gray-200"
                         >
                             <Search className="w-4 h-4 shrink-0 text-[color:var(--brand-primary)]" />
-                            Search
+                            <span className="max-w-full truncate">Search</span>
                         </button>
                         <button
                             onClick={() => window.scrollTo({ top: 0, behavior: 'smooth' })}
-                            className="flex items-center gap-2 px-3 py-2 rounded-xl bg-white/5 border border-white/10 text-[10px] uppercase tracking-widest text-gray-200"
+                            className="flex flex-1 min-w-0 flex-col items-center justify-center gap-1 px-1.5 py-1.5 rounded-xl bg-white/5 border border-white/10 text-[10px] uppercase tracking-widest text-gray-200"
                         >
                             <ArrowUp className="w-4 h-4 shrink-0 text-[color:var(--brand-primary)]" />
-                            Top
+                            <span className="max-w-full truncate">Top</span>
                         </button>
                     </div>
                 </div>


### PR DESCRIPTION
## Why

`MOBL-008: mobile action bar has no layout violations` has been **failing on `main` since v2.19.0** — the release run itself is red.

`00e2f12c` ("web report search moves from page header into the nav sidebar") added a fourth item to a bar that had ~50px of slack.

Measured at the test's 393px viewport:

| | width |
|---|---|
| Bar content box | **337px** |
| Back / Contents / Search / Top | 82 + 113 + 95 + 73 = 363px |
| 3 × `gap-2` | 24px |
| **Needed** | **387px** |

Every label is a single unbreakable word, so `min-content == max-content` and `flex-shrink` has nothing to give. The last button ran 23px past the viewport and 39px past its parent.

## What

Stack the icon over the label, and give each item `flex-1 min-w-0` with a truncating label span. That drops the row to ~291px, and because the items now share the available space it stays bounded on narrower phones rather than overflowing. Item padding and the inter-item gap are tightened so the taller bar still fits inside the `5.5rem` that `.mobile-bottom-pad` reserves (83px of 88px).

## Verification

Measured at 320 / 360 / 393 / 430px: **no overflow at any width**, and no label clipping at 393px or above. Below that only "Contents" ellipsizes — a graceful fallback rather than a layout break.

Labels are unchanged, so `navigateToGroup`'s `getByText(/contents/i)` selector (used by MOBL-002–007 and the navigation specs) still resolves.

- Web E2E: **46/46**
- Unit: **1371/1371**
- `npm run typecheck` clean

## Notes

Unblocks darkharasho/axibridge#37 and darkharasho/axiom#3, which are sitting on this pre-existing red baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)