### PR TITLE
fix: exclude WvW NPCs from the web report's enemy count

### DIFF
--- a/src/renderer/stats/__tests__/computeFightBreakdown.test.ts
+++ b/src/renderer/stats/__tests__/computeFightBreakdown.test.ts
@@ -29,6 +29,39 @@ describe('ingestLogFightBreakdown team colors', () => {
     });
 });
 
+describe('ingestLogFightBreakdown enemy NPC exclusion', () => {
+    // WvW fights near objectives pull guards/lords/sentries into targets[]. EI marks
+    // them enemyPlayer: false. They must not inflate enemyCount, because teamBreakdown
+    // and enemyClassCounts exclude them -- the columns have to sum to the headline.
+    const mkNpcLog = () => ({
+        filePath: 'f1',
+        details: {
+            durationMS: 10000,
+            players: [{ notInSquad: false, teamID: 50, dpsAll: [{ damage: 0 }], defenses: [{}], statsAll: [{}] }],
+            targets: [
+                { enemyPlayer: true, isFake: false, teamID: 707, name: 'Tempest pl-1', profession: 'Tempest' },
+                { enemyPlayer: true, isFake: false, teamID: 707, name: 'Scourge pl-2', profession: 'Scourge' },
+                { enemyPlayer: false, isFake: false, teamID: 707, name: 'Veteran Guard' },
+                { enemyPlayer: false, isFake: false, teamID: 707, name: 'Keep Lord' },
+                { enemyPlayer: true, isFake: true, teamID: 707, name: 'Dummy PvP Agent' },
+            ],
+        },
+    });
+
+    it('excludes NPC targets from enemyCount', () => {
+        const fb = ingestLogFightBreakdown(mkNpcLog(), 0);
+        expect(fb.enemyCount).toBe(2);
+    });
+
+    it('keeps enemyCount equal to the sum of teamBreakdown and enemyClassCounts', () => {
+        const fb = ingestLogFightBreakdown(mkNpcLog(), 0);
+        const teamSum = fb.teamBreakdown.reduce((sum: number, t: any) => sum + t.count, 0);
+        const classSum = Object.values(fb.enemyClassCounts).reduce((sum: number, n: any) => sum + n, 0);
+        expect(teamSum).toBe(fb.enemyCount);
+        expect(classSum).toBe(fb.enemyCount);
+    });
+});
+
 describe('ingestLogFightBreakdown boon strips & applications', () => {
     const mkBoonLog = () => ({
         filePath: 'f1',

--- a/src/renderer/stats/computeFightBreakdown.ts
+++ b/src/renderer/stats/computeFightBreakdown.ts
@@ -47,7 +47,12 @@ export function ingestLogFightBreakdown(log: any, fightIndex: number) {
     const { squadPrimaries, pugPrimaries } = partitionSquadPlayers(players);
     const targets = Array.isArray(details?.targets) ? details.targets : [];
     const wvwTeamMap = teamMapFromLog(details);
-    const enemyTargets = targets.filter((t: any) => !t.isFake);
+    // Enemy players only. `isFake` drops EI's synthetic agents; `enemyPlayer === false`
+    // drops WvW NPCs (guards, lords, sentries, dolyaks, siege) that arcdps logs as
+    // targets. Without the second filter the headline enemyCount counts NPCs while
+    // teamBreakdown below (which applies it) does not, so the columns stop summing to
+    // the total whenever a fight happens near objectives.
+    const enemyTargets = targets.filter((t: any) => !t.isFake && t.enemyPlayer !== false);
     const summary = log?.dashboardSummary && typeof log.dashboardSummary === 'object'
         ? log.dashboardSummary
         : null;


### PR DESCRIPTION
## Problem

`ingestLogFightBreakdown` derived `enemyCount` from every non-fake target:

```ts
const enemyTargets = targets.filter((t: any) => !t.isFake);
```

but the `teamBreakdown` loop 40 lines below *also* filters `enemyPlayer === false`. So in any fight near an objective, WvW NPCs — guards, lords, sentries, dolyaks, siege — landed in the headline total but not in the per-team columns, and the columns stopped summing to the total.

It also meant the web report disagreed with the Discord embed, which has always applied both filters (`src/main/discord.ts:159` `computeEnemyTeamBreakdown`).

## Fix

Apply the `enemyPlayer` filter at the source, so `enemyCount`, `enemyClassCounts`, and `teamBreakdown` all derive from the same set.

```ts
const enemyTargets = targets.filter((t: any) => !t.isFake && t.enemyPlayer !== false);
```

## How it surfaced

A user reported enemy counts of 75–81 on a single team and asked whether they were a counting bug. They aren't — the counts are legitimate, and three back-to-back logs against the same blob showed 81/78/78 green across a 4× spread in fight duration (78 distinct green agents inside a 35-second window), which rules out any accumulation artifact.

But their screenshots showed **blue 22 in Discord vs. blue 23 in the web report** on the same fight, which is this bug.

## Tests

Two regression tests added: NPCs are excluded from `enemyCount`, and `enemyCount` stays equal to both `sum(teamBreakdown)` and `sum(enemyClassCounts)`.

- `npx vitest run src/renderer/stats` — 397 passed, 59 files
- `npm run typecheck` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)