### PR TITLE
feat(slice): fight slicer in the published web report with shareable links

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,21 +94,22 @@ src/
     SettingsView.tsx
     global.d.ts          # All shared TypeScript interfaces and default values (ILogData, IWebhook, etc.)
     stats/
-      computeStatsAggregation.ts  # Core stats computation (called directly or via worker)
+      incrementalAggregation.ts   # Core stats computation: IncrementalAggregator + computeStatsSync
       statsTypes.ts               # Stats-specific types
       statsMetrics.ts             # OFFENSE/DEFENSE/SUPPORT metric definitions
       statsTaxonomy.ts            # 11-category nav taxonomy + section/legacy-anchor resolver
       hooks/                      # React hooks for stats (aggregation, navigation, uploads, etc.)
       sections/                   # One component per stats section (OffenseSection, DefenseSection, etc.)
       search/                     # Universal search palette: index builder, matcher, jump-and-flash
-      utils/                      # dashboardUtils, pruneStatsLog, statsSyncRecovery
+      utils/                      # dashboardUtils, buildReportMeta, statsLogKey, axilogCoverage
     workers/
-      statsWorker.ts   # Web Worker that runs computeStatsAggregation off the main thread (>8 logs)
+      statsWorker.ts   # Web Worker that streams logs through IncrementalAggregator off the main thread (>8 logs)
     app/
       AppLayout.tsx         # Shell layout
       hooks/useWebUpload.ts # GitHub Pages upload flow via electronAPI
       hooks/useFilePicker.ts
-      hooks/useDevDatasets.ts
+      hooks/useLogQueue.ts        # Upload queue state
+      hooks/useDetailsHydration.ts # Fetches + caches EI details, owns detailsStatus
   web/           # Standalone web report viewer
     reportApp.tsx  # Web report root – loads report.json, renders StatsView + rollup
     rollup.ts      # Cross-report commander/player aggregate types and builder
@@ -119,7 +120,7 @@ src/
 1. **Log detection**: `LogWatcher` (chokidar) emits `log-detected` → main process IPC sends to renderer.
 2. **Upload**: `Uploader` queues .evtc/.zevtc files, posts to `dps.report/uploadContent`, then fetches EI JSON via `dps.report/getJson`. Max 3 concurrent uploads, 1 concurrent detail fetch.
 3. **State**: All `ILogData` entries live in renderer state (App.tsx). Persisted via `electronAPI.saveLogs`.
-4. **Stats computation**: `computeStatsAggregation` is the single aggregation function. For >8 logs it runs in a Web Worker (`statsWorker.ts`); otherwise inline. The `useStatsAggregationWorker` hook manages both paths.
+4. **Stats computation**: `incrementalAggregation.ts` is the single codepath — `IncrementalAggregator` folds logs in one at a time, and `computeStatsSync` wraps it for one-shot use. For >8 logs it streams through a Web Worker (`statsWorker.ts`); otherwise it runs inline. The `useStatsAggregationWorker` hook manages both paths and falls back to inline `computeStatsSync` if the worker fails.
 5. **Discord**: Main process receives screenshot/embed requests from renderer → `DiscordNotifier` posts to configured webhooks.
 6. **Web report**: Main process builds a static `dist-web/` site with `report.json` embedded, then pushes to GitHub Pages via git.
 

--- a/docs/superpowers/plans/2026-08-22-fight-slicer-phase-b.md
+++ b/docs/superpowers/plans/2026-08-22-fight-slicer-phase-b.md
@@ -3792,7 +3792,11 @@ Recompute whenever the selection changes:
         return mergeSliceFrames({
             sidecar,
             includedOrdinals: included,
-            mvpWeights: undefined,
+            // Task 15 review round 2 (R15-6): the viewer has no settings of
+            // its own in slice mode, so it must hash/merge from the SAME
+            // published values the sidecar was built under, or its
+            // settingsHash can never agree with the publisher's.
+            mvpWeights: (report?.stats as any)?.mvpWeights,
             statsViewSettings: (report?.stats as any)?.statsViewSettings,
             disruptionMethod: (report?.stats as any)?.disruptionMethod,
         }).stats;

--- a/packages/bridge-metrics/src/computePlayerAggregation.ts
+++ b/packages/bridge-metrics/src/computePlayerAggregation.ts
@@ -470,6 +470,13 @@ export interface PlayerAggregationAccumulators {
     globalEnemySkillStats: Map<number, { totalDamage: number; connectedHits: number; minTotal: number; minCount: number }>;
     mitigationCumulativeCounts: Map<string, DamageMitigationTotals>;
     mitigationMinionCumulativeCounts: Map<string, DamageMitigationTotals>;
+    /**
+     * Rotation cast counts that found no matching skill row when their log was
+     * ingested, keyed by player then skill. Write-only for the direct path; the
+     * slice merge replays them so a per-fight frame does not lose casts that a
+     * sequential ingest would have credited to an earlier fight's skill row.
+     */
+    pendingSkillCasts: Map<string, Map<string, number>>;
     wins: number;
     losses: number;
     totalSquadSizeAccum: number;
@@ -499,6 +506,7 @@ export const createPlayerAggregationAccumulators = (): PlayerAggregationAccumula
     globalEnemySkillStats: new Map(),
     mitigationCumulativeCounts: new Map(),
     mitigationMinionCumulativeCounts: new Map(),
+    pendingSkillCasts: new Map(),
     wins: 0,
     losses: 0,
     totalSquadSizeAccum: 0,
@@ -1313,6 +1321,22 @@ export const ingestLogPlayerData = (log: any, acc: PlayerAggregationAccumulators
                 const skillEntry = playerBreakdown!.skills.get(skillId);
                 if (skillEntry) {
                     skillEntry.casts += count;
+                } else {
+                    // A cast of a skill that dealt no damage in ANY log so far
+                    // has nowhere to land, and this line is order-dependent: in
+                    // a sequential ingest the entry may already exist from an
+                    // EARLIER log, so the cast counts. A per-fight slice frame
+                    // has no earlier log, so it would silently lose the cast.
+                    // Park it here instead; `mergePlayerAggregationAccumulators`
+                    // replays it against the entries the earlier fights created.
+                    // Nothing in the direct path reads this map, so the
+                    // non-sliced numbers are unchanged.
+                    let pending = acc.pendingSkillCasts.get(playerKey);
+                    if (!pending) {
+                        pending = new Map<string, number>();
+                        acc.pendingSkillCasts.set(playerKey, pending);
+                    }
+                    pending.set(skillId, (pending.get(skillId) || 0) + count);
                 }
             });
         }
@@ -1736,3 +1760,10 @@ export const computePlayerAggregation = ({
         totalEnemyDowns: acc.totalEnemyDowns,
     };
 };
+
+export {
+    mergePlayerAggregationAccumulators,
+    PLAYER_STATS_MERGE_RULES,
+    deepSumInto,
+    type MergeRule,
+} from './mergePlayerAggregation';

--- a/packages/bridge-metrics/src/mergePlayerAggregation.ts
+++ b/packages/bridge-metrics/src/mergePlayerAggregation.ts
@@ -54,9 +54,23 @@ export type MergeRule =
  * A field produced by a real log with no rule here is a test failure, not a
  * silent drop — see the coverage test in mergePlayerAggregation.test.ts.
  */
-const IS_PRODUCTION = typeof process !== 'undefined'
+/**
+ * True only under a test runner.
+ *
+ * The sense of this check matters and used to be inverted. It was
+ * `NODE_ENV === 'production'`, so it read FALSE in a browser worker (where
+ * `process` does not exist at all) — i.e. the unknown-field `throw` below fired
+ * in exactly the one environment its own comment promised to degrade in, and a
+ * single unmapped field added upstream would have stranded every *published*
+ * report's slice recompute on an uncaught throw. "Not production" is not a
+ * usable proxy for "somewhere a throw is safe" when the shipping target has no
+ * `process` object. So the condition is now positive and narrow: throw where a
+ * human is watching a test run and can fix the rule table, degrade everywhere
+ * else. Vitest sets both `NODE_ENV=test` and `VITEST`.
+ */
+const isTestRun = (): boolean => typeof process !== 'undefined'
     && typeof process.env === 'object'
-    && process.env?.NODE_ENV === 'production';
+    && (process.env?.NODE_ENV === 'test' || Boolean(process.env?.VITEST));
 
 export const PLAYER_STATS_MERGE_RULES: Readonly<Record<string, MergeRule>> = Object.freeze({
     name: 'first',
@@ -209,14 +223,15 @@ const mergePlayerStatsInto = (target: PlayerStats, source: PlayerStats): void =>
             // Defaulting to 'sum' would turn a string field added upstream into
             // NaN in every sliced report — the exact silent corruption the rule
             // table exists to prevent. Fail loudly wherever failing is safe.
-            if (!IS_PRODUCTION) {
+            if (isTestRun()) {
                 throw new Error(
                     `mergePlayerAggregationAccumulators: PlayerStats field "${key}" has no entry in `
                     + 'PLAYER_STATS_MERGE_RULES. Add one (see the coverage test in mergePlayerAggregation.test.ts).',
                 );
             }
-            // In a published report, degrade rather than blank the page: sum
-            // numbers, keep the first value for anything else.
+            // Anywhere else — a published report, a packaged desktop build —
+            // degrade rather than blank the page: sum numbers, keep the first
+            // value for anything else.
             (target as any)[key] = applyRule(typeof value === 'number' ? 'sum' : 'first', (target as any)[key], value);
             return;
         }

--- a/packages/bridge-metrics/src/mergePlayerAggregation.ts
+++ b/packages/bridge-metrics/src/mergePlayerAggregation.ts
@@ -1,0 +1,476 @@
+/**
+ * Merging player-aggregation accumulators.
+ *
+ * The fight slicer takes a snapshot of `PlayerAggregationAccumulators` per
+ * fight, *before* `finalizePlayerAggregation` runs, and re-finalizes an
+ * arbitrary subset of those snapshots in the browser. That only works if two
+ * accumulators can be combined into the state a single sequential ingest of the
+ * same fights would have produced:
+ *
+ *     finalize(merge(frame(A), frame(B))) === finalize(ingest(A); ingest(B))
+ *
+ * `PlayerStats` alone carries ~50 fields, so the per-field behaviour lives in
+ * an explicit rule table (`PLAYER_STATS_MERGE_RULES`) rather than in fifty
+ * hand-written assignments. The table is paired with a coverage test that fails
+ * when a real fixture produces a `PlayerStats` key with no rule — without it, a
+ * field added upstream would be silently dropped from every sliced report.
+ *
+ * Structures whose combination is genuinely not a table entry (skill entries
+ * with `min`/`max`, mitigation totals, the special-buff aggregates) get small
+ * hand-written combiners below, each mirroring the corresponding `ingest`
+ * arithmetic exactly.
+ */
+import type {
+    PlayerAggregationAccumulators,
+    PlayerStats,
+    DamageMitigationTotals,
+    DamageMitigationRow,
+    SpecialBuffAggEntry,
+} from './computePlayerAggregation';
+import type { PlayerSkillDamageEntry, PlayerHealingSkillEntry } from './aggregationTypes';
+
+export type MergeRule =
+    | 'sum' | 'max' | 'min' | 'first' | 'or'
+    | 'setUnion' | 'arrayUnion' | 'recordSum' | 'recordDeepSum'
+    | 'firstKnown' | 'lastKnown' | 'derived' | 'special';
+
+/**
+ * How each `PlayerStats` field combines when two accumulators are merged.
+ *
+ * - `sum` / `max` / `min` / `or`: numeric or boolean accumulation. `min` treats
+ *   0 as "unset", matching `firstSeenFightTs`'s sentinel in ingest.
+ * - `first`: the field is written once, when the player row is created, so the
+ *   earlier accumulator's value wins.
+ * - `lastKnown`: ingest *overwrites* the field on every log that reports a real
+ *   value, so the later accumulator wins unless its value is missing/'Unknown'.
+ * - `firstKnown`: the mirror image — kept for fields written only when unset.
+ * - `recordSum` / `recordDeepSum`: `Record<string, number>` and nested-object
+ *   variants, summed leaf by leaf.
+ * - `derived`: not written by ingest at all (recomputed downstream), so the
+ *   target's value is left alone.
+ * - `special`: resolved by hand-written code in `mergePlayerStatsInto` because
+ *   it depends on the value of another field.
+ *
+ * A field produced by a real log with no rule here is a test failure, not a
+ * silent drop — see the coverage test in mergePlayerAggregation.test.ts.
+ */
+export const PLAYER_STATS_MERGE_RULES: Record<string, MergeRule> = {
+    name: 'first',
+    account: 'first',
+    characterNames: 'setUnion',
+    downContrib: 'sum',
+    cleanses: 'sum',
+    strips: 'sum',
+    stab: 'sum',
+    healing: 'sum',
+    barrier: 'sum',
+    cc: 'sum',
+    interrupts: 'sum',
+    logsJoined: 'sum',
+    totalDist: 'sum',
+    distCount: 'sum',
+    stackedLogCount: 'sum',
+    dodges: 'sum',
+    downs: 'sum',
+    deaths: 'sum',
+    kills: 'sum',
+    enemyDowns: 'sum',
+    damageTaken: 'sum',
+    breakbar: 'sum',
+    blocks: 'sum',
+    evades: 'sum',
+    misses: 'sum',
+    totalFightMs: 'sum',
+    offenseTotals: 'recordSum',
+    offenseRateWeights: 'recordSum',
+    defenseActiveMs: 'sum',
+    defenseTotals: 'recordSum',
+    defenseMinionDamageTaken: 'recordSum',
+    supportActiveMs: 'sum',
+    supportTotals: 'recordSum',
+    healingActiveMs: 'sum',
+    healingTotals: 'recordSum',
+    hasHealAddon: 'or',
+    // ingest does `s.profession = p.profession` for every log that reports a
+    // known profession, so the LAST log seen wins, not the first.
+    profession: 'lastKnown',
+    professions: 'setUnion',
+    professionList: 'arrayUnion',
+    professionTimeMs: 'recordSum',
+    squadActiveMs: 'sum',
+    firstSeenFightTs: 'min',
+    lastSeenFightTs: 'max',
+    // Belongs to whichever side saw the later fight; ties take the longer
+    // fight, exactly as ingest does.
+    lastSeenFightDurationMs: 'special',
+    isCommander: 'or',
+    damage: 'sum',
+    // ingest accumulates `s.dps += dpsAll.dps` per player entry — it is a raw
+    // running total, not a rate recomputed at finalize.
+    dps: 'sum',
+    revives: 'sum',
+    outgoingConditions: 'recordDeepSum',
+    incomingConditions: 'recordDeepSum',
+    damageModTotals: 'recordDeepSum',
+    incomingDamageModTotals: 'recordDeepSum',
+    roleClassification: 'derived',
+};
+
+/** Sum every numeric leaf of `source` into `target`, first-wins for strings. */
+export const deepSumInto = (target: any, source: any): void => {
+    if (!source || typeof source !== 'object') return;
+    Object.entries(source).forEach(([key, value]) => {
+        if (typeof value === 'number') {
+            target[key] = Number(target[key] || 0) + value;
+        } else if (Array.isArray(value)) {
+            if (!Array.isArray(target[key])) target[key] = [...value];
+            else {
+                value.forEach((v, i) => {
+                    if (typeof v === 'number') target[key][i] = Number(target[key][i] || 0) + v;
+                });
+            }
+        } else if (value && typeof value === 'object') {
+            if (!target[key] || typeof target[key] !== 'object') target[key] = {};
+            deepSumInto(target[key], value);
+        } else if (target[key] === undefined) {
+            target[key] = value;
+        }
+    });
+};
+
+const applyRule = (rule: MergeRule, targetValue: any, sourceValue: any): any => {
+    switch (rule) {
+        case 'sum': return Number(targetValue || 0) + Number(sourceValue || 0);
+        case 'max': return Math.max(Number(targetValue || 0), Number(sourceValue || 0));
+        case 'min': {
+            const t = Number(targetValue || 0);
+            const s = Number(sourceValue || 0);
+            if (!t) return s;
+            if (!s) return t;
+            return Math.min(t, s);
+        }
+        case 'or': return Boolean(targetValue) || Boolean(sourceValue);
+        case 'first': return targetValue !== undefined && targetValue !== '' ? targetValue : sourceValue;
+        case 'firstKnown':
+            return targetValue && targetValue !== 'Unknown' ? targetValue : sourceValue;
+        case 'lastKnown':
+            return sourceValue && sourceValue !== 'Unknown' ? sourceValue : targetValue;
+        case 'setUnion': {
+            const out = targetValue instanceof Set ? targetValue : new Set(targetValue || []);
+            (sourceValue instanceof Set ? sourceValue : new Set(sourceValue || []))
+                .forEach((v: any) => out.add(v));
+            return out;
+        }
+        case 'arrayUnion': {
+            const out = Array.isArray(targetValue) ? targetValue : [];
+            (Array.isArray(sourceValue) ? sourceValue : []).forEach((v) => {
+                if (!out.includes(v)) out.push(v);
+            });
+            return out;
+        }
+        case 'recordSum': {
+            const out = targetValue && typeof targetValue === 'object' ? targetValue : {};
+            Object.entries(sourceValue || {}).forEach(([k, v]) => {
+                out[k] = Number(out[k] || 0) + Number(v || 0);
+            });
+            return out;
+        }
+        case 'recordDeepSum': {
+            const out = targetValue && typeof targetValue === 'object' ? targetValue : {};
+            deepSumInto(out, sourceValue || {});
+            return out;
+        }
+        case 'special':
+            // Handled by the caller; leave the target untouched here.
+            return targetValue;
+        case 'derived':
+        default:
+            return targetValue === undefined ? sourceValue : targetValue;
+    }
+};
+
+const mergePlayerStatsInto = (target: PlayerStats, source: PlayerStats): void => {
+    // Resolved before the rule pass, because it reads `lastSeenFightTs` on both
+    // sides and the rule pass overwrites the target's copy with the max.
+    const targetTs = Number(target.lastSeenFightTs || 0);
+    const sourceTs = Number(source.lastSeenFightTs || 0);
+    const sourceDuration = Number(source.lastSeenFightDurationMs || 0);
+    let lastDuration = Number(target.lastSeenFightDurationMs || 0);
+    if (targetTs <= 0 || sourceTs > targetTs) lastDuration = sourceDuration;
+    else if (sourceTs > 0 && sourceTs === targetTs) lastDuration = Math.max(lastDuration, sourceDuration);
+
+    Object.entries(source as any).forEach(([key, value]) => {
+        const rule = PLAYER_STATS_MERGE_RULES[key] || 'sum';
+        (target as any)[key] = applyRule(rule, (target as any)[key], value);
+    });
+
+    target.lastSeenFightDurationMs = lastDuration;
+};
+
+const mergeMapInto = <V>(
+    target: Map<any, V>,
+    source: Map<any, V>,
+    combine: (existing: V, incoming: V) => void,
+    clone: (incoming: V) => V,
+): void => {
+    source.forEach((incoming, key) => {
+        const existing = target.get(key);
+        if (existing === undefined) target.set(key, clone(incoming));
+        else combine(existing, incoming);
+    });
+};
+
+const cloneDeep = <T>(value: T): T => {
+    if (value instanceof Set) return new Set(value) as unknown as T;
+    if (value instanceof Map) return new Map([...value].map(([k, v]) => [k, cloneDeep(v)])) as unknown as T;
+    if (Array.isArray(value)) return value.map(cloneDeep) as unknown as T;
+    if (value && typeof value === 'object') {
+        const out: any = {};
+        Object.entries(value as any).forEach(([k, v]) => { out[k] = cloneDeep(v); });
+        return out;
+    }
+    return value;
+};
+
+const addToList = (list: string[], incoming: string[] | undefined): void => {
+    (incoming || []).forEach((p) => {
+        if (!list.includes(p)) list.push(p);
+    });
+};
+
+/**
+ * `min` is seeded to `Infinity` and only lowered by finite, positive hits, so a
+ * skill that never reported one keeps `Infinity`. JSON has no `Infinity`, and
+ * the sidecar codec turns it into `null`, so both sentinels normalise back to
+ * `Infinity` here — otherwise a round-tripped frame would merge a `null` into
+ * the minimum and report 0.
+ */
+const asMinSentinel = (value: any): number => {
+    if (value === null || value === undefined) return Infinity;
+    const numeric = Number(value);
+    return Number.isFinite(numeric) ? numeric : Infinity;
+};
+
+/**
+ * Skill names arrive as `Skill <id>` placeholders when the log's `skillMap` has
+ * no entry, and ingest upgrades a placeholder the first time a real name shows
+ * up. Merging has to do the same or a slice starting on a nameless log would
+ * keep the placeholder forever.
+ */
+const upgradeSkillName = (existing: string, incoming: string): string => (
+    existing.startsWith('Skill ') && !incoming.startsWith('Skill ') ? incoming : existing
+);
+
+const mergeSkillDamageEntryInto = (
+    existing: { name: string; icon?: string; damage: number; hits: number; downContribution: number },
+    incoming: { name: string; icon?: string; damage: number; hits: number; downContribution: number },
+): void => {
+    existing.name = upgradeSkillName(existing.name, incoming.name);
+    if (!existing.icon && incoming.icon) existing.icon = incoming.icon;
+    existing.damage += incoming.damage;
+    existing.hits += incoming.hits;
+    existing.downContribution += incoming.downContribution;
+};
+
+const mergeIncomingSkillDamageEntryInto = (
+    existing: { name: string; icon?: string; damage: number; hits: number },
+    incoming: { name: string; icon?: string; damage: number; hits: number },
+): void => {
+    // Mirrors ingest's own (unusual) precedence at computePlayerAggregation.ts:
+    // the name is replaced unless the existing one is a placeholder and the
+    // incoming one is not.
+    if (!existing.name.startsWith('Skill ') || incoming.name.startsWith('Skill ')) {
+        existing.name = incoming.name;
+    }
+    if (!existing.icon && incoming.icon) existing.icon = incoming.icon;
+    existing.damage += incoming.damage;
+    existing.hits += incoming.hits;
+};
+
+const mergeRecordOfEntries = <T>(
+    target: Record<string | number, T>,
+    source: Record<string | number, T>,
+    combine: (existing: T, incoming: T) => void,
+): void => {
+    Object.entries(source || {}).forEach(([key, incoming]) => {
+        const existing = (target as any)[key];
+        if (!existing) (target as any)[key] = cloneDeep(incoming);
+        else combine(existing, incoming as T);
+    });
+};
+
+const mergePlayerSkillEntryInto = (existing: PlayerSkillDamageEntry, incoming: PlayerSkillDamageEntry): void => {
+    existing.name = upgradeSkillName(existing.name, incoming.name);
+    if (!existing.icon && incoming.icon) existing.icon = incoming.icon;
+    existing.damage += incoming.damage;
+    existing.downContribution += incoming.downContribution;
+    existing.hits += incoming.hits;
+    existing.casts += incoming.casts;
+    existing.min = Math.min(asMinSentinel(existing.min), asMinSentinel(incoming.min));
+    existing.max = Math.max(Number(existing.max || 0), Number(incoming.max || 0));
+};
+
+const mergeHealingSkillEntryInto = (existing: PlayerHealingSkillEntry, incoming: PlayerHealingSkillEntry): void => {
+    existing.name = upgradeSkillName(existing.name, incoming.name);
+    if (!existing.icon && incoming.icon) existing.icon = incoming.icon;
+    existing.total += incoming.total;
+    existing.hits += incoming.hits;
+    existing.max = Math.max(Number(existing.max || 0), Number(incoming.max || 0));
+};
+
+/**
+ * Every field here is a running `+=` in ingest, `minMitigation` included — it
+ * accumulates `min_avoided_damage`, it is not a minimum.
+ */
+const mergeMitigationTotalsInto = (target: DamageMitigationTotals, source: DamageMitigationTotals): void => {
+    target.totalHits += source.totalHits;
+    target.blocked += source.blocked;
+    target.evaded += source.evaded;
+    target.glanced += source.glanced;
+    target.missed += source.missed;
+    target.invulned += source.invulned;
+    target.interrupted += source.interrupted;
+    target.totalMitigation += source.totalMitigation;
+    target.minMitigation += source.minMitigation;
+};
+
+const mergeSpecialBuffEntryInto = (existing: SpecialBuffAggEntry, incoming: SpecialBuffAggEntry): void => {
+    existing.totalMs += incoming.totalMs;
+    existing.uptimeMs += incoming.uptimeMs;
+    existing.durationMs += incoming.durationMs;
+    incoming.professions.forEach((p) => existing.professions.add(p));
+    Object.entries(incoming.professionTimeMs || {}).forEach(([p, ms]) => {
+        existing.professionTimeMs[p] = Number(existing.professionTimeMs[p] || 0) + Number(ms || 0);
+    });
+    // ingest reassigns `agg.profession` on every known profession it sees, so
+    // the later accumulator wins.
+    if (incoming.profession && incoming.profession !== 'Unknown') existing.profession = incoming.profession;
+};
+
+const mergeBuffAggInto = (
+    targetAgg: Map<string, Map<string, SpecialBuffAggEntry>>,
+    sourceAgg: Map<string, Map<string, SpecialBuffAggEntry>>,
+): void => {
+    sourceAgg.forEach((sourceInner, buffId) => {
+        let inner = targetAgg.get(buffId);
+        if (!inner) {
+            inner = new Map<string, SpecialBuffAggEntry>();
+            targetAgg.set(buffId, inner);
+        }
+        mergeMapInto(inner, sourceInner, mergeSpecialBuffEntryInto, cloneDeep);
+    });
+};
+
+/**
+ * Mitigation rows: `profession`, `account` and `name` are written only when the
+ * row is created, so they are first-wins even when the first value is
+ * 'Unknown'. Only `professionList` grows, and the row's `mitigationTotals` are
+ * overwritten wholesale by `finalizePlayerAggregation`.
+ */
+const mergeMitigationRowsInto = <T extends DamageMitigationRow>(
+    targetRows: Map<string, T>,
+    sourceRows: Map<string, T>,
+): void => {
+    mergeMapInto(targetRows, sourceRows, (existing, incoming) => {
+        existing.activeMs += incoming.activeMs;
+        addToList(existing.professionList, incoming.professionList);
+        mergeMitigationTotalsInto(existing.mitigationTotals, incoming.mitigationTotals);
+    }, cloneDeep);
+};
+
+/**
+ * Merge one fight's player aggregation state into a running accumulator.
+ *
+ * `target` is mutated in place; `source` is only read (values copied out of it
+ * are deep-cloned, so a frame can be merged into several different slices).
+ * Call `finalizePlayerAggregation` on the result, never on the inputs —
+ * `recomputeMitigationTotals` overwrites row totals from the cumulative counts
+ * and is not safe to run twice on state that is still being accumulated.
+ */
+export function mergePlayerAggregationAccumulators(
+    target: PlayerAggregationAccumulators,
+    source: PlayerAggregationAccumulators,
+): void {
+    if (!target || !source) throw new Error('mergePlayerAggregationAccumulators: both accumulators are required');
+    if (!(target.playerStats instanceof Map) || !(source.playerStats instanceof Map)) {
+        throw new Error('mergePlayerAggregationAccumulators: accumulators must carry Map state (did the frame skip decodeState?)');
+    }
+
+    mergeMapInto(target.playerStats, source.playerStats, mergePlayerStatsInto, cloneDeep);
+
+    mergeRecordOfEntries(target.skillDamageMap, source.skillDamageMap, mergeSkillDamageEntryInto);
+    mergeRecordOfEntries(target.incomingSkillDamageMap, source.incomingSkillDamageMap, mergeIncomingSkillDamageEntryInto);
+    deepSumInto(target.outgoingCondiTotals, source.outgoingCondiTotals);
+    deepSumInto(target.incomingCondiTotals, source.incomingCondiTotals);
+    deepSumInto(target.enemyProfessionCounts, source.enemyProfessionCounts);
+
+    mergeMapInto(target.playerSkillBreakdownMap, source.playerSkillBreakdownMap, (existing, incoming) => {
+        existing.totalFightMs += incoming.totalFightMs;
+        addToList(existing.professionList, incoming.professionList);
+        mergeMapInto(existing.skills, incoming.skills, mergePlayerSkillEntryInto, cloneDeep);
+    }, cloneDeep);
+
+    mergeMapInto(target.healingBreakdownMap, source.healingBreakdownMap, (existing, incoming) => {
+        existing.hasHealAddon = existing.hasHealAddon || incoming.hasHealAddon;
+        addToList(existing.professionList, incoming.professionList);
+        mergeMapInto(existing.healingSkills, incoming.healingSkills, mergeHealingSkillEntryInto, cloneDeep);
+        mergeMapInto(existing.barrierSkills, incoming.barrierSkills, mergeHealingSkillEntryInto, cloneDeep);
+    }, cloneDeep);
+
+    // Rotation casts parked by ingest because their skill row did not exist in
+    // their own fight. A sequential ingest would have credited them to a row an
+    // EARLIER fight created, so they are replayed against the target's rows —
+    // which is exactly the set of rows the earlier fights contributed. Casts
+    // that still find no row stay parked, matching the direct path, where they
+    // are never credited either.
+    source.pendingSkillCasts.forEach((skills, playerKey) => {
+        const breakdown = target.playerSkillBreakdownMap.get(playerKey);
+        skills.forEach((count, skillId) => {
+            const entry = breakdown?.skills.get(skillId);
+            if (entry) {
+                entry.casts += count;
+                return;
+            }
+            let leftover = target.pendingSkillCasts.get(playerKey);
+            if (!leftover) {
+                leftover = new Map<string, number>();
+                target.pendingSkillCasts.set(playerKey, leftover);
+            }
+            leftover.set(skillId, (leftover.get(skillId) || 0) + count);
+        });
+    });
+
+    // First-wins metadata: name, icon and stacking never change across logs.
+    source.specialBuffMeta.forEach((meta, key) => {
+        if (!target.specialBuffMeta.has(key)) target.specialBuffMeta.set(key, cloneDeep(meta));
+    });
+
+    mergeBuffAggInto(target.specialBuffAgg, source.specialBuffAgg);
+    mergeBuffAggInto(target.specialBuffOutputAgg, source.specialBuffOutputAgg);
+
+    mergeMitigationRowsInto(target.damageMitigationPlayersMap, source.damageMitigationPlayersMap);
+    mergeMitigationRowsInto(target.damageMitigationMinionsMap, source.damageMitigationMinionsMap);
+
+    mergeMapInto(target.mitigationCumulativeCounts, source.mitigationCumulativeCounts,
+        mergeMitigationTotalsInto, cloneDeep);
+    mergeMapInto(target.mitigationMinionCumulativeCounts, source.mitigationMinionCumulativeCounts,
+        mergeMitigationTotalsInto, cloneDeep);
+
+    mergeMapInto(target.globalEnemySkillStats, source.globalEnemySkillStats, (existing, incoming) => {
+        existing.totalDamage += incoming.totalDamage;
+        existing.connectedHits += incoming.connectedHits;
+        existing.minTotal += incoming.minTotal;
+        existing.minCount += incoming.minCount;
+    }, cloneDeep);
+
+    target.wins += source.wins;
+    target.losses += source.losses;
+    target.totalSquadSizeAccum += source.totalSquadSizeAccum;
+    target.totalEnemiesAccum += source.totalEnemiesAccum;
+    target.totalSquadDeaths += source.totalSquadDeaths;
+    target.totalSquadKills += source.totalSquadKills;
+    target.totalEnemyDeaths += source.totalEnemyDeaths;
+    target.totalEnemyKills += source.totalEnemyKills;
+    target.totalSquadDowns += source.totalSquadDowns;
+    target.totalEnemyDowns += source.totalEnemyDowns;
+}

--- a/packages/bridge-metrics/src/mergePlayerAggregation.ts
+++ b/packages/bridge-metrics/src/mergePlayerAggregation.ts
@@ -54,7 +54,11 @@ export type MergeRule =
  * A field produced by a real log with no rule here is a test failure, not a
  * silent drop — see the coverage test in mergePlayerAggregation.test.ts.
  */
-export const PLAYER_STATS_MERGE_RULES: Record<string, MergeRule> = {
+const IS_PRODUCTION = typeof process !== 'undefined'
+    && typeof process.env === 'object'
+    && process.env?.NODE_ENV === 'production';
+
+export const PLAYER_STATS_MERGE_RULES: Readonly<Record<string, MergeRule>> = Object.freeze({
     name: 'first',
     account: 'first',
     characterNames: 'setUnion',
@@ -114,7 +118,7 @@ export const PLAYER_STATS_MERGE_RULES: Record<string, MergeRule> = {
     damageModTotals: 'recordDeepSum',
     incomingDamageModTotals: 'recordDeepSum',
     roleClassification: 'derived',
-};
+});
 
 /** Sum every numeric leaf of `source` into `target`, first-wins for strings. */
 export const deepSumInto = (target: any, source: any): void => {
@@ -200,7 +204,22 @@ const mergePlayerStatsInto = (target: PlayerStats, source: PlayerStats): void =>
     else if (sourceTs > 0 && sourceTs === targetTs) lastDuration = Math.max(lastDuration, sourceDuration);
 
     Object.entries(source as any).forEach(([key, value]) => {
-        const rule = PLAYER_STATS_MERGE_RULES[key] || 'sum';
+        const rule = PLAYER_STATS_MERGE_RULES[key];
+        if (!rule) {
+            // Defaulting to 'sum' would turn a string field added upstream into
+            // NaN in every sliced report — the exact silent corruption the rule
+            // table exists to prevent. Fail loudly wherever failing is safe.
+            if (!IS_PRODUCTION) {
+                throw new Error(
+                    `mergePlayerAggregationAccumulators: PlayerStats field "${key}" has no entry in `
+                    + 'PLAYER_STATS_MERGE_RULES. Add one (see the coverage test in mergePlayerAggregation.test.ts).',
+                );
+            }
+            // In a published report, degrade rather than blank the page: sum
+            // numbers, keep the first value for anything else.
+            (target as any)[key] = applyRule(typeof value === 'number' ? 'sum' : 'first', (target as any)[key], value);
+            return;
+        }
         (target as any)[key] = applyRule(rule, (target as any)[key], value);
     });
 
@@ -299,6 +318,29 @@ const mergeRecordOfEntries = <T>(
     });
 };
 
+/**
+ * A skill row that only ONE frame ever saw is copied verbatim, so nothing on
+ * the merge path below ever inspects its `min` — and a frame that came back
+ * through JSON carries `null` there, because JSON has no `Infinity`. The
+ * sentinel has to be restored while cloning or a sliced accumulator ends up
+ * with `null` where an unsliced one holds `Infinity`, which
+ * `computeSpecialTables` tests for by identity.
+ *
+ * Restoring it here rather than in `stateCodec` is deliberate: the codec is
+ * shared by every slice module and knows nothing about which fields are
+ * sentinels. `min` is a fact about `PlayerSkillDamageEntry`, so it belongs with
+ * the code that owns that type's merge semantics.
+ */
+const clonePlayerSkillEntry = (entry: PlayerSkillDamageEntry): PlayerSkillDamageEntry => ({
+    ...entry,
+    min: asMinSentinel(entry.min),
+});
+
+const clonePlayerBreakdownRow = <T extends { skills: Map<string, PlayerSkillDamageEntry> }>(row: T): T => ({
+    ...cloneDeep(row),
+    skills: new Map([...row.skills].map(([id, entry]) => [id, clonePlayerSkillEntry(entry)])),
+});
+
 const mergePlayerSkillEntryInto = (existing: PlayerSkillDamageEntry, incoming: PlayerSkillDamageEntry): void => {
     existing.name = upgradeSkillName(existing.name, incoming.name);
     if (!existing.icon && incoming.icon) existing.icon = incoming.icon;
@@ -381,6 +423,11 @@ const mergeMitigationRowsInto = <T extends DamageMitigationRow>(
 /**
  * Merge one fight's player aggregation state into a running accumulator.
  *
+ * ORDER MATTERS. Frames must be merged in the same order the direct path would
+ * have ingested them — chronological fight order — because `first` / `lastKnown`
+ * rules, the pending-cast replay and Map insertion order (which the stable
+ * `finalize*` sorts carry through to the output) all depend on it.
+ *
  * `target` is mutated in place; `source` is only read (values copied out of it
  * are deep-cloned, so a frame can be merged into several different slices).
  * Call `finalizePlayerAggregation` on the result, never on the inputs —
@@ -407,8 +454,8 @@ export function mergePlayerAggregationAccumulators(
     mergeMapInto(target.playerSkillBreakdownMap, source.playerSkillBreakdownMap, (existing, incoming) => {
         existing.totalFightMs += incoming.totalFightMs;
         addToList(existing.professionList, incoming.professionList);
-        mergeMapInto(existing.skills, incoming.skills, mergePlayerSkillEntryInto, cloneDeep);
-    }, cloneDeep);
+        mergeMapInto(existing.skills, incoming.skills, mergePlayerSkillEntryInto, clonePlayerSkillEntry);
+    }, clonePlayerBreakdownRow);
 
     mergeMapInto(target.healingBreakdownMap, source.healingBreakdownMap, (existing, incoming) => {
         existing.hasHealAddon = existing.hasHealAddon || incoming.hasHealAddon;

--- a/src/main/handlers/__tests__/r2ReplayHosting.test.ts
+++ b/src/main/handlers/__tests__/r2ReplayHosting.test.ts
@@ -11,7 +11,7 @@ vi.mock('electron-log', () => ({
     default: { info: vi.fn(), warn: vi.fn(), error: vi.fn() }
 }));
 
-import { MAX_GITHUB_BLOB_BYTES, planReplayHosting, resolveR2Config } from '../githubHandlers';
+import { MAX_GITHUB_BLOB_BYTES, planSidecarHosting, resolveR2Config } from '../githubHandlers';
 
 const makeStore = (values: Record<string, unknown>) => ({
     get: (key: string) => values[key]
@@ -65,33 +65,50 @@ describe('resolveR2Config', () => {
     });
 });
 
-describe('planReplayHosting', () => {
-    const base = { reportId: 'rep1', baseUrl: 'https://user.github.io/repo' };
+describe('planSidecarHosting', () => {
+    const BASE = 'https://user.github.io/repo';
 
-    it('uses the R2 url when the R2 upload succeeded', () => {
-        const plan = planReplayHosting({ ...base, replayBytes: 900 * 1024 * 1024, r2Url: 'https://pub-x.r2.dev/reports/rep1/replay.json' });
-        expect(plan.mode).toBe('r2');
-        expect(plan.url).toBe('https://pub-x.r2.dev/reports/rep1/replay.json');
-        expect(plan.warning).toBeNull();
+    it('prefers R2 for a replay', () => {
+        expect(planSidecarHosting({
+            kind: 'replay', bytes: 1024, r2Url: 'https://pub-x.r2.dev/reports/a/replay.json',
+            reportId: 'a', baseUrl: BASE,
+        })).toEqual({ mode: 'r2', url: 'https://pub-x.r2.dev/reports/a/replay.json', warning: null });
     });
 
-    it('falls back to Pages when R2 is unavailable and the replay fits in a blob', () => {
-        const plan = planReplayHosting({ ...base, replayBytes: 4 * 1024 * 1024, r2Url: null });
+    it('falls back to Pages for a replay with no R2', () => {
+        const plan = planSidecarHosting({ kind: 'replay', bytes: 1024, r2Url: null, reportId: 'a', baseUrl: BASE });
         expect(plan.mode).toBe('pages');
-        expect(plan.url).toBe('https://user.github.io/repo/reports/rep1/replay.json');
-        expect(plan.warning).toBeNull();
+        expect(plan.url).toBe(`${BASE}/reports/a/replay.json`);
     });
 
-    it('drops the replay instead of failing the upload when it exceeds the blob limit', () => {
-        const plan = planReplayHosting({ ...base, replayBytes: MAX_GITHUB_BLOB_BYTES + 1, r2Url: null });
+    it('drops an oversized Pages replay rather than failing the upload with a 422', () => {
+        const plan = planSidecarHosting({
+            kind: 'replay', bytes: MAX_GITHUB_BLOB_BYTES + 1, r2Url: null, reportId: 'a', baseUrl: BASE,
+        });
         expect(plan.mode).toBe('dropped');
         expect(plan.url).toBeNull();
-        expect(plan.warning).toMatch(/replay/i);
+        expect(plan.warning).toMatch(/Cloudflare R2/);
     });
 
-    it('uses a relative Pages url when no base url is known', () => {
-        const plan = planReplayHosting({ ...base, baseUrl: null, replayBytes: 1024, r2Url: null });
-        expect(plan.url).toBe('reports/rep1/replay.json');
+    it('prefers R2 for a slice sidecar', () => {
+        expect(planSidecarHosting({
+            kind: 'slice', bytes: 1024, r2Url: 'https://pub-x.r2.dev/reports/a/slice.json.gz',
+            reportId: 'a', baseUrl: BASE,
+        })).toEqual({ mode: 'r2', url: 'https://pub-x.r2.dev/reports/a/slice.json.gz', warning: null });
+    });
+
+    it('never falls back to Pages for a slice sidecar', () => {
+        // The whole point: a Pages-hosted sidecar would spend the repo storage
+        // budget this design exists to protect. No R2 means no web slicer.
+        const plan = planSidecarHosting({ kind: 'slice', bytes: 1024, r2Url: null, reportId: 'a', baseUrl: BASE });
+        expect(plan.mode).toBe('dropped');
+        expect(plan.url).toBeNull();
+        expect(plan.warning).toMatch(/Cloudflare R2/);
+    });
+
+    it('drops a slice sidecar with no R2 regardless of how small it is', () => {
+        const plan = planSidecarHosting({ kind: 'slice', bytes: 1, r2Url: null, reportId: 'a', baseUrl: null });
+        expect(plan.mode).toBe('dropped');
     });
 });
 

--- a/src/main/handlers/githubHandlers.ts
+++ b/src/main/handlers/githubHandlers.ts
@@ -660,13 +660,22 @@ const formatBytes = (value: number) => {
 };
 
 /**
- * Decide where a report's replay.json lives. R2 is preferred; Pages is the
- * fallback. A Pages-hosted replay travels through the GitHub blob API, which
- * rejects anything past MAX_GITHUB_BLOB_BYTES with a 422 — so an oversized
- * replay is dropped rather than allowed to fail the whole upload.
+ * Decide where a report's out-of-band artifact lives.
+ *
+ * Replays prefer R2 and fall back to GitHub Pages, since one artifact on Pages
+ * is affordable and losing the replay outright costs a feature. A Pages-hosted
+ * replay travels through the GitHub blob API, which 422s past
+ * MAX_GITHUB_BLOB_BYTES, so an oversized one is dropped rather than allowed to
+ * fail the whole upload.
+ *
+ * Slice sidecars are R2-only, deliberately. A Pages fallback would spend ~1.56x
+ * of the repo's storage budget per report — precisely the cost the web slicer
+ * was designed to avoid. With no R2 the report publishes exactly as it does
+ * today and simply has no slicer.
  */
-export const planReplayHosting = ({ replayBytes, r2Url, reportId, baseUrl }: {
-    replayBytes: number;
+export const planSidecarHosting = ({ kind, bytes, r2Url, reportId, baseUrl }: {
+    kind: 'replay' | 'slice';
+    bytes: number;
     r2Url: string | null;
     reportId: string;
     baseUrl: string | null;
@@ -674,12 +683,21 @@ export const planReplayHosting = ({ replayBytes, r2Url, reportId, baseUrl }: {
     if (r2Url) {
         return { mode: 'r2', url: r2Url, warning: null };
     }
-    if (replayBytes > MAX_GITHUB_BLOB_BYTES) {
+    if (kind === 'slice') {
         return {
             mode: 'dropped',
             url: null,
             warning:
-                `Replay data (${formatBytes(replayBytes)}) is too large to host on GitHub Pages ` +
+                'Fight slicing in the published report needs Cloudflare R2 — configure it in Settings. ' +
+                'The report itself publishes normally either way.'
+        };
+    }
+    if (bytes > MAX_GITHUB_BLOB_BYTES) {
+        return {
+            mode: 'dropped',
+            url: null,
+            warning:
+                `Replay data (${formatBytes(bytes)}) is too large to host on GitHub Pages ` +
                 `(limit ${formatBytes(MAX_GITHUB_BLOB_BYTES)}) — publishing the report without the map replay. ` +
                 `Configure Cloudflare R2 in Settings to keep replays on large sessions.`
         };
@@ -1837,8 +1855,9 @@ export function registerGithubHandlers(opts: GithubHandlerOptions) {
                         sendWebUploadStatus('Warning', `R2 upload failed: ${r2Result.error}`, 39);
                     }
                 }
-                const replayPlan = planReplayHosting({
-                    replayBytes: replayBuffer.length,
+                const replayPlan = planSidecarHosting({
+                    kind: 'replay',
+                    bytes: replayBuffer.length,
                     r2Url,
                     reportId: reportMeta.id,
                     baseUrl

--- a/src/main/handlers/githubHandlers.ts
+++ b/src/main/handlers/githubHandlers.ts
@@ -1897,6 +1897,11 @@ export function registerGithubHandlers(opts: GithubHandlerOptions) {
             if (sliceSidecar && Array.isArray(sliceSidecar.frames) && sliceSidecar.frames.length > 0) {
                 const sliceBuffer = gzipSync(Buffer.from(JSON.stringify(sliceSidecar), 'utf8'), { level: 9 });
                 let sliceR2Url: string | null = null;
+                // Distinguishes "R2 is not configured" from "R2 is configured and
+                // the upload failed" — the two need different advice, and telling a
+                // user who has already configured R2 to go configure it sends them
+                // looking in the wrong place.
+                let sliceUploadFailed = false;
                 if (r2Config) {
                     sendWebUploadStatus('Uploading', 'Uploading fight slice data to R2...', 39);
                     const sliceKey = `reports/${reportMeta.id}/slice.json.gz`;
@@ -1908,6 +1913,7 @@ export function registerGithubHandlers(opts: GithubHandlerOptions) {
                         sliceR2Url = sliceResult.url;
                         log.info(`[Main] R2 slice upload succeeded: ${sliceResult.url} (${formatBytes(sliceBuffer.length)})`);
                     } else {
+                        sliceUploadFailed = true;
                         log.warn(`[Main] R2 slice upload failed: ${sliceResult.error} — publishing without the web slicer.`);
                     }
                 }
@@ -1927,9 +1933,20 @@ export function registerGithubHandlers(opts: GithubHandlerOptions) {
                 } else {
                     delete (builtReport.payload.stats as any).sliceDataUrl;
                     delete (builtReport.payload.stats as any).sliceSettingsHash;
-                    if (slicePlan.warning) {
-                        log.info(`[Main] ${slicePlan.warning}`);
-                        sendWebUploadStatus('Packaging', slicePlan.warning, 39);
+                    // These two ride along ONLY so the viewer can merge frames
+                    // under the publisher's settings. With no sliceDataUrl there
+                    // is nothing to merge, so they are dead weight in report.json.
+                    // (The renderer already strips them when R2 is unconfigured;
+                    // this covers the upload-failed path, where it could not know.)
+                    delete (builtReport.payload.stats as any).mvpWeights;
+                    delete (builtReport.payload.stats as any).disruptionMethod;
+                    const sliceWarning = sliceUploadFailed
+                        ? 'Fight slice data could not be uploaded to Cloudflare R2 — publishing the report without '
+                        + 'the web slicer. The report itself publishes normally; check the log for the R2 error.'
+                        : slicePlan.warning;
+                    if (sliceWarning) {
+                        log.info(`[Main] ${sliceWarning}`);
+                        sendWebUploadStatus('Packaging', sliceWarning, 39);
                     }
                 }
                 builtReport.jsonBuffer = Buffer.from(JSON.stringify(builtReport.payload), 'utf8');

--- a/src/main/handlers/githubHandlers.ts
+++ b/src/main/handlers/githubHandlers.ts
@@ -3,6 +3,7 @@ import fs from 'fs';
 import path from 'node:path';
 import https from 'node:https';
 import { createHash, createHmac } from 'node:crypto';
+import { gzipSync } from 'node:zlib';
 import { spawn } from 'node:child_process';
 import log from 'electron-log';
 import {
@@ -1706,7 +1707,7 @@ export function registerGithubHandlers(opts: GithubHandlerOptions) {
         };
     });
 
-    ipcMain.handle('upload-web-report', async (_event, payload: { meta: any; stats: any; repoFullName?: string; repoOwner?: string; repoName?: string; reportWebhookIds?: string[] }) => {
+    ipcMain.handle('upload-web-report', async (_event, payload: { meta: any; stats: any; repoFullName?: string; repoOwner?: string; repoName?: string; reportWebhookIds?: string[]; sliceSidecar?: any }) => {
         try {
             if (!hasWebReportContent(payload)) {
                 return { success: false, error: 'Cannot upload an empty web report. Add at least one fight before publishing.' };
@@ -1874,6 +1875,50 @@ export function registerGithubHandlers(opts: GithubHandlerOptions) {
                 } else {
                     replayHostedOnPages = replayPlan.mode === 'pages';
                     (builtReport.payload.stats as any).replayDataUrl = replayPlan.url;
+                }
+                builtReport.jsonBuffer = Buffer.from(JSON.stringify(builtReport.payload), 'utf8');
+            }
+
+            // Slice sidecar — R2 only. With no R2 the report publishes exactly as
+            // it always has and the published viewer simply has no slicer.
+            const sliceSidecar = (payload as any)?.sliceSidecar;
+            if (sliceSidecar && Array.isArray(sliceSidecar.frames) && sliceSidecar.frames.length > 0) {
+                const sliceBuffer = gzipSync(Buffer.from(JSON.stringify(sliceSidecar), 'utf8'), { level: 9 });
+                let sliceR2Url: string | null = null;
+                if (r2Config) {
+                    sendWebUploadStatus('Uploading', 'Uploading fight slice data to R2...', 39);
+                    const sliceKey = `reports/${reportMeta.id}/slice.json.gz`;
+                    // Content-Type only, no Content-Encoding: the viewer inflates
+                    // these bytes itself with DecompressionStream('gzip'), so the
+                    // browser must NOT transparently inflate them first.
+                    const sliceResult = await r2PutObject(sliceKey, sliceBuffer, 'application/gzip', r2Config);
+                    if (sliceResult.success && sliceResult.url) {
+                        sliceR2Url = sliceResult.url;
+                        log.info(`[Main] R2 slice upload succeeded: ${sliceResult.url} (${formatBytes(sliceBuffer.length)})`);
+                    } else {
+                        log.warn(`[Main] R2 slice upload failed: ${sliceResult.error} — publishing without the web slicer.`);
+                    }
+                }
+                const slicePlan = planSidecarHosting({
+                    kind: 'slice',
+                    bytes: sliceBuffer.length,
+                    r2Url: sliceR2Url,
+                    reportId: reportMeta.id,
+                    baseUrl
+                });
+                if (slicePlan.mode === 'r2' && slicePlan.url) {
+                    (builtReport.payload.stats as any).sliceDataUrl = slicePlan.url;
+                    // The viewer compares this against the sidecar's own hash and
+                    // disables slicing on a mismatch rather than rendering numbers
+                    // computed under different settings.
+                    (builtReport.payload.stats as any).sliceSettingsHash = sliceSidecar.settingsHash;
+                } else {
+                    delete (builtReport.payload.stats as any).sliceDataUrl;
+                    delete (builtReport.payload.stats as any).sliceSettingsHash;
+                    if (slicePlan.warning) {
+                        log.info(`[Main] ${slicePlan.warning}`);
+                        sendWebUploadStatus('Packaging', slicePlan.warning, 39);
+                    }
                 }
                 builtReport.jsonBuffer = Buffer.from(JSON.stringify(builtReport.payload), 'utf8');
             }

--- a/src/main/handlers/githubHandlers.ts
+++ b/src/main/handlers/githubHandlers.ts
@@ -1485,6 +1485,18 @@ export function registerGithubHandlers(opts: GithubHandlerOptions) {
         }
     });
 
+    // Cheap, synchronous-ish existence check for the renderer to gate the
+    // (relatively expensive: ~300ms build + 10MB+ structured clone over IPC)
+    // slice sidecar build on. Does not validate the credentials against R2 —
+    // just "are all the fields present" like the upload path itself checks.
+    ipcMain.handle('get-r2-configured', async () => {
+        try {
+            return { configured: !!getR2Config(store) };
+        } catch {
+            return { configured: false };
+        }
+    });
+
     ipcMain.handle('ensure-github-template', async () => {
         try {
             const token = store.get('githubToken') as string | undefined;

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -119,7 +119,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
     ensureGithubTemplate: () => ipcRenderer.invoke('ensure-github-template'),
     selectGithubLogo: () => ipcRenderer.invoke('select-github-logo'),
     applyGithubLogo: (payload?: { logoPath?: string }) => ipcRenderer.invoke('apply-github-logo', payload),
-    uploadWebReport: (payload: { meta: any; stats: any; repoFullName?: string; repoOwner?: string; repoName?: string; reportWebhookIds?: string[] }) => ipcRenderer.invoke('upload-web-report', payload),
+    uploadWebReport: (payload: { meta: any; stats: any; repoFullName?: string; repoOwner?: string; repoName?: string; reportWebhookIds?: string[]; sliceSidecar?: any }) => ipcRenderer.invoke('upload-web-report', payload),
     mockWebReport: (payload: { meta: any; stats: any }) => ipcRenderer.invoke('mock-web-report', payload),
     getGithubPagesBuildStatus: (payload?: { repoFullName?: string; repoOwner?: string; repoName?: string }) => ipcRenderer.invoke('get-github-pages-build-status', payload),
     onWebUploadStatus: (callback: (data: any) => void) => {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -119,9 +119,19 @@ contextBridge.exposeInMainWorld('electronAPI', {
     ensureGithubTemplate: () => ipcRenderer.invoke('ensure-github-template'),
     selectGithubLogo: () => ipcRenderer.invoke('select-github-logo'),
     applyGithubLogo: (payload?: { logoPath?: string }) => ipcRenderer.invoke('apply-github-logo', payload),
+    // `sliceSidecar` is typed `any` here (not the renderer's `SliceSidecar`)
+    // deliberately: this file compiles under `electron/tsconfig.json`
+    // (shared with `src/main`), which has no `jsx`/module settings for the
+    // renderer graph. A type-only import of a renderer type pulls its whole
+    // dependency chain into that compile and breaks it (confirmed: caused
+    // ~80 unrelated TS errors in files several hops away, e.g.
+    // `useStatsAggregationWorker.ts`'s `--jsx`/`import.meta` errors). Same
+    // cross-process-boundary excuse the review already accepted for
+    // `githubHandlers.ts`.
     uploadWebReport: (payload: { meta: any; stats: any; repoFullName?: string; repoOwner?: string; repoName?: string; reportWebhookIds?: string[]; sliceSidecar?: any }) => ipcRenderer.invoke('upload-web-report', payload),
     mockWebReport: (payload: { meta: any; stats: any }) => ipcRenderer.invoke('mock-web-report', payload),
     getGithubPagesBuildStatus: (payload?: { repoFullName?: string; repoOwner?: string; repoName?: string }) => ipcRenderer.invoke('get-github-pages-build-status', payload),
+    isR2Configured: () => ipcRenderer.invoke('get-r2-configured'),
     onWebUploadStatus: (callback: (data: any) => void) => {
         ipcRenderer.on('web-upload-status', (_event, value) => callback(value));
         return () => ipcRenderer.removeAllListeners('web-upload-status');

--- a/src/renderer/SettingsView.tsx
+++ b/src/renderer/SettingsView.tsx
@@ -1979,16 +1979,19 @@ export function SettingsView({ onBack: _onBack, onEmbedStatSettingsSaved, onOpen
                         />
                     </SettingsSection>
 
-                    {/* Cloudflare R2 Replay Storage */}
+                    {/* Cloudflare R2 — hosts the out-of-band report sidecars */}
                     <SettingsSection
-                        title="Cloudflare R2 — Replay Storage"
+                        title="Cloudflare R2 — Replay &amp; Slice Storage"
                         icon={Key}
                         delay={0.09}
                         sectionId="r2-storage"
                         hidden={settingsSearchHidden.has('r2-storage')}
                     >
+                        <p className="text-sm text-gray-400 mb-2">
+                            Optional. When configured, the bulky out-of-band parts of a published report — map replay data and fight slice data — are uploaded to R2 instead of GitHub Pages, keeping the report repository small. Requires a Cloudflare R2 bucket with public access enabled.
+                        </p>
                         <p className="text-sm text-gray-400 mb-4">
-                            Optional. When configured, map replay data is uploaded to R2 instead of GitHub Pages, keeping report files small. Requires a Cloudflare R2 bucket with public access enabled.
+                            Without R2, map replays still publish to GitHub Pages and are dropped only when too large for it, but <span className="text-gray-300">fight slicing in the published report is unavailable</span> — slice data is never written to Pages, because it would cost more repository storage than the whole report. The report itself publishes normally either way.
                         </p>
                         <div className="space-y-3">
                             {([
@@ -2015,7 +2018,7 @@ export function SettingsView({ onBack: _onBack, onEmbedStatSettingsSaved, onOpen
                         )}
                         {r2AccountId && r2AccessKeyId && r2SecretAccessKey && r2BucketName && r2PublicUrl && (
                             <>
-                                <p className="mt-3 text-xs text-emerald-400">R2 configured — replay data will be stored in R2 on next upload.</p>
+                                <p className="mt-3 text-xs text-emerald-400">R2 configured — replay and fight slice data will be stored in R2 on next upload, and published reports can be sliced by fight.</p>
                                 <div className="mt-3">
                                     <Toggle
                                         enabled={r2PreciseReplay}

--- a/src/renderer/StatsView.tsx
+++ b/src/renderer/StatsView.tsx
@@ -874,6 +874,8 @@ export const StatsView = memo(function StatsView({ logs, onBack: _onBack, mvpWei
         stats: safeStats,
         skillUsageData,
         activeStatsViewSettings: statsViewSettings || DEFAULT_STATS_VIEW_SETTINGS,
+        mvpWeights,
+        disruptionMethod,
         embedded,
         onWebUpload
     });

--- a/src/renderer/StatsView.tsx
+++ b/src/renderer/StatsView.tsx
@@ -139,6 +139,10 @@ interface StatsViewProps {
     /** Published web report only: awaited before the tray opens, so the first
      *  open is what triggers the sidecar fetch (Task 18) rather than report load. */
     onOpenSliceTray?: () => Promise<unknown>;
+    /** Published web report only: builds and copies a shareable slice link for
+     *  the current selection. Absent everywhere else, so the banner's copy
+     *  control only appears where a link is actually meaningful. */
+    onCopySliceLink?: () => void;
 }
 
 const sidebarListClass = 'space-y-0.5 max-h-72 overflow-y-auto';
@@ -263,7 +267,7 @@ function resolveReplayFights(stats: any): any[] {
 export const deriveStatsViewLogs = (logs: any[], excluded: Set<string>, embedded: boolean): any[] =>
     embedded ? logs : selectSlicedLogs(logs, excluded);
 
-export const StatsView = memo(function StatsView({ logs, onBack: _onBack, mvpWeights, statsViewSettings, onStatsViewSettingsChange, webUploadState, onWebUpload, webUploadLogEntries, disruptionMethod, precomputedStats, embedded = false, sectionVisibility, onRequestCategory, onSearchAvailable, dashboardTitle, statsDataProgress, aggregationResult: externalAggregationResult, onLogsHealed, sliceEnabled = false, onOpenSliceTray }: StatsViewProps) {
+export const StatsView = memo(function StatsView({ logs, onBack: _onBack, mvpWeights, statsViewSettings, onStatsViewSettingsChange, webUploadState, onWebUpload, webUploadLogEntries, disruptionMethod, precomputedStats, embedded = false, sectionVisibility, onRequestCategory, onSearchAvailable, dashboardTitle, statsDataProgress, aggregationResult: externalAggregationResult, onLogsHealed, sliceEnabled = false, onOpenSliceTray, onCopySliceLink }: StatsViewProps) {
     // Defer heavy section rendering by one frame so the header + progress bar can paint first.
     const [sectionsDeferred, setSectionsDeferred] = useState(!embedded);
     useEffect(() => {
@@ -4360,7 +4364,7 @@ type SpikeFight = {
             />
 
             {(!embedded || sliceEnabled) && sliceTrayOpen && <FightSliceTray onClose={() => setSliceTrayOpen(false)} />}
-            {(!embedded || sliceEnabled) && <FightSliceBanner />}
+            {(!embedded || sliceEnabled) && <FightSliceBanner onCopyLink={onCopySliceLink} />}
 
             {/* Processing indicator: particle spinner with witty remarks (desktop) */}
             {(aggregationSettling.active || detailsProgress.active) && !embedded && (

--- a/src/renderer/StatsView.tsx
+++ b/src/renderer/StatsView.tsx
@@ -14,6 +14,7 @@ import { SectionPanel } from './stats/ui/SectionPanel';
 import { useStatsNavigation, STATS_TOC_GROUPS } from './stats/hooks/useStatsNavigation';
 import { GROUP_ACCENT_COLORS } from './stats/sectionColors';
 import { useStatsStore } from './stats/statsStore';
+import { isReplayUnsliceable } from './stats/slice/replaySlicing';
 import { statsLogKey } from './stats/utils/statsLogKey';
 import { selectSlicedLogs } from './app/selectSlicedLogs';
 import { useStatsUploads } from './stats/hooks/useStatsUploads';
@@ -143,6 +144,10 @@ interface StatsViewProps {
      *  the current selection. Absent everywhere else, so the banner's copy
      *  control only appears where a link is actually meaningful. */
     onCopySliceLink?: () => void;
+    /** Published-report only: the slice recompute failed or refused, so the
+     *  stats being rendered are the FULL report's. The banner switches to an
+     *  honest "Slice unavailable" line rather than claiming a subset. */
+    sliceUnavailable?: boolean;
 }
 
 const sidebarListClass = 'space-y-0.5 max-h-72 overflow-y-auto';
@@ -267,7 +272,7 @@ function resolveReplayFights(stats: any): any[] {
 export const deriveStatsViewLogs = (logs: any[], excluded: Set<string>, embedded: boolean): any[] =>
     embedded ? logs : selectSlicedLogs(logs, excluded);
 
-export const StatsView = memo(function StatsView({ logs, onBack: _onBack, mvpWeights, statsViewSettings, onStatsViewSettingsChange, webUploadState, onWebUpload, webUploadLogEntries, disruptionMethod, precomputedStats, embedded = false, sectionVisibility, onRequestCategory, onSearchAvailable, dashboardTitle, statsDataProgress, aggregationResult: externalAggregationResult, onLogsHealed, sliceEnabled = false, onOpenSliceTray, onCopySliceLink }: StatsViewProps) {
+export const StatsView = memo(function StatsView({ logs, onBack: _onBack, mvpWeights, statsViewSettings, onStatsViewSettingsChange, webUploadState, onWebUpload, webUploadLogEntries, disruptionMethod, precomputedStats, embedded = false, sectionVisibility, onRequestCategory, onSearchAvailable, dashboardTitle, statsDataProgress, aggregationResult: externalAggregationResult, onLogsHealed, sliceEnabled = false, onOpenSliceTray, onCopySliceLink, sliceUnavailable = false }: StatsViewProps) {
     // Defer heavy section rendering by one frame so the header + progress bar can paint first.
     const [sectionsDeferred, setSectionsDeferred] = useState(!embedded);
     useEffect(() => {
@@ -416,6 +421,40 @@ export const StatsView = memo(function StatsView({ logs, onBack: _onBack, mvpWei
         }
         return r2ReplayFights ?? [];
     }, [stats, r2ReplayFights]);
+
+    /**
+     * The combat replay cannot be sliced.
+     *
+     * `r2ReplayFights` is fetched once from the report's `replayDataUrl` and
+     * cached; it always holds EVERY fight in the session. Sliced stats carry no
+     * `replayFights` of their own (frames deliberately exclude replay payloads
+     * — they are 66% of report.json and none of the merge maths needs them), so
+     * `getReplayFights()` above falls through to that whole-session cache. The
+     * result would be a replay playing all 7 fights while every other section
+     * on the page shows the 3 the user picked, with nothing saying so.
+     *
+     * Filtering the cache by slice is not viable: the replay payload is keyed
+     * on its own fight identities, not the sidecar's roster ordinals. So the
+     * section is replaced by an explicit note while a slice is active.
+     *
+     * Scoped narrowly on purpose: when `stats.replayFights` IS populated the
+     * replay came from the same (already-sliced) aggregation as everything else
+     * — that is the desktop path, and it stays fully functional under a slice.
+     */
+    const replayUnsliceable = isReplayUnsliceable({
+        replayFights: (stats as any)?.replayFights,
+        excludedFightCount: excludedFightKeys.size,
+    });
+
+    const replaySliceNotice = (
+        <div className="flex flex-col items-center justify-center w-full gap-2 text-center px-6">
+            <span className="text-sm text-gray-300">Combat replay is not available while a fight slice is active.</span>
+            <span className="text-xs text-gray-500 max-w-md">
+                The replay covers the full session and cannot be narrowed to the selected fights.
+                Clear the slice to watch it.
+            </span>
+        </div>
+    );
 
     const aggregationSettling = useMemo(() => {
         // Prefer real aggregation progress over the generic "Preparing" placeholder.
@@ -4364,7 +4403,7 @@ type SpikeFight = {
             />
 
             {(!embedded || sliceEnabled) && sliceTrayOpen && <FightSliceTray onClose={() => setSliceTrayOpen(false)} />}
-            {(!embedded || sliceEnabled) && <FightSliceBanner onCopyLink={onCopySliceLink} />}
+            {(!embedded || sliceEnabled) && <FightSliceBanner onCopyLink={onCopySliceLink} unavailable={sliceUnavailable} />}
 
             {/* Processing indicator: particle spinner with witty remarks (desktop) */}
             {(aggregationSettling.active || detailsProgress.active) && !embedded && (
@@ -4416,6 +4455,8 @@ type SpikeFight = {
                             <span className="text-sm text-rose-400">Failed to load replay data.</span>
                             {r2ReplayError && <span className="text-xs text-rose-300/70">{r2ReplayError}</span>}
                         </div>
+                    ) : replayUnsliceable ? (
+                        replaySliceNotice
                     ) : (
                         <div style={{ display: 'contents' }}>
                             {r2ReplayStatus === 'loading' && (
@@ -5393,7 +5434,7 @@ type SpikeFight = {
                         ])}
 
                         {renderGroup('replay', [
-                            { id: 'replay', element: <div style={{ height: '88vh', minHeight: 500, maxHeight: 1000, display: 'flex', width: '100%' }}>{r2ReplayStatus === 'loading' ? <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', width: '100%', fontSize: '0.875rem', color: '#9ca3af' }}>Loading replay data...</div> : r2ReplayStatus === 'error' ? <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', width: '100%', fontSize: '0.875rem', color: '#fb7185' }}>Failed to load replay data.</div> : <ReplaySection fights={getReplayFights()} />}</div> },
+                            { id: 'replay', element: <div style={{ height: '88vh', minHeight: 500, maxHeight: 1000, display: 'flex', width: '100%' }}>{replayUnsliceable ? <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', width: '100%' }}>{replaySliceNotice}</div> : r2ReplayStatus === 'loading' ? <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', width: '100%', fontSize: '0.875rem', color: '#9ca3af' }}>Loading replay data...</div> : r2ReplayStatus === 'error' ? <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', width: '100%', fontSize: '0.875rem', color: '#fb7185' }}>Failed to load replay data.</div> : <ReplaySection fights={getReplayFights()} />}</div> },
                         ])}
                     </>
                 )}

--- a/src/renderer/StatsView.tsx
+++ b/src/renderer/StatsView.tsx
@@ -132,6 +132,13 @@ interface StatsViewProps {
     };
     /** Called with the file paths of logs an Axilog re-parse repaired. */
     onLogsHealed?: (filePaths: string[]) => void;
+    /** Published web report only: true when the report shipped a slice sidecar,
+     *  so the pill/tray/banner should render even though the view is embedded.
+     *  A historical FightReportHistoryView (also embedded) leaves this unset. */
+    sliceEnabled?: boolean;
+    /** Published web report only: awaited before the tray opens, so the first
+     *  open is what triggers the sidecar fetch (Task 18) rather than report load. */
+    onOpenSliceTray?: () => Promise<unknown>;
 }
 
 const sidebarListClass = 'space-y-0.5 max-h-72 overflow-y-auto';
@@ -256,7 +263,7 @@ function resolveReplayFights(stats: any): any[] {
 export const deriveStatsViewLogs = (logs: any[], excluded: Set<string>, embedded: boolean): any[] =>
     embedded ? logs : selectSlicedLogs(logs, excluded);
 
-export const StatsView = memo(function StatsView({ logs, onBack: _onBack, mvpWeights, statsViewSettings, onStatsViewSettingsChange, webUploadState, onWebUpload, webUploadLogEntries, disruptionMethod, precomputedStats, embedded = false, sectionVisibility, onRequestCategory, onSearchAvailable, dashboardTitle, statsDataProgress, aggregationResult: externalAggregationResult, onLogsHealed }: StatsViewProps) {
+export const StatsView = memo(function StatsView({ logs, onBack: _onBack, mvpWeights, statsViewSettings, onStatsViewSettingsChange, webUploadState, onWebUpload, webUploadLogEntries, disruptionMethod, precomputedStats, embedded = false, sectionVisibility, onRequestCategory, onSearchAvailable, dashboardTitle, statsDataProgress, aggregationResult: externalAggregationResult, onLogsHealed, sliceEnabled = false, onOpenSliceTray }: StatsViewProps) {
     // Defer heavy section rendering by one frame so the header + progress bar can paint first.
     const [sectionsDeferred, setSectionsDeferred] = useState(!embedded);
     useEffect(() => {
@@ -4317,7 +4324,15 @@ type SpikeFight = {
                 actionsDisabled={statsActionsDisabled}
                 publishBlockedReason={publishBlockedReason}
                 onSearchClick={() => setSearchOpen(true)}
-                onToggleSliceTray={embedded ? undefined : () => setSliceTrayOpen((open) => !open)}
+                onToggleSliceTray={(!embedded || sliceEnabled) ? () => {
+                    setSliceTrayOpen((open) => {
+                        const next = !open;
+                        if (next && onOpenSliceTray) {
+                            void onOpenSliceTray();
+                        }
+                        return next;
+                    });
+                } : undefined}
             />
 
             <AxilogCoverageBanner
@@ -4344,8 +4359,8 @@ type SpikeFight = {
                 devMockUploadState={devMockUploadState}
             />
 
-            {!embedded && sliceTrayOpen && <FightSliceTray onClose={() => setSliceTrayOpen(false)} />}
-            {!embedded && <FightSliceBanner />}
+            {(!embedded || sliceEnabled) && sliceTrayOpen && <FightSliceTray onClose={() => setSliceTrayOpen(false)} />}
+            {(!embedded || sliceEnabled) && <FightSliceBanner />}
 
             {/* Processing indicator: particle spinner with witty remarks (desktop) */}
             {(aggregationSettling.active || detailsProgress.active) && !embedded && (

--- a/src/renderer/app/hooks/useWebUpload.ts
+++ b/src/renderer/app/hooks/useWebUpload.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { DEFAULT_WEB_UPLOAD_STATE, type IWebUploadState } from '../../global.d';
+import type { SliceSidecar } from '../../stats/slice/sliceTypes';
 
 export type LogEntry = { elapsed: string; text: string; isError: boolean; isWarn: boolean };
 
@@ -122,7 +123,7 @@ export function useWebUpload(opts?: {
         }, 2500);
     }, [webUploadState.stage]);
 
-    const handleWebUpload = useCallback(async (payload: { meta: any; stats: any; repoFullName?: string; repoOwner?: string; repoName?: string; logIds?: string[]; reportWebhookIds?: string[]; sliceSidecar?: any }) => {
+    const handleWebUpload = useCallback(async (payload: { meta: any; stats: any; repoFullName?: string; repoOwner?: string; repoName?: string; logIds?: string[]; reportWebhookIds?: string[]; sliceSidecar?: SliceSidecar }) => {
         if (!window.electronAPI?.uploadWebReport) {
             setWebUploadState((prev) => ({
                 ...prev,

--- a/src/renderer/app/hooks/useWebUpload.ts
+++ b/src/renderer/app/hooks/useWebUpload.ts
@@ -122,7 +122,7 @@ export function useWebUpload(opts?: {
         }, 2500);
     }, [webUploadState.stage]);
 
-    const handleWebUpload = useCallback(async (payload: { meta: any; stats: any; repoFullName?: string; repoOwner?: string; repoName?: string; logIds?: string[]; reportWebhookIds?: string[] }) => {
+    const handleWebUpload = useCallback(async (payload: { meta: any; stats: any; repoFullName?: string; repoOwner?: string; repoName?: string; logIds?: string[]; reportWebhookIds?: string[]; sliceSidecar?: any }) => {
         if (!window.electronAPI?.uploadWebReport) {
             setWebUploadState((prev) => ({
                 ...prev,

--- a/src/renderer/global.d.ts
+++ b/src/renderer/global.d.ts
@@ -420,7 +420,7 @@ export interface IElectronAPI {
     ensureGithubTemplate: () => Promise<{ success: boolean; updated?: boolean; error?: string }>;
     selectGithubLogo: () => Promise<string | null>;
     applyGithubLogo: (payload?: { logoPath?: string }) => Promise<{ success: boolean; updated?: boolean; error?: string }>;
-    uploadWebReport: (payload: { meta: any; stats: any; repoFullName?: string; repoOwner?: string; repoName?: string; reportWebhookIds?: string[] }) => Promise<{ success: boolean; url?: string; replayDataUrl?: string | null; error?: string; errorDetail?: string; webhookResults?: Array<{ id: string; name: string; ok: boolean; error?: string }> }>;
+    uploadWebReport: (payload: { meta: any; stats: any; repoFullName?: string; repoOwner?: string; repoName?: string; reportWebhookIds?: string[]; sliceSidecar?: any }) => Promise<{ success: boolean; url?: string; replayDataUrl?: string | null; error?: string; errorDetail?: string; webhookResults?: Array<{ id: string; name: string; ok: boolean; error?: string }> }>;
     mockWebReport: (payload: { meta: any; stats: any }) => Promise<{ success: boolean; url?: string; error?: string }>;
     getGithubPagesBuildStatus: (payload?: { repoFullName?: string; repoOwner?: string; repoName?: string }) => Promise<{ success: boolean; status?: string; updatedAt?: string; errorMessage?: string; error?: string }>;
     onWebUploadStatus: (callback: (data: { stage: string; message?: string; progress?: number }) => void) => () => void;

--- a/src/renderer/global.d.ts
+++ b/src/renderer/global.d.ts
@@ -1,5 +1,6 @@
 import type { ColorPalette } from '../shared/webThemes';
 import type { IReportWebhook } from '../shared/reportWebhooks';
+import type { SliceSidecar } from './stats/slice/sliceTypes';
 
 export interface IWebhook {
     id: string;
@@ -420,9 +421,10 @@ export interface IElectronAPI {
     ensureGithubTemplate: () => Promise<{ success: boolean; updated?: boolean; error?: string }>;
     selectGithubLogo: () => Promise<string | null>;
     applyGithubLogo: (payload?: { logoPath?: string }) => Promise<{ success: boolean; updated?: boolean; error?: string }>;
-    uploadWebReport: (payload: { meta: any; stats: any; repoFullName?: string; repoOwner?: string; repoName?: string; reportWebhookIds?: string[]; sliceSidecar?: any }) => Promise<{ success: boolean; url?: string; replayDataUrl?: string | null; error?: string; errorDetail?: string; webhookResults?: Array<{ id: string; name: string; ok: boolean; error?: string }> }>;
+    uploadWebReport: (payload: { meta: any; stats: any; repoFullName?: string; repoOwner?: string; repoName?: string; reportWebhookIds?: string[]; sliceSidecar?: SliceSidecar }) => Promise<{ success: boolean; url?: string; replayDataUrl?: string | null; error?: string; errorDetail?: string; webhookResults?: Array<{ id: string; name: string; ok: boolean; error?: string }> }>;
     mockWebReport: (payload: { meta: any; stats: any }) => Promise<{ success: boolean; url?: string; error?: string }>;
     getGithubPagesBuildStatus: (payload?: { repoFullName?: string; repoOwner?: string; repoName?: string }) => Promise<{ success: boolean; status?: string; updatedAt?: string; errorMessage?: string; error?: string }>;
+    isR2Configured: () => Promise<{ configured: boolean }>;
     onWebUploadStatus: (callback: (data: { stage: string; message?: string; progress?: number }) => void) => () => void;
     exportSettings: () => Promise<{ success: boolean; canceled?: boolean; error?: string }>;
     importSettings: () => Promise<{ success: boolean; canceled?: boolean; error?: string }>;

--- a/src/renderer/stats/components/FightSliceTray.tsx
+++ b/src/renderer/stats/components/FightSliceTray.tsx
@@ -29,7 +29,7 @@ export const FightSlicePill = ({ onClick }: { onClick: () => void }) => {
     );
 };
 
-export const FightSliceBanner = ({ onCopyLink }: { onCopyLink?: () => void } = {}) => {
+export const FightSliceBanner = ({ onCopyLink, unavailable = false }: { onCopyLink?: () => void; unavailable?: boolean } = {}) => {
     const roster = useStatsStore((s) => s.fightRoster);
     const excluded = useStatsStore((s) => s.excludedFightKeys);
     const clearFightSlice = useStatsStore((s) => s.clearFightSlice);
@@ -37,7 +37,13 @@ export const FightSliceBanner = ({ onCopyLink }: { onCopyLink?: () => void } = {
     const included = roster.length - roster.filter((f) => excluded.has(f.id)).length;
     return (
         <div className="flex items-center gap-2 border-b border-[color:var(--accent-border)] bg-[var(--accent-bg)] px-4 py-1.5 text-[11px] font-semibold text-[color:var(--text-primary)]">
-            <span>Sliced view — {included} of {roster.length} fights</span>
+            {/* `unavailable` means the published viewer's slice recompute failed
+                or refused, so the tables below are the FULL report. Saying
+                "Sliced view — N of M fights" over them is the one thing this
+                banner must never do. */}
+            {unavailable
+                ? <span>Slice unavailable — showing all {roster.length} fights</span>
+                : <span>Sliced view — {included} of {roster.length} fights</span>}
             <span className="ml-auto flex items-center gap-2">
                 {onCopyLink && (
                     <button

--- a/src/renderer/stats/components/FightSliceTray.tsx
+++ b/src/renderer/stats/components/FightSliceTray.tsx
@@ -29,7 +29,7 @@ export const FightSlicePill = ({ onClick }: { onClick: () => void }) => {
     );
 };
 
-export const FightSliceBanner = () => {
+export const FightSliceBanner = ({ onCopyLink }: { onCopyLink?: () => void } = {}) => {
     const roster = useStatsStore((s) => s.fightRoster);
     const excluded = useStatsStore((s) => s.excludedFightKeys);
     const clearFightSlice = useStatsStore((s) => s.clearFightSlice);
@@ -38,13 +38,24 @@ export const FightSliceBanner = () => {
     return (
         <div className="flex items-center gap-2 border-b border-[color:var(--accent-border)] bg-[var(--accent-bg)] px-4 py-1.5 text-[11px] font-semibold text-[color:var(--text-primary)]">
             <span>Sliced view — {included} of {roster.length} fights</span>
-            <button
-                type="button"
-                onClick={clearFightSlice}
-                className="ml-auto rounded-[var(--radius-md)] border border-[color:var(--border-default)] px-2 py-0.5 text-[10px] text-[color:var(--text-secondary)]"
-            >
-                Clear slice
-            </button>
+            <span className="ml-auto flex items-center gap-2">
+                {onCopyLink && (
+                    <button
+                        type="button"
+                        onClick={onCopyLink}
+                        className="rounded-[var(--radius-md)] border border-[color:var(--border-default)] px-2 py-0.5 text-[10px] text-[color:var(--text-secondary)]"
+                    >
+                        Copy slice link
+                    </button>
+                )}
+                <button
+                    type="button"
+                    onClick={clearFightSlice}
+                    className="rounded-[var(--radius-md)] border border-[color:var(--border-default)] px-2 py-0.5 text-[10px] text-[color:var(--text-secondary)]"
+                >
+                    Clear slice
+                </button>
+            </span>
         </div>
     );
 };

--- a/src/renderer/stats/components/__tests__/FightSliceTray.test.tsx
+++ b/src/renderer/stats/components/__tests__/FightSliceTray.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { useStatsStore, type FightRosterEntry } from '../../statsStore';
 import { FightSliceTray, FightSliceBanner } from '../FightSliceTray';
@@ -144,5 +144,19 @@ describe('FightSliceBanner', () => {
         render(<FightSliceBanner />);
         fireEvent.click(screen.getByRole('button', { name: /clear slice/i }));
         expect(useStatsStore.getState().excludedFightKeys.size).toBe(0);
+    });
+
+    it('renders no copy control when no handler is supplied', () => {
+        useStatsStore.getState().setFightsExcluded(['b'], true);
+        render(<FightSliceBanner />);
+        expect(screen.queryByRole('button', { name: /copy slice link/i })).not.toBeInTheDocument();
+    });
+
+    it('renders a copy control when a handler is supplied and calls it', () => {
+        useStatsStore.getState().setFightsExcluded(['b'], true);
+        const onCopyLink = vi.fn();
+        render(<FightSliceBanner onCopyLink={onCopyLink} />);
+        fireEvent.click(screen.getByRole('button', { name: /copy slice link/i }));
+        expect(onCopyLink).toHaveBeenCalledTimes(1);
     });
 });

--- a/src/renderer/stats/components/__tests__/FightSliceTray.test.tsx
+++ b/src/renderer/stats/components/__tests__/FightSliceTray.test.tsx
@@ -139,6 +139,19 @@ describe('FightSliceBanner', () => {
         expect(screen.getByText(/1 of 2 fights/i)).toBeInTheDocument();
     });
 
+    /**
+     * C1: when the published viewer's slice recompute fails or refuses, the
+     * tables under this banner are the FULL report. Claiming "Sliced view — 1
+     * of 2 fights" over them is the exact "degrade to wrong numbers" outcome
+     * the spec forbids, and it is invisible — the numbers look plausible.
+     */
+    it('says the slice is unavailable rather than claiming a subset when the recompute failed', () => {
+        useStatsStore.getState().setFightsExcluded(['b'], true);
+        render(<FightSliceBanner unavailable />);
+        expect(screen.getByText(/slice unavailable/i)).toBeInTheDocument();
+        expect(screen.queryByText(/1 of 2 fights/i)).not.toBeInTheDocument();
+    });
+
     it('clears the slice', () => {
         useStatsStore.getState().setFightsExcluded(['b'], true);
         render(<FightSliceBanner />);

--- a/src/renderer/stats/computeAllDamageData.ts
+++ b/src/renderer/stats/computeAllDamageData.ts
@@ -53,6 +53,13 @@ export interface AllDamageAccumulator {
     playerAgg: Map<string, AllDamagePlayer>;
     /** Running fight index counter. */
     fightIndex: number;
+    /**
+     * Squad member order for each entry in `fights` (index-aligned), captured
+     * before `fight.players` is sorted by damage. Needed so a solo
+     * accumulator's frame can carry the same fold order `ingestLogAllDamage`
+     * used, rather than falling back to `fight.players`' damage order.
+     */
+    fightMemberOrders: string[][];
 }
 
 export interface AllDamageIngestOptions {
@@ -112,6 +119,7 @@ export function createAllDamageAccumulator(): AllDamageAccumulator {
         fights: [],
         playerAgg: new Map(),
         fightIndex: 0,
+        fightMemberOrders: [],
     };
 }
 
@@ -120,12 +128,26 @@ export function createAllDamageAccumulator(): AllDamageAccumulator {
  * `ingestLogAllDamage` and `mergeAllDamageFrame`, so slice-mode totals cannot
  * drift from all-fights totals. Every field it needs already lives on the
  * bucket, which is why this module's frame carries no seeds.
+ *
+ * `fight.players` ships sorted by `totalDamage` descending (that ordering is
+ * part of the public `AllDamageData` shape), but folding in that order would
+ * make first-insertion order into `playerAgg` — and therefore the tie-break
+ * among players whose MERGED totals end up byte-identical, since
+ * `finalizeAllDamage`'s sort is stable — depend on per-fight damage order
+ * instead of squad member order. `order`, when given, is the list of player
+ * keys in the order they were originally built (native's member order); the
+ * fold visits buckets in that order instead of `fight.players`' sorted order.
  */
 export function foldAllDamageFightIntoPlayers(
     fight: AllDamageFight,
     playerAgg: Map<string, AllDamagePlayer>,
+    order?: string[],
 ): void {
-    fight.players.forEach((bucket) => {
+    const bucketsByKey = order ? new Map(fight.players.map((b) => [b.key, b])) : null;
+    const buckets = bucketsByKey
+        ? order!.map((key) => bucketsByKey.get(key)).filter((b): b is AllDamagePlayerBucket => Boolean(b))
+        : fight.players;
+    buckets.forEach((bucket) => {
         const existing = playerAgg.get(bucket.key);
         if (existing) {
             existing.logs += 1;
@@ -221,6 +243,12 @@ export function ingestLogAllDamage(log: any, acc: AllDamageAccumulator, options:
         fightTotalDown += totalDownContribution;
     });
 
+    // Member order, captured before the damage sort below — this is the order
+    // `foldAllDamageFightIntoPlayers` must fold in, both here and from a
+    // frame, so tie-break order among players is squad order, not damage
+    // order (see that function's doc comment).
+    const memberOrder = fightPlayers.map((p) => p.key);
+
     // Sort players within fight by total damage descending
     fightPlayers.sort((a, b) => b.totalDamage - a.totalDamage);
 
@@ -238,7 +266,8 @@ export function ingestLogAllDamage(log: any, acc: AllDamageAccumulator, options:
         players: fightPlayers,
     };
     acc.fights.push(fight);
-    foldAllDamageFightIntoPlayers(fight, acc.playerAgg);
+    acc.fightMemberOrders.push(memberOrder);
+    foldAllDamageFightIntoPlayers(fight, acc.playerAgg, memberOrder);
 }
 
 export function finalizeAllDamage(acc: AllDamageAccumulator): AllDamageData {
@@ -256,19 +285,29 @@ export function finalizeAllDamage(acc: AllDamageAccumulator): AllDamageData {
 
 export interface AllDamageFrame {
     fight: AllDamageFight;
+    /**
+     * Player keys in squad member order, i.e. the order `ingestLogAllDamage`
+     * built them in before sorting `fight.players` by damage. Carried so
+     * `mergeAllDamageFrame` folds in the same order `ingestLogAllDamage` does
+     * — without it, merge would fall back to `fight.players`' damage order,
+     * which only agrees with member order when no fight sorts its players
+     * differently from squad order.
+     */
+    memberOrder: string[];
 }
 
 export function extractAllDamageFrame(acc: AllDamageAccumulator): AllDamageFrame {
     if (acc.fights.length !== 1) {
         throw new Error(`extractAllDamageFrame expects exactly one fight, got ${acc.fights.length}`);
     }
-    return { fight: acc.fights[0] };
+    return { fight: acc.fights[0], memberOrder: acc.fightMemberOrders[0] };
 }
 
 export function mergeAllDamageFrame(target: AllDamageAccumulator, frame: AllDamageFrame): void {
     target.fightIndex += 1;
     target.fights.push(frame.fight);
-    foldAllDamageFightIntoPlayers(frame.fight, target.playerAgg);
+    target.fightMemberOrders.push(frame.memberOrder);
+    foldAllDamageFightIntoPlayers(frame.fight, target.playerAgg, frame.memberOrder);
 }
 
 export function computeAllDamageData(validLogs: any[], splitPlayersByClass = false): AllDamageData {

--- a/src/renderer/stats/computeAllDamageData.ts
+++ b/src/renderer/stats/computeAllDamageData.ts
@@ -115,6 +115,40 @@ export function createAllDamageAccumulator(): AllDamageAccumulator {
     };
 }
 
+/**
+ * Fold one fight's player buckets into the running player aggregate. Shared by
+ * `ingestLogAllDamage` and `mergeAllDamageFrame`, so slice-mode totals cannot
+ * drift from all-fights totals. Every field it needs already lives on the
+ * bucket, which is why this module's frame carries no seeds.
+ */
+export function foldAllDamageFightIntoPlayers(
+    fight: AllDamageFight,
+    playerAgg: Map<string, AllDamagePlayer>,
+): void {
+    fight.players.forEach((bucket) => {
+        const existing = playerAgg.get(bucket.key);
+        if (existing) {
+            existing.logs += 1;
+            existing.totalDamage += bucket.totalDamage;
+            existing.totalDownContribution += bucket.totalDownContribution;
+            if (!existing.professionList.includes(bucket.profession) && bucket.profession !== 'Unknown') {
+                existing.professionList.push(bucket.profession);
+            }
+        } else {
+            playerAgg.set(bucket.key, {
+                key: bucket.key,
+                account: bucket.account,
+                displayName: bucket.displayName,
+                profession: bucket.profession,
+                professionList: [bucket.profession].filter((p) => p !== 'Unknown'),
+                logs: 1,
+                totalDamage: bucket.totalDamage,
+                totalDownContribution: bucket.totalDownContribution,
+            });
+        }
+    });
+}
+
 export function ingestLogAllDamage(log: any, acc: AllDamageAccumulator, options: AllDamageIngestOptions = {}): void {
     const splitPlayersByClass = options.splitPlayersByClass ?? false;
     const details = log?.details;
@@ -185,28 +219,6 @@ export function ingestLogAllDamage(log: any, acc: AllDamageAccumulator, options:
 
         fightTotalDamage += totalDamage;
         fightTotalDown += totalDownContribution;
-
-        // Aggregate player totals
-        const existing = acc.playerAgg.get(key);
-        if (existing) {
-            existing.logs += 1;
-            existing.totalDamage += totalDamage;
-            existing.totalDownContribution += totalDownContribution;
-            if (!existing.professionList.includes(profession) && profession !== 'Unknown') {
-                existing.professionList.push(profession);
-            }
-        } else {
-            acc.playerAgg.set(key, {
-                key,
-                account,
-                displayName: characterName || account,
-                profession,
-                professionList: [profession].filter((p) => p !== 'Unknown'),
-                logs: 1,
-                totalDamage,
-                totalDownContribution,
-            });
-        }
     });
 
     // Sort players within fight by total damage descending
@@ -214,7 +226,7 @@ export function ingestLogAllDamage(log: any, acc: AllDamageAccumulator, options:
 
     const isWin = members.length > 0 ? getFightOutcome(details) : null;
 
-    acc.fights.push({
+    const fight: AllDamageFight = {
         id: String(log?.filePath || log?.id || `fight-${index + 1}`),
         shortLabel: `F${index + 1}`,
         fullLabel,
@@ -224,7 +236,9 @@ export function ingestLogAllDamage(log: any, acc: AllDamageAccumulator, options:
         durationMs,
         isWin,
         players: fightPlayers,
-    });
+    };
+    acc.fights.push(fight);
+    foldAllDamageFightIntoPlayers(fight, acc.playerAgg);
 }
 
 export function finalizeAllDamage(acc: AllDamageAccumulator): AllDamageData {
@@ -238,6 +252,23 @@ export function finalizeAllDamage(acc: AllDamageAccumulator): AllDamageData {
         .map((fight, i) => ({ ...fight, shortLabel: `F${i + 1}` }));
 
     return { fights, players };
+}
+
+export interface AllDamageFrame {
+    fight: AllDamageFight;
+}
+
+export function extractAllDamageFrame(acc: AllDamageAccumulator): AllDamageFrame {
+    if (acc.fights.length !== 1) {
+        throw new Error(`extractAllDamageFrame expects exactly one fight, got ${acc.fights.length}`);
+    }
+    return { fight: acc.fights[0] };
+}
+
+export function mergeAllDamageFrame(target: AllDamageAccumulator, frame: AllDamageFrame): void {
+    target.fightIndex += 1;
+    target.fights.push(frame.fight);
+    foldAllDamageFightIntoPlayers(frame.fight, target.playerAgg);
 }
 
 export function computeAllDamageData(validLogs: any[], splitPlayersByClass = false): AllDamageData {

--- a/src/renderer/stats/computeAllDamageData.ts
+++ b/src/renderer/stats/computeAllDamageData.ts
@@ -6,6 +6,7 @@ import {
 import { resolveFightTimestamp } from './utils/timestampUtils';
 import { buildFightLabelV2, computeFightAvgPosition } from './utils/labelUtils';
 import { getFightOutcome } from './computePlayerAggregation';
+import { applyLabel, type FrameFightLabels } from './slice/frameLabels';
 
 export interface AllDamagePlayerBucket {
     key: string;
@@ -303,7 +304,18 @@ export function extractAllDamageFrame(acc: AllDamageAccumulator): AllDamageFrame
     return { fight: acc.fights[0], memberOrder: acc.fightMemberOrders[0] };
 }
 
-export function mergeAllDamageFrame(target: AllDamageAccumulator, frame: AllDamageFrame): void {
+
+/**
+ * `labels` re-states the ordinal-derived strings at the merge ordinal. A frame
+ * is always built by a solo aggregator, so `fight.id` / `shortLabel` are baked
+ * at ordinal 0 and `fullLabel` carries the `Fight 1` zone fallback whenever the
+ * log named no zone. They are rewritten BEFORE the player fold, so the fold's
+ * `peakFightLabel` picks up the corrected string for free.
+ */
+export function mergeAllDamageFrame(target: AllDamageAccumulator, frame: AllDamageFrame, labels: FrameFightLabels): void {
+    applyLabel(frame.fight, 'id', labels.fightId);
+    applyLabel(frame.fight, 'shortLabel', labels.shortLabel);
+    applyLabel(frame.fight, 'fullLabel', labels.fullLabel);
     target.fightIndex += 1;
     target.fights.push(frame.fight);
     target.fightMemberOrders.push(frame.memberOrder);

--- a/src/renderer/stats/computeBoonTimeline.ts
+++ b/src/renderer/stats/computeBoonTimeline.ts
@@ -527,19 +527,16 @@ export function mergeBoonTimelineFrame(target: BoonTimelineAccumulator, frame: B
         // logs — is metadata (unions/integer sums), not a float accumulation,
         // so merging it in one shot is exact. `totals` was already replayed
         // above and must not be touched again here.
+        //
+        // No `!existing` fallback: every `players` entry here was created
+        // moments ago by the event replay loop above (every player is
+        // touched by at least one of its own events), so `existing` is
+        // guaranteed. A defensive clone-and-continue branch would silently
+        // paper over a future divergence between the event stream and
+        // `players` instead of surfacing it — let a violation of that
+        // invariant throw here rather than hide.
         sourceBucket.players.forEach((sourcePlayer, key) => {
-            const existing = bucket!.players.get(key);
-            if (!existing) {
-                // No event touched this key this fight — shouldn't happen,
-                // since every `players` entry is created alongside at least
-                // one event, but fall back to a full clone defensively.
-                bucket!.players.set(key, {
-                    ...sourcePlayer,
-                    professionList: [...sourcePlayer.professionList],
-                    totals: { ...sourcePlayer.totals },
-                });
-                return;
-            }
+            const existing = bucket!.players.get(key)!;
             existing.logs += sourcePlayer.logs;
             sourcePlayer.professionList.forEach((profession) => {
                 if (!existing.professionList.includes(profession)) existing.professionList.push(profession);

--- a/src/renderer/stats/computeBoonTimeline.ts
+++ b/src/renderer/stats/computeBoonTimeline.ts
@@ -31,6 +31,18 @@ type BoonFightValue = {
     bucketWeights5s: number[];
     buckets5s: number[];
 };
+/**
+ * One raw `addBoonCategoryGeneration` call captured in the exact order it was
+ * applied to `boonBuckets.players` during ingest. `category` is an index into
+ * `['selfBuffs', 'groupBuffs', 'squadBuffs']` — kept numeric to stay small.
+ *
+ * A frame is always exactly one log (see `extractBoonTimelineFrame`), so this
+ * is one fight's complete, ordered event stream. It exists purely so a slice
+ * merge can replay it — see `mergeBoonTimelineFrame` — and is stripped back
+ * out in `finalizeBoonTimeline` so it never reaches the published `stats`
+ * output for non-slice builds.
+ */
+type BoonRawEvent = { key: string; category: 0 | 1 | 2; value: number };
 type BoonFight = {
     id: string;
     shortLabel: string;
@@ -39,6 +51,7 @@ type BoonFight = {
     durationMs: number;
     values: Record<string, BoonFightValue>;
     maxTotal: number;
+    events: BoonRawEvent[];
 };
 export type BoonBucket = {
     id: string;
@@ -201,6 +214,8 @@ export function ingestLogBoonTimeline(log: any, acc: BoonTimelineAccumulator, _b
     const fightValuesByBoon = new Map<string, Map<string, { selfBuffs: number; groupBuffs: number; squadBuffs: number; totalBuffs: number }>>();
     const fightBucketTimelineByBoon = new Map<string, Map<string, number[]>>();
     const fightPlayerSeenByBoon = new Map<string, Set<string>>();
+    const fightRawEventsByBoon = new Map<string, BoonRawEvent[]>();
+    const categories: Array<'selfBuffs' | 'groupBuffs' | 'squadBuffs'> = ['selfBuffs', 'groupBuffs', 'squadBuffs'];
 
     members.forEach((entity: any) => {
         const key = entity.account || entity.character || 'Unknown';
@@ -208,7 +223,6 @@ export function ingestLogBoonTimeline(log: any, acc: BoonTimelineAccumulator, _b
         const profession = getEntityProfession(entity) || 'Unknown';
         const group = entity.subgroup ?? 0;
         const groupCount = Math.max(1, Number(groupCounts.get(group) || 1));
-        const categories: Array<'selfBuffs' | 'groupBuffs' | 'squadBuffs'> = ['selfBuffs', 'groupBuffs', 'squadBuffs'];
 
         listBoonIds(details).forEach((boonIdNum) => {
             const meta = getBuffMeta(details, boonIdNum);
@@ -259,6 +273,14 @@ export function ingestLogBoonTimeline(log: any, acc: BoonTimelineAccumulator, _b
                 };
                 addBoonCategoryGeneration(allEntry.totals, category, generationMs);
                 boonBucket.players.set('__all__', allEntry);
+                // Record the raw event in the same order it was just applied
+                // above (player entry, then `__all__`) so a later slice merge
+                // can replay it bit-for-bit — see `BoonRawEvent`.
+                const categoryIndex = categories.indexOf(category) as 0 | 1 | 2;
+                const rawEvents = fightRawEventsByBoon.get(boonId) || [];
+                rawEvents.push({ key, category: categoryIndex, value: generationMs });
+                rawEvents.push({ key: '__all__', category: categoryIndex, value: generationMs });
+                fightRawEventsByBoon.set(boonId, rawEvents);
                 const fightValues = fightValuesByBoon.get(boonId) || new Map<string, { selfBuffs: number; groupBuffs: number; squadBuffs: number; totalBuffs: number }>();
                 const playerFightTotals = fightValues.get(key) || createBoonCategoryTotals();
                 addBoonCategoryGeneration(playerFightTotals, category, generationMs);
@@ -359,7 +381,8 @@ export function ingestLogBoonTimeline(log: any, acc: BoonTimelineAccumulator, _b
             timestamp: resolveFightTimestamp(details, log),
             durationMs,
             values,
-            maxTotal
+            maxTotal,
+            events: fightRawEventsByBoon.get(boonId) || []
         });
     });
 }
@@ -386,7 +409,12 @@ export function finalizeBoonTimeline(acc: BoonTimelineAccumulator): any {
                 // Reassign shortLabels after sort so F1=oldest, F2=next, etc.
                 // Labels are assigned during ingestion by insertion order, which may
                 // not match chronological order, causing scrambled fight numbers.
-                .map((fight, i) => ({ ...fight, shortLabel: `F${i + 1}` }))
+                //
+                // `events` is dropped here: it is raw per-generation-event data
+                // that only exists so a slice merge can replay it bit-exactly
+                // (see `BoonRawEvent`); the published `stats` output never reads
+                // it and it would otherwise meaningfully bloat every report.
+                .map(({ events: _events, ...fight }, i) => ({ ...fight, shortLabel: `F${i + 1}` }))
         }))
         .filter((boon) => boon.players.length > 0 && boon.fights.length > 0)
         .sort((a, b) => String(a.name || '').localeCompare(String(b.name || '')));
@@ -458,9 +486,53 @@ export function mergeBoonTimelineFrame(target: BoonTimelineAccumulator, frame: B
             if (!bucket.stacking && sourceBucket.stacking) bucket.stacking = true;
         }
         sourceBucket.fights.forEach((fight) => bucket!.fights.push(fight));
+
+        // Replay this fight's raw per-event boon generation onto the running
+        // cross-fight totals, in the exact order `ingestLogBoonTimeline` would
+        // have applied them directly. A frame is always exactly one log (see
+        // `extractBoonTimelineFrame`), so `fights[0].events` is that fight's
+        // complete, ordered event stream.
+        //
+        // This is NOT the same as merging `sourcePlayer.totals` in one shot:
+        // `totals` is itself the pre-reduced sum of many small per-event
+        // additions that started from zero inside the solo frame aggregator.
+        // A direct multi-log run never resets between fights — its running
+        // total carries a nonzero value into this fight's events — so adding
+        // the whole pre-reduced fight total in one step regroups the
+        // floating-point arithmetic differently and can drift by an ULP or
+        // more (observed on `test-fixtures/native/` at 5+ merged fights: a
+        // `squadBuffs` total came out `9298732` direct vs
+        // `9298731.999999998` from a one-shot merge). Replaying the
+        // individual events reproduces the direct-ingest float bit-for-bit.
+        const categoryNames: Array<'selfBuffs' | 'groupBuffs' | 'squadBuffs'> = ['selfBuffs', 'groupBuffs', 'squadBuffs'];
+        const events: BoonRawEvent[] = (sourceBucket.fights[0] as any)?.events || [];
+        events.forEach((event) => {
+            let entry = bucket!.players.get(event.key);
+            if (!entry) {
+                entry = {
+                    key: event.key,
+                    account: event.key === '__all__' ? 'All' : event.key,
+                    displayName: event.key === '__all__' ? 'All' : event.key,
+                    profession: event.key === '__all__' ? 'All' : 'Unknown',
+                    professionList: [],
+                    logs: 0,
+                    totals: createBoonCategoryTotals(),
+                };
+                bucket!.players.set(event.key, entry);
+            }
+            addBoonCategoryGeneration(entry.totals, categoryNames[event.category], event.value);
+        });
+
+        // Everything else about a player row — profession, professionList,
+        // logs — is metadata (unions/integer sums), not a float accumulation,
+        // so merging it in one shot is exact. `totals` was already replayed
+        // above and must not be touched again here.
         sourceBucket.players.forEach((sourcePlayer, key) => {
             const existing = bucket!.players.get(key);
             if (!existing) {
+                // No event touched this key this fight — shouldn't happen,
+                // since every `players` entry is created alongside at least
+                // one event, but fall back to a full clone defensively.
                 bucket!.players.set(key, {
                     ...sourcePlayer,
                     professionList: [...sourcePlayer.professionList],
@@ -469,19 +541,6 @@ export function mergeBoonTimelineFrame(target: BoonTimelineAccumulator, frame: B
                 return;
             }
             existing.logs += sourcePlayer.logs;
-            // `totalBuffs` is not merged as a pre-summed value: ingestLogBoonTimeline
-            // builds it by adding selfBuffs then squadBuffs (see the category loop
-            // above, and addBoonCategoryGeneration) onto the SAME running total that
-            // carries over between fights. IEEE754 addition isn't associative, so
-            // merging `sourcePlayer.totals.totalBuffs` in one shot regroups the sum
-            // differently from that continuous per-fight accumulation and can drift by
-            // an ULP. Replaying the same two-step (self, then squad) addition order
-            // here reproduces the direct-ingest float bit-for-bit.
-            existing.totals.groupBuffs += sourcePlayer.totals.groupBuffs;
-            existing.totals.totalBuffs += sourcePlayer.totals.selfBuffs;
-            existing.totals.selfBuffs += sourcePlayer.totals.selfBuffs;
-            existing.totals.totalBuffs += sourcePlayer.totals.squadBuffs;
-            existing.totals.squadBuffs += sourcePlayer.totals.squadBuffs;
             sourcePlayer.professionList.forEach((profession) => {
                 if (!existing.professionList.includes(profession)) existing.professionList.push(profession);
             });

--- a/src/renderer/stats/computeBoonTimeline.ts
+++ b/src/renderer/stats/computeBoonTimeline.ts
@@ -4,6 +4,7 @@ import {
 import { getEntityBoonGenerationMs } from '../../shared/boonGeneration';
 import { resolveFightTimestamp } from './utils/timestampUtils';
 import { buildFightLabelV2, computeFightAvgPosition } from './utils/labelUtils';
+import { applyLabel, type FrameFightLabels } from './slice/frameLabels';
 
 export type BoonPlayer = {
     key: string;
@@ -425,7 +426,19 @@ export function extractBoonTimelineFrame(acc: BoonTimelineAccumulator): BoonTime
  * and merging is adding it in. `fights` concatenates; `finalizeBoonTimeline`
  * re-sorts and renumbers.
  */
-export function mergeBoonTimelineFrame(target: BoonTimelineAccumulator, frame: BoonTimelineFrame): void {
+
+/**
+ * `labels` re-states the ordinal-derived strings at the merge ordinal. Every
+ * boon bucket repeats the same per-fight row, so the rewrite walks all of them.
+ */
+export function mergeBoonTimelineFrame(target: BoonTimelineAccumulator, frame: BoonTimelineFrame, labels: FrameFightLabels): void {
+    frame.boonBuckets.forEach((sourceBucket) => {
+        sourceBucket.fights.forEach((fight: any) => {
+            applyLabel(fight, 'id', labels.fightId);
+            applyLabel(fight, 'shortLabel', labels.shortLabel);
+            applyLabel(fight, 'fullLabel', labels.fullLabel);
+        });
+    });
     target.logIndex += 1;
     frame.boonBuckets.forEach((sourceBucket, boonId) => {
         let bucket = target.boonBuckets.get(boonId);

--- a/src/renderer/stats/computeBoonTimeline.ts
+++ b/src/renderer/stats/computeBoonTimeline.ts
@@ -5,7 +5,7 @@ import { getEntityBoonGenerationMs } from '../../shared/boonGeneration';
 import { resolveFightTimestamp } from './utils/timestampUtils';
 import { buildFightLabelV2, computeFightAvgPosition } from './utils/labelUtils';
 
-type BoonPlayer = {
+export type BoonPlayer = {
     key: string;
     account: string;
     displayName: string;
@@ -39,7 +39,7 @@ type BoonFight = {
     values: Record<string, BoonFightValue>;
     maxTotal: number;
 };
-type BoonBucket = {
+export type BoonBucket = {
     id: string;
     name: string;
     icon?: string;
@@ -404,4 +404,78 @@ export function computeBoonTimeline(validLogs: any[]) {
     }
 
     return finalizeBoonTimeline(acc);
+}
+
+export interface BoonTimelineFrame {
+    boonBuckets: Map<string, BoonBucket>;
+}
+
+export function extractBoonTimelineFrame(acc: BoonTimelineAccumulator): BoonTimelineFrame {
+    if (acc.logIndex !== 1) {
+        throw new Error(`extractBoonTimelineFrame expects exactly one log, got ${acc.logIndex}`);
+    }
+    return { boonBuckets: acc.boonBuckets };
+}
+
+/**
+ * Merge one fight's boon buckets into a running accumulator.
+ *
+ * Every `BoonPlayer` field is a sum or a union — `ingestLogBoonTimeline` only
+ * ever adds — so a single-log frame's player map IS that fight's contribution
+ * and merging is adding it in. `fights` concatenates; `finalizeBoonTimeline`
+ * re-sorts and renumbers.
+ */
+export function mergeBoonTimelineFrame(target: BoonTimelineAccumulator, frame: BoonTimelineFrame): void {
+    target.logIndex += 1;
+    frame.boonBuckets.forEach((sourceBucket, boonId) => {
+        let bucket = target.boonBuckets.get(boonId);
+        if (!bucket) {
+            bucket = {
+                id: sourceBucket.id,
+                name: sourceBucket.name,
+                icon: sourceBucket.icon,
+                stacking: sourceBucket.stacking,
+                players: new Map<string, BoonPlayer>(),
+                fights: []
+            };
+            target.boonBuckets.set(boonId, bucket);
+        } else {
+            if ((!bucket.name || bucket.name === boonId) && sourceBucket.name) bucket.name = sourceBucket.name;
+            if (!bucket.icon && sourceBucket.icon) bucket.icon = sourceBucket.icon;
+            if (!bucket.stacking && sourceBucket.stacking) bucket.stacking = true;
+        }
+        sourceBucket.fights.forEach((fight) => bucket!.fights.push(fight));
+        sourceBucket.players.forEach((sourcePlayer, key) => {
+            const existing = bucket!.players.get(key);
+            if (!existing) {
+                bucket!.players.set(key, {
+                    ...sourcePlayer,
+                    professionList: [...sourcePlayer.professionList],
+                    totals: { ...sourcePlayer.totals },
+                });
+                return;
+            }
+            existing.logs += sourcePlayer.logs;
+            // `totalBuffs` is not merged as a pre-summed value: ingestLogBoonTimeline
+            // builds it by adding selfBuffs then squadBuffs (see the category loop
+            // above, and addBoonCategoryGeneration) onto the SAME running total that
+            // carries over between fights. IEEE754 addition isn't associative, so
+            // merging `sourcePlayer.totals.totalBuffs` in one shot regroups the sum
+            // differently from that continuous per-fight accumulation and can drift by
+            // an ULP. Replaying the same two-step (self, then squad) addition order
+            // here reproduces the direct-ingest float bit-for-bit.
+            existing.totals.groupBuffs += sourcePlayer.totals.groupBuffs;
+            existing.totals.totalBuffs += sourcePlayer.totals.selfBuffs;
+            existing.totals.selfBuffs += sourcePlayer.totals.selfBuffs;
+            existing.totals.totalBuffs += sourcePlayer.totals.squadBuffs;
+            existing.totals.squadBuffs += sourcePlayer.totals.squadBuffs;
+            sourcePlayer.professionList.forEach((profession) => {
+                if (!existing.professionList.includes(profession)) existing.professionList.push(profession);
+            });
+            if ((!existing.profession || existing.profession === 'Unknown')
+                && sourcePlayer.profession && sourcePlayer.profession !== 'Unknown') {
+                existing.profession = sourcePlayer.profession;
+            }
+        });
+    });
 }

--- a/src/renderer/stats/computeBoonUptimeTimeline.ts
+++ b/src/renderer/stats/computeBoonUptimeTimeline.ts
@@ -4,7 +4,7 @@ import {
 import { resolveFightTimestamp } from './utils/timestampUtils';
 import { buildFightLabelV2, computeFightAvgPosition } from './utils/labelUtils';
 
-type UptimePlayer = {
+export type UptimePlayer = {
     key: string;
     account: string;
     displayName: string;
@@ -28,7 +28,7 @@ type UptimeFight = {
     values: Record<string, UptimeFightValue>;
     maxTotal: number;
 };
-type UptimeBucket = {
+export type UptimeBucket = {
     id: string;
     name: string;
     icon?: string;
@@ -293,4 +293,68 @@ export function computeBoonUptimeTimeline(
     }
 
     return finalizeBoonUptimeTimeline(acc);
+}
+
+export interface BoonUptimeFrame {
+    boonBuckets: Map<string, UptimeBucket>;
+}
+
+export function extractBoonUptimeFrame(acc: BoonUptimeTimelineAccumulator): BoonUptimeFrame {
+    if (acc.logIndex !== 1) {
+        throw new Error(`extractBoonUptimeFrame expects exactly one log, got ${acc.logIndex}`);
+    }
+    return { boonBuckets: acc.boonBuckets };
+}
+
+/**
+ * Merge one fight's uptime buckets into a running accumulator.
+ *
+ * `total` and `logs` are sums; `peak` is a max, mirroring the ingest fold.
+ * `intervalMs` comes from settings rather than from the log, so the target's
+ * value always wins — a frame built under different settings is rejected far
+ * earlier, by the sidecar's settingsHash check.
+ */
+export function mergeBoonUptimeFrame(target: BoonUptimeTimelineAccumulator, frame: BoonUptimeFrame): void {
+    target.logIndex += 1;
+    frame.boonBuckets.forEach((sourceBucket, boonId) => {
+        let bucket = target.boonBuckets.get(boonId);
+        if (!bucket) {
+            bucket = {
+                id: sourceBucket.id,
+                name: sourceBucket.name,
+                icon: sourceBucket.icon,
+                stacking: sourceBucket.stacking,
+                intervalMs: sourceBucket.stacking
+                    ? target.defaultStackingIntervalMs
+                    : target.defaultBoonIntervalMs,
+                players: new Map<string, UptimePlayer>(),
+                fights: [],
+            };
+            target.boonBuckets.set(boonId, bucket);
+        } else {
+            if ((!bucket.name || bucket.name === boonId) && sourceBucket.name) bucket.name = sourceBucket.name;
+            if (!bucket.icon && sourceBucket.icon) bucket.icon = sourceBucket.icon;
+        }
+        sourceBucket.fights.forEach((fight) => bucket!.fights.push(fight));
+        sourceBucket.players.forEach((sourcePlayer, key) => {
+            const existing = bucket!.players.get(key);
+            if (!existing) {
+                bucket!.players.set(key, {
+                    ...sourcePlayer,
+                    professionList: [...sourcePlayer.professionList],
+                });
+                return;
+            }
+            existing.logs += sourcePlayer.logs;
+            existing.total += sourcePlayer.total;
+            existing.peak = Math.max(existing.peak, sourcePlayer.peak);
+            sourcePlayer.professionList.forEach((profession) => {
+                if (!existing.professionList.includes(profession)) existing.professionList.push(profession);
+            });
+            if ((!existing.profession || existing.profession === 'Unknown')
+                && sourcePlayer.profession && sourcePlayer.profession !== 'Unknown') {
+                existing.profession = sourcePlayer.profession;
+            }
+        });
+    });
 }

--- a/src/renderer/stats/computeBoonUptimeTimeline.ts
+++ b/src/renderer/stats/computeBoonUptimeTimeline.ts
@@ -3,6 +3,7 @@ import {
 } from '@axiapps/bridge-metrics';
 import { resolveFightTimestamp } from './utils/timestampUtils';
 import { buildFightLabelV2, computeFightAvgPosition } from './utils/labelUtils';
+import { applyLabel, type FrameFightLabels } from './slice/frameLabels';
 
 export type UptimePlayer = {
     key: string;
@@ -314,7 +315,19 @@ export function extractBoonUptimeFrame(acc: BoonUptimeTimelineAccumulator): Boon
  * value always wins — a frame built under different settings is rejected far
  * earlier, by the sidecar's settingsHash check.
  */
-export function mergeBoonUptimeFrame(target: BoonUptimeTimelineAccumulator, frame: BoonUptimeFrame): void {
+
+/**
+ * `labels` re-states the ordinal-derived strings at the merge ordinal. Every
+ * boon bucket repeats the same per-fight row, so the rewrite walks all of them.
+ */
+export function mergeBoonUptimeFrame(target: BoonUptimeTimelineAccumulator, frame: BoonUptimeFrame, labels: FrameFightLabels): void {
+    frame.boonBuckets.forEach((sourceBucket) => {
+        sourceBucket.fights.forEach((fight: any) => {
+            applyLabel(fight, 'id', labels.fightId);
+            applyLabel(fight, 'shortLabel', labels.shortLabel);
+            applyLabel(fight, 'fullLabel', labels.fullLabel);
+        });
+    });
     target.logIndex += 1;
     frame.boonBuckets.forEach((sourceBucket, boonId) => {
         let bucket = target.boonBuckets.get(boonId);

--- a/src/renderer/stats/computeCommanderStats.ts
+++ b/src/renderer/stats/computeCommanderStats.ts
@@ -6,6 +6,7 @@ import { resolveProfessionLabel } from './computePlayerAggregation';
 import { partitionSquadPlayers } from '../../shared/playerIdentity';
 import { buildNativeMovement } from '../../shared/movementData';
 import { squadEntities } from '@axiapps/bridge-metrics/nativeRoster';
+import { applyLabel, type FrameFightLabels } from './slice/frameLabels';
 
 const isBoon = (meta?: { classification?: string }) => {
     if (!meta?.classification) return true;
@@ -725,7 +726,19 @@ export function ingestLogCommanderStats(log: any, idx: number, commanders: Map<s
 export function mergeCommanderStatsInto(
     target: Map<string, CommanderEntry>,
     source: Map<string, CommanderEntry>,
+    labels: FrameFightLabels,
 ): void {
+    // `ingestLogCommanderStats` bakes the running log ordinal into every fight
+    // row's `id` / `shortLabel` / `fullLabel`, and `finalizeCommanderStats` only
+    // re-SORTS those rows — it never renumbers them. A frame is built by a solo
+    // aggregator, so restate them at the merge ordinal before folding.
+    source.forEach((incoming) => {
+        incoming.fightRows.forEach((row: any) => {
+            applyLabel(row, 'id', labels.fightId);
+            applyLabel(row, 'shortLabel', labels.shortLabel);
+            applyLabel(row, 'fullLabel', labels.fullLabelWithEncounter);
+        });
+    });
     source.forEach((incoming, account) => {
         const existing = target.get(account);
         if (!existing) {

--- a/src/renderer/stats/computeCommanderStats.ts
+++ b/src/renderer/stats/computeCommanderStats.ts
@@ -737,6 +737,11 @@ export function mergeCommanderStatsInto(
         }
 
         // identity strings -> first-wins
+        // key/account are defensive, not load-bearing: `existing` is only ever
+        // reached via `target.get(account)` above, so `existing.key` and
+        // `existing.account` are always already truthy (they equal the map
+        // key `account` itself). These two lines can't be exercised by any
+        // real call.
         if (!existing.key) existing.key = incoming.key;
         if (!existing.account) existing.account = incoming.account;
         if (!existing.primaryProfession || existing.primaryProfession === 'Unknown') {

--- a/src/renderer/stats/computeCommanderStats.ts
+++ b/src/renderer/stats/computeCommanderStats.ts
@@ -263,7 +263,7 @@ const collectIncomingBoonRows = (player: any, buffMap: Record<string, any>, dura
         .sort((a, b) => b.uptimePct - a.uptimePct || b.uptimeMs - a.uptimeMs || a.name.localeCompare(b.name));
 };
 
-type CommanderEntry = {
+export type CommanderEntry = {
     key: string;
     account: string;
     characterNames: Set<string>;
@@ -712,13 +712,99 @@ export function ingestLogCommanderStats(log: any, idx: number, commanders: Map<s
     });
 }
 
-export function computeCommanderStats(sortedFightLogsWithDetails: any[]) {
-const commanders = new Map<string, CommanderEntry>();
+/**
+ * Merge one fight's commander state into a running map.
+ *
+ * `ingestLogCommanderStats` only ever adds, so merging is addition: fight-row
+ * arrays concatenate, counters and durations sum, identity strings are
+ * first-wins, and the two per-skill/per-boon incoming maps fold entry-by-entry
+ * using the same rules `ingestLogCommanderStats` itself uses when a second
+ * fight touches the same skill/boon id. `finalizeCommanderStats` sorts fight
+ * rows by timestamp itself, so nothing here renumbers labels.
+ */
+export function mergeCommanderStatsInto(
+    target: Map<string, CommanderEntry>,
+    source: Map<string, CommanderEntry>,
+): void {
+    source.forEach((incoming, account) => {
+        const existing = target.get(account);
+        if (!existing) {
+            // CommanderEntry is plain data (no Infinity/-Infinity/NaN seeds,
+            // no functions), so structuredClone is safe here and also gives
+            // us real Map/Set clones instead of shallow references.
+            target.set(account, structuredClone(incoming));
+            return;
+        }
 
-sortedFightLogsWithDetails.forEach(({ log }, idx) => {
-    ingestLogCommanderStats(log, idx, commanders);
-});
+        // identity strings -> first-wins
+        if (!existing.key) existing.key = incoming.key;
+        if (!existing.account) existing.account = incoming.account;
+        if (!existing.primaryProfession || existing.primaryProfession === 'Unknown') {
+            existing.primaryProfession = incoming.primaryProfession;
+        }
 
+        // characterNames -> union
+        incoming.characterNames.forEach((name) => existing.characterNames.add(name));
+
+        // professionTimeMs -> sum per profession key
+        Object.entries(incoming.professionTimeMs).forEach(([profession, ms]) => {
+            existing.professionTimeMs[profession] = (existing.professionTimeMs[profession] || 0) + ms;
+        });
+
+        // counters / totals -> sum
+        existing.fights += incoming.fights;
+        existing.wins += incoming.wins;
+        existing.losses += incoming.losses;
+        existing.totalDurationMs += incoming.totalDurationMs;
+        existing.totalSquadCount += incoming.totalSquadCount;
+        existing.totalEnemyCount += incoming.totalEnemyCount;
+        existing.totalKills += incoming.totalKills;
+        existing.totalDowns += incoming.totalDowns;
+        existing.totalCommanderDowns += incoming.totalCommanderDowns;
+        existing.totalCommanderDeaths += incoming.totalCommanderDeaths;
+        existing.totalAlliesDown += incoming.totalAlliesDown;
+        existing.totalAlliesDead += incoming.totalAlliesDead;
+        existing.totalDamageTaken += incoming.totalDamageTaken;
+        existing.totalIncomingBarrierAbsorbed += incoming.totalIncomingBarrierAbsorbed;
+        existing.totalIncomingStrips += incoming.totalIncomingStrips;
+        existing.totalIncomingCC += incoming.totalIncomingCC;
+        existing.boonWeightedPctMs += incoming.boonWeightedPctMs;
+        existing.boonDurationMs += incoming.boonDurationMs;
+        existing.boonEntriesSeen += incoming.boonEntriesSeen;
+
+        // incomingSkillMap -> per-id fold, mirroring ingestLogCommanderStats
+        incoming.incomingSkillMap.forEach((skillRow, id) => {
+            const existingSkill = existing.incomingSkillMap.get(id);
+            if (!existingSkill) {
+                existing.incomingSkillMap.set(id, { ...skillRow });
+                return;
+            }
+            existingSkill.damage += skillRow.damage;
+            existingSkill.hits += skillRow.hits;
+            if (existingSkill.name.startsWith('Skill ') && !skillRow.name.startsWith('Skill ')) {
+                existingSkill.name = skillRow.name;
+            }
+            if (!existingSkill.icon && skillRow.icon) existingSkill.icon = skillRow.icon;
+        });
+
+        // incomingBoonMap -> per-id fold, mirroring ingestLogCommanderStats
+        incoming.incomingBoonMap.forEach((boonRow, id) => {
+            const existingBoon = existing.incomingBoonMap.get(id);
+            if (!existingBoon) {
+                existing.incomingBoonMap.set(id, { ...boonRow });
+                return;
+            }
+            existingBoon.uptimePctWeightedMs += boonRow.uptimePctWeightedMs;
+            existingBoon.durationMs += boonRow.durationMs;
+            if (!existingBoon.icon && boonRow.icon) existingBoon.icon = boonRow.icon;
+        });
+
+        // fightRows -> per-fight array, concatenate
+        existing.fightRows.push(...incoming.fightRows);
+    });
+}
+
+export function finalizeCommanderStats(commanders: Map<string, CommanderEntry>) {
 const rows = Array.from(commanders.values())
     .map((entry) => {
         const professions = Object.keys(entry.professionTimeMs)
@@ -829,4 +915,14 @@ const rows = Array.from(commanders.values())
 
 return { rows };
 
+}
+
+export function computeCommanderStats(sortedFightLogsWithDetails: any[]) {
+    const commanders = new Map<string, CommanderEntry>();
+
+    sortedFightLogsWithDetails.forEach(({ log }, idx) => {
+        ingestLogCommanderStats(log, idx, commanders);
+    });
+
+    return finalizeCommanderStats(commanders);
 }

--- a/src/renderer/stats/computeIncomingStrikeDamageData.ts
+++ b/src/renderer/stats/computeIncomingStrikeDamageData.ts
@@ -5,6 +5,7 @@ import {
 import { resolveFightTimestamp } from './utils/timestampUtils';
 import { buildFightLabelV2, computeFightAvgPosition } from './utils/labelUtils';
 import { resolveProfessionLabel } from './computePlayerAggregation';
+import { applyLabel, type FrameFightLabels } from './slice/frameLabels';
 
 /**
  * The enemy's own biggest strike, from `by_skill[].max`.
@@ -360,10 +361,22 @@ export function extractIncomingStrikeFrame(acc: IncomingStrikeDamageAccumulator)
     return { fight: acc.fights[0] };
 }
 
+
+/**
+ * `labels` re-states the ordinal-derived strings at the merge ordinal. A frame
+ * is always built by a solo aggregator, so `fight.id` / `shortLabel` are baked
+ * at ordinal 0 and `fullLabel` carries the `Fight 1` zone fallback whenever the
+ * log named no zone. They are rewritten BEFORE the player fold, so the fold's
+ * `peakFightLabel` picks up the corrected string for free.
+ */
 export function mergeIncomingStrikeFrame(
     target: IncomingStrikeDamageAccumulator,
     frame: IncomingStrikeFrame,
+    labels: FrameFightLabels,
 ): void {
+    applyLabel(frame.fight, 'id', labels.fightId);
+    applyLabel(frame.fight, 'shortLabel', labels.shortLabel);
+    applyLabel(frame.fight, 'fullLabel', labels.fullLabel);
     target.fightIndex += 1;
     target.fights.push(frame.fight);
     foldIncomingStrikeFightIntoPlayers(frame.fight, target.playerMap);

--- a/src/renderer/stats/computeIncomingStrikeDamageData.ts
+++ b/src/renderer/stats/computeIncomingStrikeDamageData.ts
@@ -158,6 +158,48 @@ export function createIncomingStrikeDamageAccumulator(): IncomingStrikeDamageAcc
     };
 }
 
+/**
+ * Fold one fight's per-profession values into the running player map. Shared by
+ * `ingestLogIncomingStrikeDamage` and `mergeIncomingStrikeFrame`. This map is
+ * keyed by profession, so the fight object already carries every identity field
+ * the fold needs - hence no seeds.
+ */
+export function foldIncomingStrikeFightIntoPlayers(
+    fight: IncomingStrikeFight,
+    playerMap: Map<string, IncomingStrikePlayer>,
+): void {
+    Object.entries(fight.values).forEach(([profession, value]) => {
+        const existing = playerMap.get(profession) || {
+            key: profession,
+            account: profession,
+            displayName: profession,
+            characterName: '',
+            profession,
+            professionList: [profession],
+            logs: 0,
+            peakHit: 0,
+            peak1s: 0,
+            peak5s: 0,
+            peak30s: 0,
+            totalDamage: 0,
+            peakFightLabel: '',
+            peakSkillName: ''
+        };
+        existing.totalDamage += Number(value.totalDamage || 0);
+        existing.logs += 1;
+        const hit = Number(value.hit || 0);
+        if (hit > existing.peakHit) {
+            existing.peakHit = hit;
+            existing.peakFightLabel = fight.fullLabel;
+            existing.peakSkillName = value.skillName || 'Unknown Skill';
+        }
+        if (value.burst1s > existing.peak1s) existing.peak1s = value.burst1s;
+        if (value.burst5s > existing.peak5s) existing.peak5s = value.burst5s;
+        if (value.burst30s > existing.peak30s) existing.peak30s = value.burst30s;
+        playerMap.set(profession, existing);
+    });
+}
+
 export function ingestLogIncomingStrikeDamage(log: any, acc: IncomingStrikeDamageAccumulator): void {
     const details = log?.details;
     if (!details) return;
@@ -268,34 +310,6 @@ export function ingestLogIncomingStrikeDamage(log: any, acc: IncomingStrikeDamag
                 .sort((a, b) => b.damage - a.damage)
                 .slice(0, 50)
         };
-
-        const existing = acc.playerMap.get(key) || {
-            key,
-            account: profession,
-            displayName: profession,
-            characterName: '',
-            profession,
-            professionList: [profession],
-            logs: 0,
-            peakHit: 0,
-            peak1s: 0,
-            peak5s: 0,
-            peak30s: 0,
-            totalDamage: 0,
-            peakFightLabel: '',
-            peakSkillName: ''
-        };
-        existing.totalDamage += totalDamage;
-        existing.logs += 1;
-        if (hit > existing.peakHit) {
-            existing.peakHit = hit;
-            existing.peakFightLabel = fullLabel;
-            existing.peakSkillName = entry.skillName || 'Unknown Skill';
-        }
-        if (burst1s > existing.peak1s) existing.peak1s = burst1s;
-        if (burst5s > existing.peak5s) existing.peak5s = burst5s;
-        if (burst30s > existing.peak30s) existing.peak30s = burst30s;
-        acc.playerMap.set(key, existing);
     });
 
     const maxHit = Object.values(values).reduce((best, value) => Math.max(best, Number(value?.hit || 0)), 0);
@@ -303,7 +317,7 @@ export function ingestLogIncomingStrikeDamage(log: any, acc: IncomingStrikeDamag
     const max5s = Object.values(values).reduce((best, value) => Math.max(best, Number(value?.burst5s || 0)), 0);
     const max30s = Object.values(values).reduce((best, value) => Math.max(best, Number(value?.burst30s || 0)), 0);
     const maxTotal = Object.values(values).reduce((best, value) => Math.max(best, Number(value?.totalDamage || 0)), 0);
-    acc.fights.push({
+    const fight: IncomingStrikeFight = {
         id: log.filePath || log.id || `fight-${index + 1}`,
         shortLabel: `F${index + 1}`,
         fullLabel,
@@ -314,7 +328,9 @@ export function ingestLogIncomingStrikeDamage(log: any, acc: IncomingStrikeDamag
         max5s,
         max30s,
         maxTotal
-    });
+    };
+    acc.fights.push(fight);
+    foldIncomingStrikeFightIntoPlayers(fight, acc.playerMap);
 }
 
 export function finalizeIncomingStrikeDamage(acc: IncomingStrikeDamageAccumulator): { fights: IncomingStrikeFight[]; players: IncomingStrikePlayer[] } {
@@ -331,6 +347,26 @@ export function finalizeIncomingStrikeDamage(acc: IncomingStrikeDamageAccumulato
         .map((fight, i) => ({ ...fight, shortLabel: `F${i + 1}` }));
 
     return { fights, players };
+}
+
+export interface IncomingStrikeFrame {
+    fight: IncomingStrikeFight;
+}
+
+export function extractIncomingStrikeFrame(acc: IncomingStrikeDamageAccumulator): IncomingStrikeFrame {
+    if (acc.fights.length !== 1) {
+        throw new Error(`extractIncomingStrikeFrame expects exactly one fight, got ${acc.fights.length}`);
+    }
+    return { fight: acc.fights[0] };
+}
+
+export function mergeIncomingStrikeFrame(
+    target: IncomingStrikeDamageAccumulator,
+    frame: IncomingStrikeFrame,
+): void {
+    target.fightIndex += 1;
+    target.fights.push(frame.fight);
+    foldIncomingStrikeFightIntoPlayers(frame.fight, target.playerMap);
 }
 
 export function computeIncomingStrikeDamageData(validLogs: any[]) {

--- a/src/renderer/stats/computeSkillUsageData.ts
+++ b/src/renderer/stats/computeSkillUsageData.ts
@@ -136,3 +136,66 @@ export const computeSkillUsageData = (validLogs: any[]): SkillUsageSummary => {
     for (const log of validLogs) ingestLogSkillUsage(log, acc);
     return finalizeSkillUsage(acc);
 };
+
+export interface SkillUsageFrame {
+    acc: SkillUsageAccumulator;
+}
+
+export function extractSkillUsageFrame(acc: SkillUsageAccumulator): SkillUsageFrame {
+    if (acc.logRecords.length !== 1) {
+        throw new Error(`extractSkillUsageFrame expects exactly one log, got ${acc.logRecords.length}`);
+    }
+    return { acc };
+}
+
+/**
+ * Merge one fight's skill usage into a running accumulator.
+ *
+ * Two metadata rules, and they are opposites — `skillNameMap` is `set`
+ * unconditionally during ingest, so the LAST log wins; the icon, auto-attack
+ * and proc maps are `has()`-guarded, so the FIRST log wins. Merging frames in
+ * fight order reproduces both.
+ */
+export function mergeSkillUsageFrame(target: SkillUsageAccumulator, frame: SkillUsageFrame): void {
+    const source = frame.acc;
+
+    source.skillTotals.forEach((total, sId) => {
+        target.skillTotals.set(sId, (target.skillTotals.get(sId) || 0) + total);
+    });
+
+    source.playerMap.forEach((sourcePlayer, key) => {
+        const existing = target.playerMap.get(key);
+        if (!existing) {
+            target.playerMap.set(key, {
+                ...sourcePlayer,
+                professionList: [...sourcePlayer.professionList],
+                skillTotals: { ...sourcePlayer.skillTotals },
+            });
+            return;
+        }
+        existing.logs += sourcePlayer.logs;
+        existing.totalActiveSeconds = (existing.totalActiveSeconds || 0) + (sourcePlayer.totalActiveSeconds || 0);
+        Object.entries(sourcePlayer.skillTotals).forEach(([sId, count]) => {
+            existing.skillTotals[sId] = (existing.skillTotals[sId] || 0) + count;
+        });
+        sourcePlayer.professionList.forEach((profession) => {
+            if (!existing.professionList.includes(profession)) existing.professionList.push(profession);
+        });
+    });
+
+    source.logRecords.forEach((record) => target.logRecords.push(record));
+
+    // Last-wins.
+    source.skillNameMap.forEach((name, sId) => target.skillNameMap.set(sId, name));
+
+    // First-wins.
+    source.skillIconMap.forEach((icon, sId) => {
+        if (!target.skillIconMap.has(sId)) target.skillIconMap.set(sId, icon);
+    });
+    source.skillAutoAttackMap.forEach((autoAttack, sId) => {
+        if (!target.skillAutoAttackMap.has(sId)) target.skillAutoAttackMap.set(sId, autoAttack);
+    });
+    source.skillProcMap.forEach((proc, sId) => {
+        if (!target.skillProcMap.has(sId)) target.skillProcMap.set(sId, proc);
+    });
+}

--- a/src/renderer/stats/computeSpikeDamageData.ts
+++ b/src/renderer/stats/computeSpikeDamageData.ts
@@ -5,6 +5,7 @@ import {
 } from '@axiapps/bridge-metrics';
 import { resolveFightTimestamp } from './utils/timestampUtils';
 import { buildFightLabelV2, computeFightAvgPosition } from './utils/labelUtils';
+import { applyLabel, type FrameFightLabels } from './slice/frameLabels';
 
 /**
  * Strike-damage skill rows for one entity, per-target first.
@@ -416,7 +417,18 @@ export function extractSpikeDamageFrame(acc: SpikeDamageAccumulator): SpikeDamag
     return { fight: acc.fights[0], seeds: acc.fightSeeds[0] || {} };
 }
 
-export function mergeSpikeDamageFrame(target: SpikeDamageAccumulator, frame: SpikeDamageFrame): void {
+
+/**
+ * `labels` re-states the ordinal-derived strings at the merge ordinal. A frame
+ * is always built by a solo aggregator, so `fight.id` / `shortLabel` are baked
+ * at ordinal 0 and `fullLabel` carries the `Fight 1` zone fallback whenever the
+ * log named no zone. They are rewritten BEFORE the player fold, so the fold's
+ * `peakFightLabel` picks up the corrected string for free.
+ */
+export function mergeSpikeDamageFrame(target: SpikeDamageAccumulator, frame: SpikeDamageFrame, labels: FrameFightLabels): void {
+    applyLabel(frame.fight, 'id', labels.fightId);
+    applyLabel(frame.fight, 'shortLabel', labels.shortLabel);
+    applyLabel(frame.fight, 'fullLabel', labels.fullLabel);
     target.fightIndex += 1;
     target.fights.push(frame.fight);
     target.fightSeeds.push(frame.seeds);

--- a/src/renderer/stats/computeSpikeDamageData.ts
+++ b/src/renderer/stats/computeSpikeDamageData.ts
@@ -192,11 +192,21 @@ export type SpikeDamagePlayer = {
     peakSkillName: string;
 };
 
+export interface SpikeDamagePlayerSeed {
+    account: string;
+    characterName: string;
+    profession: string;
+}
+
 export interface SpikeDamageAccumulator {
     fights: SpikeDamageFight[];
     playerMap: Map<string, SpikeDamagePlayer>;
     /** Running fight index counter. */
     fightIndex: number;
+    /** Per-fight player identity, parallel to `fights`. Not part of any
+     *  finalize output — this exists so a slice frame can re-run the player
+     *  fold without the original log. */
+    fightSeeds: Array<Record<string, SpikeDamagePlayerSeed>>;
 }
 
 export interface SpikeDamageIngestOptions {
@@ -208,7 +218,64 @@ export function createSpikeDamageAccumulator(): SpikeDamageAccumulator {
         fights: [],
         playerMap: new Map(),
         fightIndex: 0,
+        fightSeeds: [],
     };
+}
+
+/**
+ * Fold one fight's player values into the running player map.
+ *
+ * Shared by `ingestLogSpikeDamage` and `mergeSpikeDamageFrame` on purpose:
+ * one fold means slice-mode peaks cannot drift from all-fights peaks.
+ */
+export function foldSpikeFightIntoPlayers(
+    fight: SpikeDamageFight,
+    seeds: Record<string, SpikeDamagePlayerSeed>,
+    playerMap: Map<string, SpikeDamagePlayer>,
+): void {
+    Object.entries(fight.values).forEach(([key, value]) => {
+        const seed = seeds[key] || { account: key, characterName: '', profession: 'Unknown' };
+        const existing = playerMap.get(key) || {
+            key,
+            account: seed.account,
+            displayName: seed.account,
+            characterName: seed.characterName,
+            profession: seed.profession,
+            professionList: [seed.profession],
+            logs: 0,
+            peakHit: 0,
+            peak1s: 0,
+            peak5s: 0,
+            peak30s: 0,
+            peakHitDown: 0,
+            peak1sDown: 0,
+            peak5sDown: 0,
+            peak30sDown: 0,
+            peakFightLabel: '',
+            peakSkillName: '',
+        };
+        existing.logs += 1;
+        if (!existing.professionList.includes(seed.profession)) {
+            existing.professionList.push(seed.profession);
+        }
+        if (!existing.characterName && seed.characterName) {
+            existing.characterName = seed.characterName;
+        }
+        const hit = Number(value.hit || 0);
+        if (hit > existing.peakHit) {
+            existing.peakHit = hit;
+            existing.peakFightLabel = fight.fullLabel;
+            existing.peakSkillName = value.skillName || 'Unknown Skill';
+        }
+        if (value.burst1s > existing.peak1s) existing.peak1s = value.burst1s;
+        if (value.burst5s > existing.peak5s) existing.peak5s = value.burst5s;
+        if (value.burst30s > existing.peak30s) existing.peak30s = value.burst30s;
+        if (value.hitDown > existing.peakHitDown) existing.peakHitDown = value.hitDown;
+        if (value.burst1sDown > existing.peak1sDown) existing.peak1sDown = value.burst1sDown;
+        if (value.burst5sDown > existing.peak5sDown) existing.peak5sDown = value.burst5sDown;
+        if (value.burst30sDown > existing.peak30sDown) existing.peak30sDown = value.burst30sDown;
+        playerMap.set(key, existing);
+    });
 }
 
 export function ingestLogSpikeDamage(log: any, acc: SpikeDamageAccumulator, options: SpikeDamageIngestOptions = {}): void {
@@ -223,6 +290,7 @@ export function ingestLogSpikeDamage(log: any, acc: SpikeDamageAccumulator, opti
         avgPosition: computeFightAvgPosition(details),
     });
     const values: Record<string, SpikeDamageFightValue> = {};
+    const seeds: Record<string, SpikeDamagePlayerSeed> = {};
     const members = squadEntities(details?.native);
     members.forEach((entity) => {
         const account = String(entity?.account || entity?.character || 'Unknown');
@@ -289,46 +357,7 @@ export function ingestLogSpikeDamage(log: any, acc: SpikeDamageAccumulator, opti
             deathIndices5s: markerIndices(replay?.dead, bucketCount),
             skillRows
         };
-
-        const existing = acc.playerMap.get(key) || {
-            key,
-            account,
-            displayName: account,
-            characterName,
-            profession,
-            professionList: [profession],
-            logs: 0,
-            peakHit: 0,
-            peak1s: 0,
-            peak5s: 0,
-            peak30s: 0,
-            peakHitDown: 0,
-            peak1sDown: 0,
-            peak5sDown: 0,
-            peak30sDown: 0,
-            peakFightLabel: '',
-            peakSkillName: ''
-        };
-        existing.logs += 1;
-        if (!existing.professionList.includes(profession)) {
-            existing.professionList.push(profession);
-        }
-        if (!existing.characterName && characterName) {
-            existing.characterName = characterName;
-        }
-        if (hit > existing.peakHit) {
-            existing.peakHit = hit;
-            existing.peakFightLabel = fullLabel;
-            existing.peakSkillName = spike.skillName || 'Unknown Skill';
-        }
-        if (burst1s > existing.peak1s) existing.peak1s = burst1s;
-        if (burst5s > existing.peak5s) existing.peak5s = burst5s;
-        if (burst30s > existing.peak30s) existing.peak30s = burst30s;
-        if (hitDown > existing.peakHitDown) existing.peakHitDown = hitDown;
-        if (burst1sDown > existing.peak1sDown) existing.peak1sDown = burst1sDown;
-        if (burst5sDown > existing.peak5sDown) existing.peak5sDown = burst5sDown;
-        if (burst30sDown > existing.peak30sDown) existing.peak30sDown = burst30sDown;
-        acc.playerMap.set(key, existing);
+        seeds[key] = { account, characterName, profession };
     });
 
     const maxHit = Object.values(values).reduce((best, value) => Math.max(best, Number(value?.hit || 0)), 0);
@@ -339,7 +368,7 @@ export function ingestLogSpikeDamage(log: any, acc: SpikeDamageAccumulator, opti
     const max1sDown = Object.values(values).reduce((best, value) => Math.max(best, Number(value?.burst1sDown || 0)), 0);
     const max5sDown = Object.values(values).reduce((best, value) => Math.max(best, Number(value?.burst5sDown || 0)), 0);
     const max30sDown = Object.values(values).reduce((best, value) => Math.max(best, Number(value?.burst30sDown || 0)), 0);
-    acc.fights.push({
+    const fight: SpikeDamageFight = {
         id: log.filePath || log.id || `fight-${index + 1}`,
         shortLabel: `F${index + 1}`,
         fullLabel,
@@ -353,7 +382,10 @@ export function ingestLogSpikeDamage(log: any, acc: SpikeDamageAccumulator, opti
         max1sDown,
         max5sDown,
         max30sDown
-    });
+    };
+    acc.fights.push(fight);
+    acc.fightSeeds.push(seeds);
+    foldSpikeFightIntoPlayers(fight, seeds, acc.playerMap);
 }
 
 export function finalizeSpikeDamage(acc: SpikeDamageAccumulator): { fights: SpikeDamageFight[]; players: SpikeDamagePlayer[] } {
@@ -370,6 +402,25 @@ export function finalizeSpikeDamage(acc: SpikeDamageAccumulator): { fights: Spik
         .map((fight, i) => ({ ...fight, shortLabel: `F${i + 1}` }));
 
     return { fights, players };
+}
+
+export interface SpikeDamageFrame {
+    fight: SpikeDamageFight;
+    seeds: Record<string, SpikeDamagePlayerSeed>;
+}
+
+export function extractSpikeDamageFrame(acc: SpikeDamageAccumulator): SpikeDamageFrame {
+    if (acc.fights.length !== 1) {
+        throw new Error(`extractSpikeDamageFrame expects exactly one fight, got ${acc.fights.length}`);
+    }
+    return { fight: acc.fights[0], seeds: acc.fightSeeds[0] || {} };
+}
+
+export function mergeSpikeDamageFrame(target: SpikeDamageAccumulator, frame: SpikeDamageFrame): void {
+    target.fightIndex += 1;
+    target.fights.push(frame.fight);
+    target.fightSeeds.push(frame.seeds);
+    foldSpikeFightIntoPlayers(frame.fight, frame.seeds, target.playerMap);
 }
 
 export function computeSpikeDamageData(validLogs: any[], splitPlayersByClass = false) {

--- a/src/renderer/stats/computeStabPerformance.ts
+++ b/src/renderer/stats/computeStabPerformance.ts
@@ -232,3 +232,26 @@ export function ingestLogStabPerformance(log: any, acc: StabPerfAccumulator): vo
 export function finalizeStabPerformance(acc: StabPerfAccumulator): { fights: StabPerfFightData[] } {
     return { fights: acc.fights };
 }
+
+/**
+ * Slice frame for the stab-performance accumulator.
+ *
+ * The accumulator is nothing but a per-fight array (`{ fights: [] }`) and
+ * `finalizeStabPerformance` returns it unchanged, so a frame is one fight's
+ * entry and merging is concatenation — no re-weighting, no renumbering.
+ */
+export interface StabPerformanceFrame {
+    fights: StabPerfFightData[];
+}
+
+export function extractStabPerformanceFrame(acc: StabPerfAccumulator): StabPerformanceFrame {
+    if (acc.fights.length > 1) {
+        throw new Error(`extractStabPerformanceFrame expects at most one fight, got ${acc.fights.length}`);
+    }
+    return { fights: acc.fights };
+}
+
+/** The accumulator is a bare per-fight array, so merging is concatenation. */
+export function mergeStabPerformanceFrame(target: StabPerfAccumulator, frame: StabPerformanceFrame): void {
+    (frame?.fights || []).forEach((fight) => target.fights.push(fight));
+}

--- a/src/renderer/stats/computeStripSpikesData.ts
+++ b/src/renderer/stats/computeStripSpikesData.ts
@@ -40,11 +40,20 @@ export type StripSpikesData = {
     players: StripPlayer[];
 };
 
+export interface StripSpikesPlayerSeed {
+    account: string;
+    characterName: string;
+    profession: string;
+}
+
 export interface StripSpikesAccumulator {
     fights: StripFight[];
     playerMap: Map<string, StripPlayer>;
     /** Running fight index counter (incremented per ingested log with details). */
     fightIndex: number;
+    /** Per-fight player identity, parallel to `fights`. Slice frames only —
+     *  never part of any finalize output. */
+    fightSeeds: Array<Record<string, StripSpikesPlayerSeed>>;
 }
 
 export function createStripSpikesAccumulator(): StripSpikesAccumulator {
@@ -52,11 +61,61 @@ export function createStripSpikesAccumulator(): StripSpikesAccumulator {
         fights: [],
         playerMap: new Map(),
         fightIndex: 0,
+        fightSeeds: [],
     };
 }
 
 export interface StripSpikesIngestOptions {
     splitPlayersByClass?: boolean;
+}
+
+/**
+ * Fold one fight's strip values into the running player map. Shared by
+ * `ingestLogStripSpikes` and `mergeStripSpikesFrame` so slice-mode totals
+ * cannot drift from all-fights totals.
+ */
+export function foldStripFightIntoPlayers(
+    fight: StripFight,
+    seeds: Record<string, StripSpikesPlayerSeed>,
+    playerMap: Map<string, StripPlayer>,
+): void {
+    Object.entries(fight.values).forEach(([key, value]) => {
+        const seed = seeds[key] || { account: key, characterName: '', profession: 'Unknown' };
+        const { strips, stripTime, stripDownContrib } = value;
+        const existing = playerMap.get(key);
+        if (existing) {
+            existing.logs += 1;
+            existing.totalStrips += strips;
+            existing.totalStripTime += stripTime;
+            existing.totalStripDownContrib += stripDownContrib;
+            if (!existing.professionList.includes(seed.profession)) {
+                existing.professionList.push(seed.profession);
+            }
+            if (strips > existing.peakStrips) {
+                existing.peakStrips = strips;
+                existing.peakFightLabel = fight.fullLabel;
+            }
+            if (stripTime > existing.peakStripTime) existing.peakStripTime = stripTime;
+            if (stripDownContrib > existing.peakStripDownContrib) existing.peakStripDownContrib = stripDownContrib;
+        } else {
+            playerMap.set(key, {
+                key,
+                account: seed.account,
+                displayName: seed.account,
+                characterName: seed.characterName,
+                profession: seed.profession,
+                professionList: [seed.profession],
+                logs: 1,
+                totalStrips: strips,
+                totalStripTime: stripTime,
+                totalStripDownContrib: stripDownContrib,
+                peakStrips: strips,
+                peakStripTime: stripTime,
+                peakStripDownContrib: stripDownContrib,
+                peakFightLabel: fight.fullLabel,
+            });
+        }
+    });
 }
 
 export function ingestLogStripSpikes(log: any, acc: StripSpikesAccumulator, options: StripSpikesIngestOptions = {}): void {
@@ -75,6 +134,7 @@ export function ingestLogStripSpikes(log: any, acc: StripSpikesAccumulator, opti
     const timestamp = resolveFightTimestamp(details, log);
 
     const values: Record<string, StripFightValue> = {};
+    const seeds: Record<string, StripSpikesPlayerSeed> = {};
     let maxStrips = 0;
     let maxStripTime = 0;
     let maxStripDownContrib = 0;
@@ -93,47 +153,14 @@ export function ingestLogStripSpikes(log: any, acc: StripSpikesAccumulator, opti
         const stripDownContrib = Number(support?.boonStripDownContribution || 0);
 
         values[key] = { strips, stripTime, stripDownContrib };
+        seeds[key] = { account, characterName, profession };
 
         if (strips > maxStrips) maxStrips = strips;
         if (stripTime > maxStripTime) maxStripTime = stripTime;
         if (stripDownContrib > maxStripDownContrib) maxStripDownContrib = stripDownContrib;
-
-        const existing = acc.playerMap.get(key);
-        if (existing) {
-            existing.logs += 1;
-            existing.totalStrips += strips;
-            existing.totalStripTime += stripTime;
-            existing.totalStripDownContrib += stripDownContrib;
-            if (!existing.professionList.includes(profession)) {
-                existing.professionList.push(profession);
-            }
-            if (strips > existing.peakStrips) {
-                existing.peakStrips = strips;
-                existing.peakFightLabel = fullLabel;
-            }
-            if (stripTime > existing.peakStripTime) existing.peakStripTime = stripTime;
-            if (stripDownContrib > existing.peakStripDownContrib) existing.peakStripDownContrib = stripDownContrib;
-        } else {
-            acc.playerMap.set(key, {
-                key,
-                account,
-                displayName: account,
-                characterName,
-                profession,
-                professionList: [profession],
-                logs: 1,
-                totalStrips: strips,
-                totalStripTime: stripTime,
-                totalStripDownContrib: stripDownContrib,
-                peakStrips: strips,
-                peakStripTime: stripTime,
-                peakStripDownContrib: stripDownContrib,
-                peakFightLabel: fullLabel,
-            });
-        }
     });
 
-    acc.fights.push({
+    const fight: StripFight = {
         id: fightId,
         shortLabel,
         fullLabel,
@@ -142,7 +169,10 @@ export function ingestLogStripSpikes(log: any, acc: StripSpikesAccumulator, opti
         maxStrips,
         maxStripTime,
         maxStripDownContrib,
-    });
+    };
+    acc.fights.push(fight);
+    acc.fightSeeds.push(seeds);
+    foldStripFightIntoPlayers(fight, seeds, acc.playerMap);
 }
 
 export function finalizeStripSpikes(acc: StripSpikesAccumulator): StripSpikesData {
@@ -160,6 +190,25 @@ export function finalizeStripSpikes(acc: StripSpikesAccumulator): StripSpikesDat
         .map((fight, i) => ({ ...fight, shortLabel: `F${i + 1}` }));
 
     return { fights, players };
+}
+
+export interface StripSpikesFrame {
+    fight: StripFight;
+    seeds: Record<string, StripSpikesPlayerSeed>;
+}
+
+export function extractStripSpikesFrame(acc: StripSpikesAccumulator): StripSpikesFrame {
+    if (acc.fights.length !== 1) {
+        throw new Error(`extractStripSpikesFrame expects exactly one fight, got ${acc.fights.length}`);
+    }
+    return { fight: acc.fights[0], seeds: acc.fightSeeds[0] || {} };
+}
+
+export function mergeStripSpikesFrame(target: StripSpikesAccumulator, frame: StripSpikesFrame): void {
+    target.fightIndex += 1;
+    target.fights.push(frame.fight);
+    target.fightSeeds.push(frame.seeds);
+    foldStripFightIntoPlayers(frame.fight, frame.seeds, target.playerMap);
 }
 
 export function computeStripSpikesData(validLogs: any[], splitPlayersByClass = false): StripSpikesData {

--- a/src/renderer/stats/computeStripSpikesData.ts
+++ b/src/renderer/stats/computeStripSpikesData.ts
@@ -1,5 +1,6 @@
 import { buildFightLabelV2, computeFightAvgPosition } from './utils/labelUtils';
 import { resolveFightTimestamp } from './utils/timestampUtils';
+import { applyLabel, type FrameFightLabels } from './slice/frameLabels';
 
 export type StripFightValue = {
     strips: number;
@@ -204,7 +205,18 @@ export function extractStripSpikesFrame(acc: StripSpikesAccumulator): StripSpike
     return { fight: acc.fights[0], seeds: acc.fightSeeds[0] || {} };
 }
 
-export function mergeStripSpikesFrame(target: StripSpikesAccumulator, frame: StripSpikesFrame): void {
+
+/**
+ * `labels` re-states the ordinal-derived strings at the merge ordinal. A frame
+ * is always built by a solo aggregator, so `fight.id` / `shortLabel` are baked
+ * at ordinal 0 and `fullLabel` carries the `Fight 1` zone fallback whenever the
+ * log named no zone. They are rewritten BEFORE the player fold, so the fold's
+ * `peakFightLabel` picks up the corrected string for free.
+ */
+export function mergeStripSpikesFrame(target: StripSpikesAccumulator, frame: StripSpikesFrame, labels: FrameFightLabels): void {
+    applyLabel(frame.fight, 'id', labels.fightId);
+    applyLabel(frame.fight, 'shortLabel', labels.shortLabel);
+    applyLabel(frame.fight, 'fullLabel', labels.fullLabel);
     target.fightIndex += 1;
     target.fights.push(frame.fight);
     target.fightSeeds.push(frame.seeds);

--- a/src/renderer/stats/hooks/__tests__/useStatsUploads.byteIdentity.test.ts
+++ b/src/renderer/stats/hooks/__tests__/useStatsUploads.byteIdentity.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Task 15 review round 2, finding 1: `buildReportStats` attached
+ * `mvpWeights`/`disruptionMethod` to the published `stats` UNCONDITIONALLY,
+ * so every no-R2 publish wrote two extra keys into `report.json` — a
+ * regression against the spec-level guarantee "with no R2 the report
+ * publishes byte-for-byte as it does today." The reviewer's probe on the
+ * regressed commit:
+ *
+ *   31fcf656  keys=[foo,skillUsageData,statsViewSettings,mvpWeights,disruptionMethod,fightDiffMode] bytes=3440
+ *   f6726445  keys=[foo,skillUsageData,statsViewSettings,fightDiffMode]                             bytes=3369
+ *
+ * Ruling R15-5: attach the settings pair to `uploadStats` ONLY when R2 is
+ * confirmed configured (the only case a sidecar — and therefore a viewer
+ * that needs to reproduce the hash — exists at all). This is a permanent
+ * regression test for that: it must FAIL if the fields ever leak back onto
+ * the no-R2 path, and its positive control proves it isn't just vacuously
+ * passing (R2-configured publishes DO carry them, and DO cost more bytes).
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useStatsUploads } from '../useStatsUploads';
+import { useStatsStore } from '../../statsStore';
+
+const LOG = { id: 'log-0', filePath: 'test-0.zevtc', permalink: 'https://dps.report/x' };
+const ROSTER = [{ id: 'test-0.zevtc', label: 'Fight 1', timestamp: 1, duration: '1:00' }];
+
+const BASE_STATS = { foo: 'bar', fightDiffMode: [{ a: 1 }] };
+const MVP_WEIGHTS = { damage: 0.4, cleanses: 0.3, strips: 0.3 };
+const DISRUPTION_METHOD = 'strips-and-interrupts';
+
+describe('useStatsUploads: byte-identical-without-R2 (settings-triple bloat)', () => {
+    let originalElectronAPI: any;
+
+    beforeEach(() => {
+        useStatsStore.setState(useStatsStore.getInitialState());
+        useStatsStore.setState({ fightRoster: ROSTER });
+        originalElectronAPI = (window as any).electronAPI;
+    });
+
+    afterEach(() => {
+        (window as any).electronAPI = originalElectronAPI;
+    });
+
+    const publish = async (configured: boolean | undefined) => {
+        (window as any).electronAPI = {
+            ...originalElectronAPI,
+            ...(configured === undefined ? {} : { isR2Configured: async () => ({ configured }) }),
+        };
+        const onWebUpload = vi.fn();
+        const { result } = renderHook(() => useStatsUploads({
+            logs: [LOG],
+            stats: BASE_STATS,
+            skillUsageData: {},
+            activeStatsViewSettings: {},
+            mvpWeights: MVP_WEIGHTS,
+            disruptionMethod: DISRUPTION_METHOD,
+            embedded: false,
+            onWebUpload,
+        }));
+        await act(async () => {
+            await result.current.handleWebUpload();
+        });
+        expect(onWebUpload).toHaveBeenCalledTimes(1);
+        return onWebUpload.mock.calls[0][0];
+    };
+
+    it('no R2 configured: published stats carries no settings-triple bloat', async () => {
+        const payload = await publish(false);
+        const keys = Object.keys(payload.stats).sort();
+        const bytes = JSON.stringify(payload.stats).length;
+        console.info(`[byte-probe] no-R2   keys=[${keys.join(',')}] bytes=${bytes}`);
+
+        expect(keys).not.toContain('mvpWeights');
+        expect(keys).not.toContain('disruptionMethod');
+        // Exactly what the report would have carried before this feature
+        // ever existed (skillUsageData/statsViewSettings were already always
+        // added by `buildReportStats`; those two are the ones under test).
+        expect(keys).toEqual(['fightDiffMode', 'foo', 'skillUsageData', 'statsViewSettings']);
+    });
+
+    it('positive control — R2 configured: published stats DOES carry the settings triple, and costs more bytes', async () => {
+        const noR2Payload = await publish(false);
+        const r2Payload = await publish(true);
+
+        const noR2Keys = Object.keys(noR2Payload.stats).sort();
+        const r2Keys = Object.keys(r2Payload.stats).sort();
+        const noR2Bytes = JSON.stringify(noR2Payload.stats).length;
+        const r2Bytes = JSON.stringify(r2Payload.stats).length;
+        console.info(`[byte-probe] no-R2   keys=[${noR2Keys.join(',')}] bytes=${noR2Bytes}`);
+        console.info(`[byte-probe] R2      keys=[${r2Keys.join(',')}] bytes=${r2Bytes}`);
+
+        expect(r2Keys).toContain('mvpWeights');
+        expect(r2Keys).toContain('disruptionMethod');
+        expect(r2Payload.stats.mvpWeights).toEqual(MVP_WEIGHTS);
+        expect(r2Payload.stats.disruptionMethod).toBe(DISRUPTION_METHOD);
+        // Proves the probe can actually see a difference, not passing vacuously.
+        expect(r2Bytes).toBeGreaterThan(noR2Bytes);
+    });
+});

--- a/src/renderer/stats/hooks/__tests__/useStatsUploads.settingsHash.test.ts
+++ b/src/renderer/stats/hooks/__tests__/useStatsUploads.settingsHash.test.ts
@@ -13,6 +13,22 @@
  * `payload.stats` — it must agree with `payload.sliceSidecar.settingsHash`.
  * A second case proves the hash actually discriminates: sidecar built under
  * different settings than the payload records must NOT agree.
+ *
+ * Round 2 re-review closed two blind spots in the original version of this
+ * test:
+ *   1. It read `payload.stats` directly (an in-memory JS object with live
+ *      references), never through JSON — but the real transport is
+ *      `JSON.stringify` in main and `JSON.parse` in the browser. A value
+ *      that hashed fine in memory (e.g. a `Map`/`Set`, `undefined` vs
+ *      absent-key, `NaN`) could silently change shape on the wire and never
+ *      be caught. Now round-tripped through `JSON.parse(JSON.stringify(...))`
+ *      before hashing.
+ *   2. Nothing pinned which keys of `payload.stats` the "viewer" reads —
+ *      a silent rename of `mvpWeights`/`statsViewSettings`/`disruptionMethod`
+ *      would just read `undefined` off the wrong key and the hash would
+ *      still "agree" (both sides independently wrong), passing for the
+ *      wrong reason. `VIEWER_SETTINGS_KEYS` below is a literal, asserted
+ *      list — see `hasOwnProperty` checks — so a rename fails loudly.
  */
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { readFileSync } from 'node:fs';
@@ -39,6 +55,12 @@ const ROSTER = [{
 const MVP_WEIGHTS = { damage: 0.4, cleanses: 0.3, strips: 0.3 };
 const DISRUPTION_METHOD = 'strips-and-interrupts';
 
+/** The exact `report.stats` keys a viewer must read to reproduce the
+ *  publisher's settingsHash (task-18-brief.md, amended round 2). Pinned as a
+ *  literal tuple, in `hashSliceSettings`'s argument order, so a rename on
+ *  either the publish or the (future, task-18) read side fails this test. */
+const VIEWER_SETTINGS_KEYS = ['mvpWeights', 'statsViewSettings', 'disruptionMethod'] as const;
+
 describe('useStatsUploads: publish-time slice settings hash', () => {
     let originalElectronAPI: any;
 
@@ -56,7 +78,7 @@ describe('useStatsUploads: publish-time slice settings hash', () => {
         (window as any).electronAPI = originalElectronAPI;
     });
 
-    it('agrees with a simulated viewer hash of the published payload', async () => {
+    it('agrees with a simulated viewer hash of the JSON-round-tripped published payload', async () => {
         const onWebUpload = vi.fn();
         const { result } = renderHook(() => useStatsUploads({
             logs: [LOG],
@@ -77,15 +99,29 @@ describe('useStatsUploads: publish-time slice settings hash', () => {
         const payload = onWebUpload.mock.calls[0][0];
         expect(payload.sliceSidecar).toBeTruthy();
 
+        // The real transport: main JSON.stringifies the payload, the browser
+        // JSON.parses it. Hash from that round-tripped copy, not the
+        // in-memory object, so this test can only pass if the settings
+        // actually survive the wire.
+        const wireStats = JSON.parse(JSON.stringify(payload.stats));
+
+        // Pin the exact keys a viewer must read — a rename of any of these
+        // in `buildReportStats`/`runWebUpload` without a matching update on
+        // the read side must fail HERE, loudly, rather than as a silent
+        // `undefined`-vs-`undefined` false agreement below.
+        for (const key of VIEWER_SETTINGS_KEYS) {
+            expect(Object.prototype.hasOwnProperty.call(wireStats, key)).toBe(true);
+        }
+
         // Simulate the viewer: it has no settings of its own in slice mode, so
         // it hashes exactly what the report payload carries.
         const viewerHash = hashSliceSettings(
-            payload.stats.mvpWeights,
-            payload.stats.statsViewSettings,
-            payload.stats.disruptionMethod,
+            wireStats[VIEWER_SETTINGS_KEYS[0]],
+            wireStats[VIEWER_SETTINGS_KEYS[1]],
+            wireStats[VIEWER_SETTINGS_KEYS[2]],
         );
-        expect(payload.stats.mvpWeights).toEqual(MVP_WEIGHTS);
-        expect(payload.stats.disruptionMethod).toBe(DISRUPTION_METHOD);
+        expect(wireStats.mvpWeights).toEqual(MVP_WEIGHTS);
+        expect(wireStats.disruptionMethod).toBe(DISRUPTION_METHOD);
         expect(viewerHash).toBe(payload.sliceSidecar.settingsHash);
     });
 

--- a/src/renderer/stats/hooks/__tests__/useStatsUploads.settingsHash.test.ts
+++ b/src/renderer/stats/hooks/__tests__/useStatsUploads.settingsHash.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Task 15 review round 1, finding 1 (Critical): the publisher hashed its
+ * *live* `mvpWeights`/`disruptionMethod` while the viewer (per the task-18
+ * spec) would hash whatever the published report carries — which, before
+ * this fix, was nothing for either field. `SliceSettingsMismatchError` fired
+ * on every real report and the slicer never ran.
+ *
+ * Ruling R15-2: carry the settings triple (`mvpWeights`, `statsViewSettings`,
+ * `disruptionMethod`) in the published payload, and have `buildSliceSidecar`
+ * hash from exactly those payload-carried values (not from the raw hook
+ * props). This pins that invariant end to end: render the real hook, capture
+ * the real `onWebUpload` payload, and hash a simulated viewer read of
+ * `payload.stats` — it must agree with `payload.sliceSidecar.settingsHash`.
+ * A second case proves the hash actually discriminates: sidecar built under
+ * different settings than the payload records must NOT agree.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { renderHook, act } from '@testing-library/react';
+import { useStatsUploads } from '../useStatsUploads';
+import { useStatsStore } from '../../statsStore';
+import { statsLogKey } from '../../utils/statsLogKey';
+import { hashSliceSettings } from '../../slice/sliceSettingsHash';
+import { buildSliceSidecar } from '../../slice/buildSliceSidecar';
+
+const fixtureDetails = JSON.parse(
+    readFileSync(resolve(process.cwd(), 'test-fixtures/native/20260117-175120.json'), 'utf8'),
+);
+
+const LOG = { id: 'log-0', filePath: 'test-0.zevtc', details: fixtureDetails };
+const ROSTER = [{
+    id: statsLogKey(LOG, 0),
+    label: 'Fight 1',
+    timestamp: 1,
+    duration: '1:00',
+}];
+
+const MVP_WEIGHTS = { damage: 0.4, cleanses: 0.3, strips: 0.3 };
+const DISRUPTION_METHOD = 'strips-and-interrupts';
+
+describe('useStatsUploads: publish-time slice settings hash', () => {
+    let originalElectronAPI: any;
+
+    beforeEach(() => {
+        useStatsStore.setState(useStatsStore.getInitialState());
+        useStatsStore.setState({ fightRoster: ROSTER });
+        originalElectronAPI = (window as any).electronAPI;
+        (window as any).electronAPI = {
+            ...originalElectronAPI,
+            isR2Configured: async () => ({ configured: true }),
+        };
+    });
+
+    afterEach(() => {
+        (window as any).electronAPI = originalElectronAPI;
+    });
+
+    it('agrees with a simulated viewer hash of the published payload', async () => {
+        const onWebUpload = vi.fn();
+        const { result } = renderHook(() => useStatsUploads({
+            logs: [LOG],
+            stats: {},
+            skillUsageData: {},
+            activeStatsViewSettings: { someSetting: true },
+            mvpWeights: MVP_WEIGHTS,
+            disruptionMethod: DISRUPTION_METHOD,
+            embedded: false,
+            onWebUpload,
+        }));
+
+        await act(async () => {
+            await result.current.handleWebUpload();
+        });
+
+        expect(onWebUpload).toHaveBeenCalledTimes(1);
+        const payload = onWebUpload.mock.calls[0][0];
+        expect(payload.sliceSidecar).toBeTruthy();
+
+        // Simulate the viewer: it has no settings of its own in slice mode, so
+        // it hashes exactly what the report payload carries.
+        const viewerHash = hashSliceSettings(
+            payload.stats.mvpWeights,
+            payload.stats.statsViewSettings,
+            payload.stats.disruptionMethod,
+        );
+        expect(payload.stats.mvpWeights).toEqual(MVP_WEIGHTS);
+        expect(payload.stats.disruptionMethod).toBe(DISRUPTION_METHOD);
+        expect(viewerHash).toBe(payload.sliceSidecar.settingsHash);
+    });
+
+    it('does NOT agree when the sidecar was built under different settings than the payload records', () => {
+        const publishedHash = hashSliceSettings(MVP_WEIGHTS, { someSetting: true }, DISRUPTION_METHOD);
+
+        const staleSidecar = buildSliceSidecar({
+            logs: [LOG],
+            roster: ROSTER,
+            mvpWeights: MVP_WEIGHTS,
+            statsViewSettings: { someSetting: false }, // drifted from what was published
+            disruptionMethod: DISRUPTION_METHOD,
+        });
+
+        expect(staleSidecar.settingsHash).not.toBe(publishedHash);
+    });
+});
+

--- a/src/renderer/stats/hooks/__tests__/useStatsUploads.sliceGating.test.ts
+++ b/src/renderer/stats/hooks/__tests__/useStatsUploads.sliceGating.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Task 15 review round 1, ruling R15-3: the slice sidecar build (not just its
+ * gzip) must be gated on an R2-configured check queried over IPC. Building
+ * it unconditionally means a fresh per-fight aggregation pass plus a
+ * multi-MB structured clone over `upload-web-report` on every single
+ * publish, even when the sidecar is provably going to be dropped in main
+ * (`planSidecarHosting` never falls back to Pages for `kind: 'slice'`).
+ *
+ * This pins: no R2 configured (or the check unavailable) → no `sliceSidecar`
+ * key in the `onWebUpload` payload at all. R2 configured → it's present.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { renderHook, act } from '@testing-library/react';
+import { useStatsUploads } from '../useStatsUploads';
+import { useStatsStore } from '../../statsStore';
+import { statsLogKey } from '../../utils/statsLogKey';
+
+const fixtureDetails = JSON.parse(
+    readFileSync(resolve(process.cwd(), 'test-fixtures/native/20260117-175120.json'), 'utf8'),
+);
+
+const LOG = { id: 'log-0', filePath: 'test-0.zevtc', details: fixtureDetails };
+const ROSTER = [{
+    id: statsLogKey(LOG, 0),
+    label: 'Fight 1',
+    timestamp: 1,
+    duration: '1:00',
+}];
+
+describe('useStatsUploads: R2-gated slice sidecar build', () => {
+    let originalElectronAPI: any;
+
+    beforeEach(() => {
+        useStatsStore.setState(useStatsStore.getInitialState());
+        useStatsStore.setState({ fightRoster: ROSTER });
+        originalElectronAPI = (window as any).electronAPI;
+    });
+
+    afterEach(() => {
+        (window as any).electronAPI = originalElectronAPI;
+    });
+
+    const publish = async () => {
+        const onWebUpload = vi.fn();
+        const { result } = renderHook(() => useStatsUploads({
+            logs: [LOG],
+            stats: {},
+            skillUsageData: {},
+            activeStatsViewSettings: {},
+            embedded: false,
+            onWebUpload,
+        }));
+        await act(async () => {
+            await result.current.handleWebUpload();
+        });
+        expect(onWebUpload).toHaveBeenCalledTimes(1);
+        return onWebUpload.mock.calls[0][0];
+    };
+
+    it('omits sliceSidecar when R2 is not configured', async () => {
+        (window as any).electronAPI = {
+            ...originalElectronAPI,
+            isR2Configured: async () => ({ configured: false }),
+        };
+        const payload = await publish();
+        expect(payload.sliceSidecar).toBeUndefined();
+    });
+
+    it('omits sliceSidecar when the R2-configured check is unavailable (older preload)', async () => {
+        (window as any).electronAPI = { ...originalElectronAPI };
+        delete (window as any).electronAPI.isR2Configured;
+        const payload = await publish();
+        expect(payload.sliceSidecar).toBeUndefined();
+    });
+
+    it('includes sliceSidecar when R2 is configured', async () => {
+        (window as any).electronAPI = {
+            ...originalElectronAPI,
+            isR2Configured: async () => ({ configured: true }),
+        };
+        const payload = await publish();
+        expect(payload.sliceSidecar).toBeTruthy();
+        expect(payload.sliceSidecar.frames.length).toBe(1);
+    });
+});

--- a/src/renderer/stats/hooks/__tests__/useStatsUploads.sliceRobustness.test.ts
+++ b/src/renderer/stats/hooks/__tests__/useStatsUploads.sliceRobustness.test.ts
@@ -1,0 +1,113 @@
+/**
+ * Task 15 review round 1.
+ *
+ * Finding 2 (Important): a log with no resolvable details (evicted from the
+ * details cache, or never loaded) must be EXCLUDED from the sidecar, not
+ * silently aggregated into an all-zero frame — the worst failure mode is
+ * wrong numbers with no error, not a missing fight.
+ *
+ * Finding 3 (Important): a throw while building the sidecar must degrade to
+ * publishing without a slicer, not abort the whole publish. "The report
+ * publishes exactly as today" must hold in the failure case too, not just
+ * the no-R2 case.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { renderHook, act } from '@testing-library/react';
+import { useStatsUploads } from '../useStatsUploads';
+import { useStatsStore } from '../../statsStore';
+import { statsLogKey } from '../../utils/statsLogKey';
+
+const fixtureDetails = JSON.parse(
+    readFileSync(resolve(process.cwd(), 'test-fixtures/native/20260117-175120.json'), 'utf8'),
+);
+
+const GOOD_LOG = { id: 'log-0', filePath: 'test-0.zevtc', details: fixtureDetails };
+// Simulates an evicted-from-cache log: no `.details`, and (with no
+// DetailsCacheContext provider in this test) nothing else to fall back to.
+const EVICTED_LOG = { id: 'log-1', filePath: 'test-1.zevtc', details: null };
+
+const ROSTER = [GOOD_LOG, EVICTED_LOG].map((log, i) => ({
+    id: statsLogKey(log, i),
+    label: `Fight ${i + 1}`,
+    timestamp: i + 1,
+    duration: '1:00',
+}));
+
+describe('useStatsUploads: slice sidecar robustness', () => {
+    let originalElectronAPI: any;
+    let warnSpy: ReturnType<typeof vi.spyOn>;
+
+    beforeEach(() => {
+        useStatsStore.setState(useStatsStore.getInitialState());
+        useStatsStore.setState({ fightRoster: ROSTER });
+        originalElectronAPI = (window as any).electronAPI;
+        (window as any).electronAPI = {
+            ...originalElectronAPI,
+            isR2Configured: async () => ({ configured: true }),
+        };
+        warnSpy = vi.spyOn(console, 'warn');
+    });
+
+    afterEach(() => {
+        (window as any).electronAPI = originalElectronAPI;
+        warnSpy.mockRestore();
+    });
+
+    it('excludes an evicted log from the sidecar instead of zero-filling it, and warns', async () => {
+        const onWebUpload = vi.fn();
+        const { result } = renderHook(() => useStatsUploads({
+            logs: [GOOD_LOG, EVICTED_LOG],
+            stats: {},
+            skillUsageData: {},
+            activeStatsViewSettings: {},
+            embedded: false,
+            onWebUpload,
+        }));
+
+        await act(async () => {
+            await result.current.handleWebUpload();
+        });
+
+        const payload = onWebUpload.mock.calls[0][0];
+        expect(payload.sliceSidecar.frames.length).toBe(1);
+        expect(payload.sliceSidecar.fights.length).toBe(1);
+        expect(payload.sliceSidecar.fights[0].id).toBe(statsLogKey(GOOD_LOG, 0));
+        expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('1 log(s)'));
+    });
+
+    it('publishes without a slicer (not aborted) when the sidecar build throws', async () => {
+        const onWebUpload = vi.fn();
+        // A roster entry whose `id` is not a string breaks `Map.get` matching
+        // inside `buildSliceSidecar` in a way that still returns undefined
+        // rather than throwing — so to force an actual throw we hand the
+        // hook a fightRoster that is not an array, which `buildSliceSidecar`
+        // (and `mergeFightRoster`) never defends against, since the store
+        // always sets it to an array.
+        useStatsStore.setState({ fightRoster: null as any });
+
+        const { result } = renderHook(() => useStatsUploads({
+            logs: [GOOD_LOG],
+            stats: {},
+            skillUsageData: {},
+            activeStatsViewSettings: {},
+            embedded: false,
+            onWebUpload,
+        }));
+
+        await act(async () => {
+            await result.current.handleWebUpload();
+        });
+
+        // The publish must still go through...
+        expect(onWebUpload).toHaveBeenCalledTimes(1);
+        const payload = onWebUpload.mock.calls[0][0];
+        // ...just without a slicer.
+        expect(payload.sliceSidecar).toBeUndefined();
+        expect(warnSpy).toHaveBeenCalledWith(
+            expect.stringContaining('Slice sidecar build failed'),
+            expect.anything(),
+        );
+    });
+});

--- a/src/renderer/stats/hooks/useStatsUploads.ts
+++ b/src/renderer/stats/hooks/useStatsUploads.ts
@@ -5,6 +5,7 @@ import { isReplayElided } from '../../workers/replayTransfer';
 import { buildReportMeta as buildReportMetaFromDetails } from '../utils/buildReportMeta';
 import { computeInitialWebhookSelection } from '../utils/reportWebhookSelection';
 import { useStatsStore } from '../statsStore';
+import { buildSliceSidecar } from '../slice/buildSliceSidecar';
 
 export interface PublishWebhookOption {
     id: string;
@@ -29,8 +30,10 @@ interface UseStatsUploadsProps {
     stats: any;
     skillUsageData: any;
     activeStatsViewSettings: any;
+    mvpWeights?: any;
+    disruptionMethod?: any;
     embedded: boolean;
-    onWebUpload?: (payload: { meta: any; stats: any; logIds?: string[]; repoFullName?: string; repoOwner?: string; repoName?: string; reportWebhookIds?: string[] }) => Promise<void> | void;
+    onWebUpload?: (payload: { meta: any; stats: any; logIds?: string[]; repoFullName?: string; repoOwner?: string; repoName?: string; reportWebhookIds?: string[]; sliceSidecar?: any }) => Promise<void> | void;
 }
 
 export const useStatsUploads = ({
@@ -38,11 +41,14 @@ export const useStatsUploads = ({
     stats,
     skillUsageData,
     activeStatsViewSettings,
+    mvpWeights,
+    disruptionMethod,
     embedded,
     onWebUpload
 }: UseStatsUploadsProps) => {
     const detailsCache = useContext(DetailsCacheContext);
     const excludedFightKeys = useStatsStore((s) => s.excludedFightKeys);
+    const fightRoster = useStatsStore((s) => s.fightRoster);
     const publishBlockedReason = canPublishWithSlice(excludedFightKeys)
         ? null
         : PUBLISH_BLOCKED_BY_SLICE_REASON;
@@ -189,13 +195,23 @@ export const useStatsUploads = ({
                     reportWebhookSeen: reportWebhooks.map((hook) => hook.id)
                 });
             }
+            // The web slicer's payload. Publishing is already blocked while a
+            // slice is active, so `logs` here is always the full night.
+            const sliceSidecar = buildSliceSidecar({
+                logs,
+                roster: fightRoster,
+                mvpWeights,
+                statsViewSettings: activeStatsViewSettings,
+                disruptionMethod,
+            });
             await onWebUpload({
                 meta,
                 stats: uploadStats,
                 logIds: logs.map((l) => l.permalink).filter(Boolean),
                 ...(normalizedRepoFullName ? { repoFullName: normalizedRepoFullName } : {}),
                 ...(repoParts.length === 2 ? { repoOwner: repoParts[0], repoName: repoParts[1] } : {}),
-                ...(Array.isArray(reportWebhookIds) ? { reportWebhookIds } : {})
+                ...(Array.isArray(reportWebhookIds) ? { reportWebhookIds } : {}),
+                sliceSidecar,
             });
         } catch (err) {
             console.error('[StatsView] Web upload failed:', err);

--- a/src/renderer/stats/hooks/useStatsUploads.ts
+++ b/src/renderer/stats/hooks/useStatsUploads.ts
@@ -163,14 +163,6 @@ export const useStatsUploads = ({
             ...stats,
             skillUsageData,
             statsViewSettings: activeStatsViewSettings,
-            // Slice mode is publisher-settings-authoritative: `buildSliceSidecar`
-            // hashes exactly these two values (read back off `uploadStats` below,
-            // never off these hook props directly) so the published report and
-            // its sidecar can never disagree about what they were built under.
-            // The viewer has no settings of its own to compare against — it
-            // reads these back out of `report.stats` and hashes THEM.
-            mvpWeights,
-            disruptionMethod,
         };
         // Never publish the transient elision marker as report content.
         delete (baseStats as any).replayFightsElided;
@@ -248,6 +240,17 @@ export const useStatsUploads = ({
             try {
                 const r2Status = await window.electronAPI?.isR2Configured?.();
                 if (r2Status?.configured) {
+                    // `mvpWeights`/`disruptionMethod` exist in the published
+                    // payload SOLELY so a viewer can reproduce the sidecar's
+                    // settingsHash — with no sidecar (no R2) they are pure
+                    // bloat that breaks "the report publishes byte-for-byte
+                    // as it does today" on the no-R2 path (regression caught
+                    // in review round 2). So they're only attached here, once
+                    // R2 is confirmed configured, never in `buildReportStats`
+                    // itself.
+                    (uploadStats as any).mvpWeights = mvpWeights;
+                    (uploadStats as any).disruptionMethod = disruptionMethod;
+
                     const { logs: sliceLogs, skipped } = collectSliceLogs();
                     if (skipped > 0) {
                         console.warn(
@@ -255,12 +258,13 @@ export const useStatsUploads = ({
                             `(evicted or never loaded) and were excluded from the fight slicer.`
                         );
                     }
-                    // Hash from exactly what `uploadStats` carries (not from the
-                    // raw hook props) — those are the same values the report
-                    // publishes as `stats.mvpWeights`/`stats.statsViewSettings`/
-                    // `stats.disruptionMethod`, so the sidecar's settingsHash is
-                    // guaranteed to agree with what a viewer re-hashes from the
-                    // published report, by construction.
+                    // Hash from exactly what `uploadStats` now carries (not
+                    // from the raw hook props) — those are the same values
+                    // the report publishes as `stats.mvpWeights`/
+                    // `stats.statsViewSettings`/`stats.disruptionMethod`, so
+                    // the sidecar's settingsHash is guaranteed to agree with
+                    // what a viewer re-hashes from the published report, by
+                    // construction.
                     sliceSidecar = buildSliceSidecar({
                         logs: sliceLogs,
                         roster: fightRoster,
@@ -272,6 +276,11 @@ export const useStatsUploads = ({
             } catch (sliceErr) {
                 console.warn('[StatsView] Slice sidecar build failed — publishing without the fight slicer.', sliceErr);
                 sliceSidecar = undefined;
+                // The mvpWeights/disruptionMethod bloat guard applies to
+                // failure too: don't leave them attached to `uploadStats` if
+                // the sidecar build itself failed after attaching them.
+                delete (uploadStats as any).mvpWeights;
+                delete (uploadStats as any).disruptionMethod;
             }
             await onWebUpload({
                 meta,

--- a/src/renderer/stats/hooks/useStatsUploads.ts
+++ b/src/renderer/stats/hooks/useStatsUploads.ts
@@ -6,6 +6,7 @@ import { buildReportMeta as buildReportMetaFromDetails } from '../utils/buildRep
 import { computeInitialWebhookSelection } from '../utils/reportWebhookSelection';
 import { useStatsStore } from '../statsStore';
 import { buildSliceSidecar } from '../slice/buildSliceSidecar';
+import type { SliceSidecar } from '../slice/sliceTypes';
 
 export interface PublishWebhookOption {
     id: string;
@@ -33,7 +34,7 @@ interface UseStatsUploadsProps {
     mvpWeights?: any;
     disruptionMethod?: any;
     embedded: boolean;
-    onWebUpload?: (payload: { meta: any; stats: any; logIds?: string[]; repoFullName?: string; repoOwner?: string; repoName?: string; reportWebhookIds?: string[]; sliceSidecar?: any }) => Promise<void> | void;
+    onWebUpload?: (payload: { meta: any; stats: any; logIds?: string[]; repoFullName?: string; repoOwner?: string; repoName?: string; reportWebhookIds?: string[]; sliceSidecar?: SliceSidecar }) => Promise<void> | void;
 }
 
 export const useStatsUploads = ({
@@ -112,10 +113,18 @@ export const useStatsUploads = ({
         };
     }, []);
 
+    // Shared with `collectDetails` and the slice sidecar builder: the cache is
+    // the source of truth for a log's details, `log.details` is only the
+    // last-resort fallback. A log whose details were evicted from the cache
+    // (a documented failure mode on this project) must be treated as
+    // unavailable, not silently aggregated from a stale/empty `log.details`.
+    const resolveDetailsForLog = (log: any): any | null =>
+        (detailsCache && log?.id ? detailsCache.peek(log.id) : null) || log.details || null;
+
     const collectDetails = (): any[] => {
         const detailsList: any[] = [];
         logs.forEach((log) => {
-            const details = (detailsCache && log?.id ? detailsCache.peek(log.id) : null) || log.details;
+            const details = resolveDetailsForLog(log);
             if (!details) return;
             // `uploadTime` lives on the log, not the details; carry it across so
             // the pure builder keeps the same last-resort fallback it had here.
@@ -128,6 +137,25 @@ export const useStatsUploads = ({
         return detailsList;
     };
 
+    // The slice sidecar builder wants `{id, filePath, details}` wrapper shapes
+    // (for `statsLogKey`/roster matching), unlike `collectDetails` which
+    // returns bare details. Same cache-first resolution as `collectDetails` —
+    // a log with no resolvable details is skipped (not zero-filled) so a
+    // sidecar frame is never silently built from nothing.
+    const collectSliceLogs = (): { logs: any[]; skipped: number } => {
+        const sliceLogs: any[] = [];
+        let skipped = 0;
+        logs.forEach((log) => {
+            const details = resolveDetailsForLog(log);
+            if (!details) {
+                skipped++;
+                return;
+            }
+            sliceLogs.push({ id: log?.id, filePath: log?.filePath, details });
+        });
+        return { logs: sliceLogs, skipped };
+    };
+
     const buildReportMeta = () => buildReportMetaFromDetails(collectDetails());
 
     const buildReportStats = () => {
@@ -135,6 +163,14 @@ export const useStatsUploads = ({
             ...stats,
             skillUsageData,
             statsViewSettings: activeStatsViewSettings,
+            // Slice mode is publisher-settings-authoritative: `buildSliceSidecar`
+            // hashes exactly these two values (read back off `uploadStats` below,
+            // never off these hook props directly) so the published report and
+            // its sidecar can never disagree about what they were built under.
+            // The viewer has no settings of its own to compare against — it
+            // reads these back out of `report.stats` and hashes THEM.
+            mvpWeights,
+            disruptionMethod,
         };
         // Never publish the transient elision marker as report content.
         delete (baseStats as any).replayFightsElided;
@@ -197,13 +233,46 @@ export const useStatsUploads = ({
             }
             // The web slicer's payload. Publishing is already blocked while a
             // slice is active, so `logs` here is always the full night.
-            const sliceSidecar = buildSliceSidecar({
-                logs,
-                roster: fightRoster,
-                mvpWeights,
-                statsViewSettings: activeStatsViewSettings,
-                disruptionMethod,
-            });
+            //
+            // Building it is not free (a fresh single-log aggregation per
+            // fight, then a multi-MB structured clone over the upload IPC and
+            // a level-9 gzip in main) and is entirely wasted work when R2 is
+            // not configured — the sidecar is R2-only and is dropped
+            // unconditionally on that path. So gate the BUILD itself, not
+            // just the gzip, on an R2-configured check.
+            //
+            // A build failure must not abort the publish: the report
+            // publishes exactly as it does today either way, just without a
+            // slicer.
+            let sliceSidecar: SliceSidecar | undefined;
+            try {
+                const r2Status = await window.electronAPI?.isR2Configured?.();
+                if (r2Status?.configured) {
+                    const { logs: sliceLogs, skipped } = collectSliceLogs();
+                    if (skipped > 0) {
+                        console.warn(
+                            `[StatsView] Slice sidecar: ${skipped} log(s) had no cached details ` +
+                            `(evicted or never loaded) and were excluded from the fight slicer.`
+                        );
+                    }
+                    // Hash from exactly what `uploadStats` carries (not from the
+                    // raw hook props) — those are the same values the report
+                    // publishes as `stats.mvpWeights`/`stats.statsViewSettings`/
+                    // `stats.disruptionMethod`, so the sidecar's settingsHash is
+                    // guaranteed to agree with what a viewer re-hashes from the
+                    // published report, by construction.
+                    sliceSidecar = buildSliceSidecar({
+                        logs: sliceLogs,
+                        roster: fightRoster,
+                        mvpWeights: (uploadStats as any).mvpWeights,
+                        statsViewSettings: (uploadStats as any).statsViewSettings,
+                        disruptionMethod: (uploadStats as any).disruptionMethod,
+                    });
+                }
+            } catch (sliceErr) {
+                console.warn('[StatsView] Slice sidecar build failed — publishing without the fight slicer.', sliceErr);
+                sliceSidecar = undefined;
+            }
             await onWebUpload({
                 meta,
                 stats: uploadStats,
@@ -211,7 +280,7 @@ export const useStatsUploads = ({
                 ...(normalizedRepoFullName ? { repoFullName: normalizedRepoFullName } : {}),
                 ...(repoParts.length === 2 ? { repoOwner: repoParts[0], repoName: repoParts[1] } : {}),
                 ...(Array.isArray(reportWebhookIds) ? { reportWebhookIds } : {}),
-                sliceSidecar,
+                ...(sliceSidecar ? { sliceSidecar } : {}),
             });
         } catch (err) {
             console.error('[StatsView] Web upload failed:', err);

--- a/src/renderer/stats/incrementalAggregation.ts
+++ b/src/renderer/stats/incrementalAggregation.ts
@@ -41,6 +41,7 @@ import { createBoonUptimeTimelineAccumulator, ingestLogBoonUptimeTimeline, final
 import { createStabPerformanceAccumulator, ingestLogStabPerformance, finalizeStabPerformance, extractStabPerformanceFrame, mergeStabPerformanceFrame } from './computeStabPerformance';
 
 import { encodeState, decodeState } from './slice/stateCodec';
+import { applyLabel, buildFrameLabelSeed, resolveFrameFightLabels, type FrameLabelSeed } from './slice/frameLabels';
 import type { SliceFrame } from './slice/sliceTypes';
 
 import { computeSpecialTables } from './computeSpecialTables';
@@ -565,6 +566,14 @@ export class IncrementalAggregator {
 
     // Stored boon table logs (minimal - just details reference for buildBoonTables)
     private boonTableLogs: StoredBoonTableLog[] = [];
+    /**
+     * The raw ingredients of every ordinal-derived id and label, captured for
+     * the LAST log ingested. Only `exportFrame` reads it — and `exportFrame`
+     * only accepts a solo aggregator — so a multi-log aggregator simply carries
+     * the most recent one and `finalize()` never sees it. All primitives, so
+     * this pins nothing large in memory and adds no measurable ingest cost.
+     */
+    private frameLabelSeed: FrameLabelSeed | null = null;
     private replayPayloads: ReplayFightPayload[] = [];
 
     constructor(options: IncrementalAggregatorOptions = {}) {
@@ -619,6 +628,8 @@ export class IncrementalAggregator {
 
         const idx = this.logCount;
         this.logCount++;
+
+        this.frameLabelSeed = buildFrameLabelSeed(log);
 
         const hasDetail = this.hasDetailedRoster(log);
 
@@ -878,6 +889,7 @@ export class IncrementalAggregator {
         return encodeState({
             logCount: this.logCount,
             validLogCount: this.validLogCount,
+            labelSeed: this.frameLabelSeed,
             logMetas: this.logMetas,
             timelineEntries: this.timelineEntries,
             fightBreakdowns: this.fightBreakdowns,
@@ -913,7 +925,8 @@ export class IncrementalAggregator {
         const frame: any = decodeState(rawFrame);
         const index = this.logCount;
         this.logCount += 1;
-        this.rewriteFrameIndexLabels(frame, index);
+        const labels = resolveFrameFightLabels(frame.labelSeed, index);
+        this.applyFrameLabels(frame, labels);
         this.validLogCount += Number(frame.validLogCount || 0);
 
         const appendIndexed = (target: any[], entries: any[] | undefined) => {
@@ -946,8 +959,14 @@ export class IncrementalAggregator {
         Object.entries(frame.mergedDamageModMap || {}).forEach(([key, value]) => {
             if (!this.mergedDamageModMap[key]) this.mergedDamageModMap[key] = value as any;
         });
-        (frame.personalDamageModKeys instanceof Set ? frame.personalDamageModKeys : new Set<string>())
-            .forEach((key: string) => this.personalDamageModKeys.add(key));
+        if (frame.personalDamageModKeys !== undefined && !(frame.personalDamageModKeys instanceof Set)) {
+            // decodeState turns a `__set` payload back into a real Set. Anything
+            // else here means the frame lost its Map/Set encoding somewhere —
+            // most likely a raw `JSON.stringify` that skipped `encodeState` —
+            // and every Set- and Map-shaped section is silently `{}`. Fail loudly.
+            throw new Error('mergeFrame: personalDamageModKeys is not a Set; the frame was not encoded with encodeState');
+        }
+        (frame.personalDamageModKeys as Set<string> | undefined)?.forEach((key: string) => this.personalDamageModKeys.add(key));
         Object.entries(frame.mapCounts || {}).forEach(([name, count]) => {
             this.mapCounts[name] = (this.mapCounts[name] || 0) + Number(count || 0);
         });
@@ -956,15 +975,15 @@ export class IncrementalAggregator {
         });
 
         if (frame.playerAcc) mergePlayerAggregationAccumulators(this.playerAcc, frame.playerAcc);
-        if (frame.commanderStatsAcc) mergeCommanderStatsInto(this.commanderStatsAcc, frame.commanderStatsAcc);
+        if (frame.commanderStatsAcc) mergeCommanderStatsInto(this.commanderStatsAcc, frame.commanderStatsAcc, labels);
 
-        if (frame.spike) mergeSpikeDamageFrame(this.spikeAcc, frame.spike);
-        if (frame.allDamage) mergeAllDamageFrame(this.allDamageAcc, frame.allDamage);
-        if (frame.stripSpikes) mergeStripSpikesFrame(this.stripSpikesAcc, frame.stripSpikes);
-        if (frame.incomingStrike) mergeIncomingStrikeFrame(this.incomingStrikeAcc, frame.incomingStrike);
+        if (frame.spike) mergeSpikeDamageFrame(this.spikeAcc, frame.spike, labels);
+        if (frame.allDamage) mergeAllDamageFrame(this.allDamageAcc, frame.allDamage, labels);
+        if (frame.stripSpikes) mergeStripSpikesFrame(this.stripSpikesAcc, frame.stripSpikes, labels);
+        if (frame.incomingStrike) mergeIncomingStrikeFrame(this.incomingStrikeAcc, frame.incomingStrike, labels);
         if (frame.skillUsage) mergeSkillUsageFrame(this.skillUsageAcc, frame.skillUsage);
-        if (frame.boonTimeline) mergeBoonTimelineFrame(this.boonTimelineAcc, frame.boonTimeline);
-        if (frame.boonUptime) mergeBoonUptimeFrame(this.boonUptimeAcc, frame.boonUptime);
+        if (frame.boonTimeline) mergeBoonTimelineFrame(this.boonTimelineAcc, frame.boonTimeline, labels);
+        if (frame.boonUptime) mergeBoonUptimeFrame(this.boonUptimeAcc, frame.boonUptime, labels);
         if (frame.stabPerformance) mergeStabPerformanceFrame(this.stabPerfAcc, frame.stabPerformance);
     }
 
@@ -1697,72 +1716,55 @@ export class IncrementalAggregator {
     // ---- Private helpers ----
 
     /**
-     * Rewrite the display strings `ingestLog` derived from the running log
-     * index, which `finalize()` does not renumber.
+     * Restate this aggregator's OWN ordinal-derived ids and labels at the merge
+     * ordinal. The eight module accumulators do the same for the strings they
+     * own, from the same `labels` object — see `slice/frameLabels.ts`.
      *
-     * `finalize()` renumbers `shortLabel` on fight breakdowns, fight diff modes,
-     * heal effectiveness, tag-distance deaths and squad comp — those need
-     * nothing here. Three strings escape it:
+     * Nothing here pattern-matches a baked string. `labels` is produced by
+     * re-evaluating the very expressions `ingestLog*` used, against the raw
+     * ingredients the frame carries in `labelSeed`, at the merge ordinal. The
+     * `fullLabel*` / `breakdown*` fields are `null` whenever the log supplied a
+     * real zone or encounter name, in which case the ingested string is already
+     * ordinal-free and `applyLabel` leaves it untouched.
      *
-     *  - `commanderStats` fight rows carry `shortLabel: F${idx + 1}` straight
-     *    through `finalizeCommanderStats` into `fightsData`. A frame is always
-     *    built by a solo aggregator, so this is always `F1`; rewriting it to the
-     *    merge index is exact, not a guess.
-     *  - `fightBreakdown.label` and the id fallbacks are only index-derived when
-     *    the log had no `encounterName` / `filePath` / `id` at all, so they are
-     *    rewritten only when they still equal the index-0 fallback.
-     *
-     * Not rewritten: `fullLabel` strings built by `buildFightLabelV2`. Those
-     * take the index only when `details.fightName`, `log.fightName` AND
-     * `log.encounterName` are all missing — a log that unlabelled is already
-     * mislabelled on the non-slice path, and the value is not recoverable from
-     * the frame.
+     * `shortLabel` is not restated on the aggregator's own arrays: `finalize()`
+     * renumbers it for fight breakdowns, fight diff modes, heal effectiveness,
+     * tag-distance deaths and squad comp after sorting, and overwriting it here
+     * would be dead work.
      */
-    private rewriteFrameIndexLabels(frame: any, index: number): void {
-        const retarget = (obj: any, key: string, soloValue: string, mergedValue: string) => {
-            if (obj && obj[key] === soloValue) obj[key] = mergedValue;
-        };
-
+    private applyFrameLabels(frame: any, labels: ReturnType<typeof resolveFrameFightLabels>): void {
         (frame.fightBreakdowns || []).forEach((stored: any) => {
-            retarget(stored?.result, 'label', 'Fight 1', `Fight ${index + 1}`);
-            retarget(stored?.result, 'zone', 'Fight 1', `Fight ${index + 1}`);
-            // A log with no `details` at all reaches `buildFightLabelV2` with no
-            // position, so its fullLabel is the bare zone fallback.
-            retarget(stored?.result, 'fullLabel', 'Fight 1', `Fight ${index + 1}`);
-            retarget(stored?.result, 'id', 'fight-0', `fight-${index}`);
+            applyLabel(stored?.result, 'id', labels.filePathFightId);
+            applyLabel(stored?.result, 'label', labels.breakdownLabel);
+            applyLabel(stored?.result, 'fullLabel', labels.breakdownFullLabel);
         });
         (frame.fightDiffModes || []).forEach((stored: any) => {
-            retarget(stored?.result, 'id', 'fight-1', `fight-${index + 1}`);
+            applyLabel(stored?.result, 'id', labels.fightId);
         });
         (frame.healEffectivenessResults || []).forEach((stored: any) => {
-            retarget(stored?.result, 'id', 'fight-1', `fight-${index + 1}`);
+            applyLabel(stored?.result, 'id', labels.fightId);
+            applyLabel(stored?.result, 'fullLabel', labels.fullLabel);
         });
         (frame.squadCompEntries || []).forEach((stored: any) => {
-            retarget(stored?.result, 'id', 'fight-1', `fight-${index + 1}`);
+            applyLabel(stored?.result, 'id', labels.fightId);
         });
         (frame.tagDistanceDeathsResults || []).forEach((stored: any) => {
-            retarget(stored?.result, 'fightId', 'fight-0', `fight-${index}`);
+            applyLabel(stored?.result, 'fightId', labels.filePathFightId);
+            applyLabel(stored?.result, 'fullLabel', labels.fullLabelEncounterOnly);
             (stored?.result?.events || []).forEach((event: any) => {
-                retarget(event, 'fightId', 'fight-0', `fight-${index}`);
+                applyLabel(event, 'fightId', labels.filePathFightId);
+                applyLabel(event, 'fullLabel', labels.fullLabelEncounterOnly);
             });
         });
         (frame.distanceToTagContribs || []).forEach((stored: any) => {
-            (stored?.contributions || []).forEach((c: any) => retarget(c, 'fightId', 'fight-0', `fight-${index}`));
+            (stored?.contributions || []).forEach((c: any) => applyLabel(c, 'fightId', labels.filePathFightId));
         });
         (frame.onTagReviewContribs || []).forEach((stored: any) => {
-            (stored?.contributions || []).forEach((c: any) => retarget(c, 'fightId', 'fight-0', `fight-${index}`));
+            (stored?.contributions || []).forEach((c: any) => applyLabel(c, 'fightId', labels.filePathFightId));
         });
         (frame.incomingDamageEntries || []).forEach((entry: any) => {
-            retarget(entry, 'fightId', 'fight-1', `fight-${index + 1}`);
+            applyLabel(entry, 'fightId', labels.fightId);
         });
-        if (frame.commanderStatsAcc instanceof Map) {
-            frame.commanderStatsAcc.forEach((entry: any) => {
-                (entry?.fightRows || []).forEach((row: any) => {
-                    row.shortLabel = `F${index + 1}`;
-                    retarget(row, 'id', 'fight-1', `fight-${index + 1}`);
-                });
-            });
-        }
     }
 
     private hasDetailedRoster(log: any): boolean {

--- a/src/renderer/stats/incrementalAggregation.ts
+++ b/src/renderer/stats/incrementalAggregation.ts
@@ -15,6 +15,7 @@ import {
     ingestLogPlayerData,
     finalizePlayerAggregation,
     resolveProfessionLabel,
+    mergePlayerAggregationAccumulators,
     PlayerStats,
     DamageMitigationRow,
     DamageMitigationTotals,
@@ -22,22 +23,25 @@ import {
 import type { PlayerAggregationAccumulators, PlayerAggregationOptions } from './computePlayerAggregation';
 
 import { ingestLogFightBreakdown } from './computeFightBreakdown';
-import { ingestLogCommanderStats } from './computeCommanderStats';
+import { ingestLogCommanderStats, mergeCommanderStatsInto } from './computeCommanderStats';
 import { ingestLogFightDiffMode } from './computeFightDiffMode';
 import { ingestLogTagDistanceDeaths } from './computeTagDistanceDeaths';
 import { ingestLogDistanceToTag, finalizeDistanceToTag, type DistanceToTagResult } from './computeDistanceToTag';
 import { ingestLogOnTagReview, finalizeOnTagReview, type OnTagReviewResult } from './computeOnTagReview';
 import { ingestLogHealEffectiveness } from './computeHealEffectivenessData';
 
-import { createSpikeDamageAccumulator, ingestLogSpikeDamage, finalizeSpikeDamage } from './computeSpikeDamageData';
-import { createAllDamageAccumulator, ingestLogAllDamage, finalizeAllDamage } from './computeAllDamageData';
-import { createStripSpikesAccumulator, ingestLogStripSpikes, finalizeStripSpikes } from './computeStripSpikesData';
-import { createIncomingStrikeDamageAccumulator, ingestLogIncomingStrikeDamage, finalizeIncomingStrikeDamage } from './computeIncomingStrikeDamageData';
-import { createSkillUsageAccumulator, ingestLogSkillUsage, finalizeSkillUsage } from './computeSkillUsageData';
+import { createSpikeDamageAccumulator, ingestLogSpikeDamage, finalizeSpikeDamage, extractSpikeDamageFrame, mergeSpikeDamageFrame } from './computeSpikeDamageData';
+import { createAllDamageAccumulator, ingestLogAllDamage, finalizeAllDamage, extractAllDamageFrame, mergeAllDamageFrame } from './computeAllDamageData';
+import { createStripSpikesAccumulator, ingestLogStripSpikes, finalizeStripSpikes, extractStripSpikesFrame, mergeStripSpikesFrame } from './computeStripSpikesData';
+import { createIncomingStrikeDamageAccumulator, ingestLogIncomingStrikeDamage, finalizeIncomingStrikeDamage, extractIncomingStrikeFrame, mergeIncomingStrikeFrame } from './computeIncomingStrikeDamageData';
+import { createSkillUsageAccumulator, ingestLogSkillUsage, finalizeSkillUsage, extractSkillUsageFrame, mergeSkillUsageFrame } from './computeSkillUsageData';
 
-import { createBoonTimelineAccumulator, ingestLogBoonTimeline, finalizeBoonTimeline } from './computeBoonTimeline';
-import { createBoonUptimeTimelineAccumulator, ingestLogBoonUptimeTimeline, finalizeBoonUptimeTimeline } from './computeBoonUptimeTimeline';
-import { createStabPerformanceAccumulator, ingestLogStabPerformance, finalizeStabPerformance } from './computeStabPerformance';
+import { createBoonTimelineAccumulator, ingestLogBoonTimeline, finalizeBoonTimeline, extractBoonTimelineFrame, mergeBoonTimelineFrame } from './computeBoonTimeline';
+import { createBoonUptimeTimelineAccumulator, ingestLogBoonUptimeTimeline, finalizeBoonUptimeTimeline, extractBoonUptimeFrame, mergeBoonUptimeFrame } from './computeBoonUptimeTimeline';
+import { createStabPerformanceAccumulator, ingestLogStabPerformance, finalizeStabPerformance, extractStabPerformanceFrame, mergeStabPerformanceFrame } from './computeStabPerformance';
+
+import { encodeState, decodeState } from './slice/stateCodec';
+import type { SliceFrame } from './slice/sliceTypes';
 
 import { computeSpecialTables } from './computeSpecialTables';
 import { classifyPlayerRoles } from './classifyPlayerRoles';
@@ -833,6 +837,137 @@ export class IncrementalAggregator {
         ingestLogCommanderStats(log, idx, this.commanderStatsAcc);
     }
 
+    /**
+     * Snapshot this aggregator's pre-finalize state as a slice frame.
+     *
+     * Only valid on an aggregator that ingested exactly one log — a frame IS a
+     * single fight's contribution. Everything here is *pre*-finalize by
+     * construction: leaderboards, MVPs, topStats, role classifications and boon
+     * leaderboards are derived inside `finalize()` from this state, so they are
+     * absent from a frame not because they were stripped but because they do
+     * not exist yet.
+     *
+     * Replay payloads are deliberately excluded: they are roughly two thirds of
+     * report.json and slice mode never needs them.
+     */
+    exportFrame(): SliceFrame {
+        if (this.options.precomputedStats) {
+            throw new Error('exportFrame is not supported on a precomputed-stats aggregator');
+        }
+        if (this.logCount !== 1) {
+            throw new Error(`exportFrame expects exactly one log, got ${this.logCount}`);
+        }
+        // An invalid log (no detailed roster) never reaches the module
+        // accumulators, and their extractors throw on zero fights. Omit those
+        // sections entirely; `mergeFrame` skips whatever is absent.
+        const moduleSections = this.validLogCount === 1
+            ? {
+                spike: extractSpikeDamageFrame(this.spikeAcc),
+                allDamage: extractAllDamageFrame(this.allDamageAcc),
+                stripSpikes: extractStripSpikesFrame(this.stripSpikesAcc),
+                incomingStrike: extractIncomingStrikeFrame(this.incomingStrikeAcc),
+                skillUsage: extractSkillUsageFrame(this.skillUsageAcc),
+                boonTimeline: extractBoonTimelineFrame(this.boonTimelineAcc),
+                boonUptime: extractBoonUptimeFrame(this.boonUptimeAcc),
+                stabPerformance: extractStabPerformanceFrame(this.stabPerfAcc),
+                playerAcc: this.playerAcc,
+                commanderStatsAcc: this.commanderStatsAcc,
+            }
+            : {};
+
+        return encodeState({
+            logCount: this.logCount,
+            validLogCount: this.validLogCount,
+            logMetas: this.logMetas,
+            timelineEntries: this.timelineEntries,
+            fightBreakdowns: this.fightBreakdowns,
+            fightDiffModes: this.fightDiffModes,
+            healEffectivenessResults: this.healEffectivenessResults,
+            tagDistanceDeathsResults: this.tagDistanceDeathsResults,
+            distanceToTagContribs: this.distanceToTagContribs,
+            onTagReviewContribs: this.onTagReviewContribs,
+            incomingDamageEntries: this.incomingDamageEntries,
+            squadCompEntries: this.squadCompEntries,
+            boonTableLogs: this.boonTableLogs,
+            mergedDamageModMap: this.mergedDamageModMap,
+            personalDamageModKeys: this.personalDamageModKeys,
+            mapCounts: this.mapCounts,
+            enemyNameCounts: this.enemyNameCounts,
+            ...moduleSections,
+        }) as SliceFrame;
+    }
+
+    /**
+     * Merge one slice frame into this aggregator. Call once per selected fight,
+     * then `finalize()`.
+     *
+     * `originalIndex` is rewritten to the running merge count: every frame was
+     * built by a solo aggregator and so carries `0`, and `finalize()` uses it as
+     * the tie-break in `sortByFightOrder`. Without the rewrite every merged
+     * entry claims to be fight zero and the tie-break stops discriminating.
+     */
+    mergeFrame(rawFrame: SliceFrame): void {
+        if (this.options.precomputedStats) {
+            throw new Error('mergeFrame is not supported on a precomputed-stats aggregator');
+        }
+        const frame: any = decodeState(rawFrame);
+        const index = this.logCount;
+        this.logCount += 1;
+        this.rewriteFrameIndexLabels(frame, index);
+        this.validLogCount += Number(frame.validLogCount || 0);
+
+        const appendIndexed = (target: any[], entries: any[] | undefined) => {
+            (entries || []).forEach((entry) => {
+                target.push(entry && typeof entry === 'object' && 'originalIndex' in entry
+                    ? { ...entry, originalIndex: index }
+                    : entry);
+            });
+        };
+
+        appendIndexed(this.logMetas, frame.logMetas);
+        appendIndexed(this.timelineEntries, frame.timelineEntries);
+        appendIndexed(this.fightBreakdowns, frame.fightBreakdowns);
+        appendIndexed(this.fightDiffModes, frame.fightDiffModes);
+        // The remaining per-log arrays are keyed by `timestamp` alone — they
+        // carry no `originalIndex` — so they only ever concatenate.
+        appendIndexed(this.healEffectivenessResults, frame.healEffectivenessResults);
+        appendIndexed(this.tagDistanceDeathsResults, frame.tagDistanceDeathsResults);
+        appendIndexed(this.distanceToTagContribs, frame.distanceToTagContribs);
+        appendIndexed(this.onTagReviewContribs, frame.onTagReviewContribs);
+        appendIndexed(this.incomingDamageEntries, frame.incomingDamageEntries);
+        appendIndexed(this.squadCompEntries, frame.squadCompEntries);
+        // A narrow per-log projection (durationMS / buffMap / trimmed native /
+        // trimmed players) that `buildBoonTables` re-reads wholesale at
+        // finalize, so it concatenates with no re-weighting.
+        (frame.boonTableLogs || []).forEach((entry: any) => this.boonTableLogs.push(entry));
+
+        // Scalar collections. `damageModMap` is first-wins exactly as ingest is;
+        // the two count maps sum.
+        Object.entries(frame.mergedDamageModMap || {}).forEach(([key, value]) => {
+            if (!this.mergedDamageModMap[key]) this.mergedDamageModMap[key] = value as any;
+        });
+        (frame.personalDamageModKeys instanceof Set ? frame.personalDamageModKeys : new Set<string>())
+            .forEach((key: string) => this.personalDamageModKeys.add(key));
+        Object.entries(frame.mapCounts || {}).forEach(([name, count]) => {
+            this.mapCounts[name] = (this.mapCounts[name] || 0) + Number(count || 0);
+        });
+        Object.entries(frame.enemyNameCounts || {}).forEach(([name, count]) => {
+            this.enemyNameCounts[name] = (this.enemyNameCounts[name] || 0) + Number(count || 0);
+        });
+
+        if (frame.playerAcc) mergePlayerAggregationAccumulators(this.playerAcc, frame.playerAcc);
+        if (frame.commanderStatsAcc) mergeCommanderStatsInto(this.commanderStatsAcc, frame.commanderStatsAcc);
+
+        if (frame.spike) mergeSpikeDamageFrame(this.spikeAcc, frame.spike);
+        if (frame.allDamage) mergeAllDamageFrame(this.allDamageAcc, frame.allDamage);
+        if (frame.stripSpikes) mergeStripSpikesFrame(this.stripSpikesAcc, frame.stripSpikes);
+        if (frame.incomingStrike) mergeIncomingStrikeFrame(this.incomingStrikeAcc, frame.incomingStrike);
+        if (frame.skillUsage) mergeSkillUsageFrame(this.skillUsageAcc, frame.skillUsage);
+        if (frame.boonTimeline) mergeBoonTimelineFrame(this.boonTimelineAcc, frame.boonTimeline);
+        if (frame.boonUptime) mergeBoonUptimeFrame(this.boonUptimeAcc, frame.boonUptime);
+        if (frame.stabPerformance) mergeStabPerformanceFrame(this.stabPerfAcc, frame.stabPerformance);
+    }
+
     /** Finalize aggregation and return the result. */
     finalize(): { stats: any; skillUsageData: any } {
         if (this.options.precomputedStats) {
@@ -1560,6 +1695,75 @@ export class IncrementalAggregator {
     }
 
     // ---- Private helpers ----
+
+    /**
+     * Rewrite the display strings `ingestLog` derived from the running log
+     * index, which `finalize()` does not renumber.
+     *
+     * `finalize()` renumbers `shortLabel` on fight breakdowns, fight diff modes,
+     * heal effectiveness, tag-distance deaths and squad comp — those need
+     * nothing here. Three strings escape it:
+     *
+     *  - `commanderStats` fight rows carry `shortLabel: F${idx + 1}` straight
+     *    through `finalizeCommanderStats` into `fightsData`. A frame is always
+     *    built by a solo aggregator, so this is always `F1`; rewriting it to the
+     *    merge index is exact, not a guess.
+     *  - `fightBreakdown.label` and the id fallbacks are only index-derived when
+     *    the log had no `encounterName` / `filePath` / `id` at all, so they are
+     *    rewritten only when they still equal the index-0 fallback.
+     *
+     * Not rewritten: `fullLabel` strings built by `buildFightLabelV2`. Those
+     * take the index only when `details.fightName`, `log.fightName` AND
+     * `log.encounterName` are all missing — a log that unlabelled is already
+     * mislabelled on the non-slice path, and the value is not recoverable from
+     * the frame.
+     */
+    private rewriteFrameIndexLabels(frame: any, index: number): void {
+        const retarget = (obj: any, key: string, soloValue: string, mergedValue: string) => {
+            if (obj && obj[key] === soloValue) obj[key] = mergedValue;
+        };
+
+        (frame.fightBreakdowns || []).forEach((stored: any) => {
+            retarget(stored?.result, 'label', 'Fight 1', `Fight ${index + 1}`);
+            retarget(stored?.result, 'zone', 'Fight 1', `Fight ${index + 1}`);
+            // A log with no `details` at all reaches `buildFightLabelV2` with no
+            // position, so its fullLabel is the bare zone fallback.
+            retarget(stored?.result, 'fullLabel', 'Fight 1', `Fight ${index + 1}`);
+            retarget(stored?.result, 'id', 'fight-0', `fight-${index}`);
+        });
+        (frame.fightDiffModes || []).forEach((stored: any) => {
+            retarget(stored?.result, 'id', 'fight-1', `fight-${index + 1}`);
+        });
+        (frame.healEffectivenessResults || []).forEach((stored: any) => {
+            retarget(stored?.result, 'id', 'fight-1', `fight-${index + 1}`);
+        });
+        (frame.squadCompEntries || []).forEach((stored: any) => {
+            retarget(stored?.result, 'id', 'fight-1', `fight-${index + 1}`);
+        });
+        (frame.tagDistanceDeathsResults || []).forEach((stored: any) => {
+            retarget(stored?.result, 'fightId', 'fight-0', `fight-${index}`);
+            (stored?.result?.events || []).forEach((event: any) => {
+                retarget(event, 'fightId', 'fight-0', `fight-${index}`);
+            });
+        });
+        (frame.distanceToTagContribs || []).forEach((stored: any) => {
+            (stored?.contributions || []).forEach((c: any) => retarget(c, 'fightId', 'fight-0', `fight-${index}`));
+        });
+        (frame.onTagReviewContribs || []).forEach((stored: any) => {
+            (stored?.contributions || []).forEach((c: any) => retarget(c, 'fightId', 'fight-0', `fight-${index}`));
+        });
+        (frame.incomingDamageEntries || []).forEach((entry: any) => {
+            retarget(entry, 'fightId', 'fight-1', `fight-${index + 1}`);
+        });
+        if (frame.commanderStatsAcc instanceof Map) {
+            frame.commanderStatsAcc.forEach((entry: any) => {
+                (entry?.fightRows || []).forEach((row: any) => {
+                    row.shortLabel = `F${index + 1}`;
+                    retarget(row, 'id', 'fight-1', `fight-${index + 1}`);
+                });
+            });
+        }
+    }
 
     private hasDetailedRoster(log: any): boolean {
         const players = Array.isArray(log?.details?.players) ? log.details.players : [];

--- a/src/renderer/stats/slice/__tests__/aggregatorFrames.test.ts
+++ b/src/renderer/stats/slice/__tests__/aggregatorFrames.test.ts
@@ -1,0 +1,300 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { IncrementalAggregator, computeStatsSync } from '../../incrementalAggregation';
+
+/**
+ * Read at runtime rather than `import`ed: a static import of these fixtures
+ * gives `tsc --noEmit` a multi-megabyte structural literal to infer, and this
+ * file's four of them are enough to push `npm run typecheck` past its 8 GB heap.
+ */
+const fixture = (name: string) => JSON.parse(
+    readFileSync(resolve(process.cwd(), `test-fixtures/native/${name}.json`), 'utf8'),
+);
+
+const LOGS = ['20260117-175120', '20260117-180135', '20260117-180259', '20260117-180458'].map(fixture).map((details, i) => ({
+    id: `log-${i}`,
+    filePath: `test-${i}.zevtc`,
+    details,
+}));
+
+/**
+ * `computeStabPerformance`'s sibling `combatMetrics` writes `stabGeneration`
+ * back onto `details.players` as a side effect of player aggregation, and
+ * `ingestLogFightDiffMode` reads it — but ingest calls the diff-mode reader
+ * BEFORE player aggregation, so the very first pass over a given `details`
+ * object reports 0 squad stability and every later pass reports the real
+ * number. The fixtures are module-level imports shared by every aggregation in
+ * this file, so whichever path ran first would win. That is a pre-existing
+ * product wart, not a slicing question: warm the fixtures once up front so both
+ * sides of every comparison read the same input.
+ */
+computeStatsSync({ logs: LOGS });
+
+/** Frames as they actually travel: through JSON, exactly like the sidecar. */
+const framesFor = (logs: any[]) => logs.map((log) => {
+    const solo = new IncrementalAggregator();
+    solo.ingestLog(log);
+    return JSON.parse(JSON.stringify(solo.exportFrame()));
+});
+
+const mergeAll = (frames: any[]) => {
+    const merged = new IncrementalAggregator();
+    frames.forEach((frame) => merged.mergeFrame(frame));
+    return merged;
+};
+
+const framedStats = (logs: any[]) => mergeAll(framesFor(logs)).finalize().stats;
+
+/** replayFights is excluded from frames by design — drop it from both sides. */
+const comparable = (stats: any) => {
+    const { replayFights, ...rest } = stats || {};
+    return rest;
+};
+
+/**
+ * Deep-equal is order-insensitive for object keys but not for arrays, and
+ * `toEqual` also treats `undefined` properties as absent. Key order is the
+ * defect class this branch keeps hitting, so pin the serialized form too.
+ */
+const canonical = (value: any) => JSON.stringify(value, (_k, v) => (
+    typeof v === 'number' && !Number.isFinite(v) ? `__nonfinite:${String(v)}` : v
+));
+
+describe('aggregator frame export/merge', () => {
+    it('reproduces the all-fights aggregation from per-fight frames', () => {
+        const direct = computeStatsSync({ logs: LOGS }).stats;
+        expect(comparable(framedStats(LOGS))).toEqual(comparable(direct));
+    });
+
+    it('reproduces a three-of-four slice', () => {
+        const subset = [LOGS[0], LOGS[1], LOGS[3]];
+        const direct = computeStatsSync({ logs: subset }).stats;
+        expect(comparable(framedStats(subset))).toEqual(comparable(direct));
+    });
+
+    it('reproduces a single-fight slice', () => {
+        const direct = computeStatsSync({ logs: [LOGS[2]] }).stats;
+        expect(comparable(framedStats([LOGS[2]]))).toEqual(comparable(direct));
+    });
+
+    it('reproduces the all-fights aggregation byte-for-byte, key order included', () => {
+        const direct = computeStatsSync({ logs: LOGS }).stats;
+        expect(canonical(comparable(framedStats(LOGS)))).toBe(canonical(comparable(direct)));
+    });
+
+    it('reproduces skillUsageData, which finalize returns alongside stats', () => {
+        const direct = computeStatsSync({ logs: LOGS }).skillUsageData;
+        expect(mergeAll(framesFor(LOGS)).finalize().skillUsageData).toEqual(direct);
+    });
+
+    it('recomputes derived sections that frames never carried', () => {
+        // The whole point of shipping pre-finalize state: leaderboards, MVPs,
+        // topStats, role classifications and boon leaderboards are absent from
+        // every frame and reappear after finalize.
+        const derived = [
+            'leaderboards', 'boonLeaderboards', 'roleClassifications',
+            'offensiveMvp', 'defensiveMvp', 'mvp',
+            'topSkills', 'topStatsPerSecond', 'topStatsPerMinute',
+            'maxDownContrib', 'closestToTag',
+        ];
+        const frame = framesFor([LOGS[0]])[0];
+        derived.forEach((key) => expect(frame).not.toHaveProperty(key));
+
+        const stats = framedStats(LOGS);
+        derived.forEach((key) => expect(stats[key]).toBeTruthy());
+        expect(stats.leaderboards.damage.length).toBeGreaterThan(0);
+        expect(stats.roleClassifications.length).toBeGreaterThan(0);
+    });
+
+    it('carries no replay payload in a frame', () => {
+        // replayFights is ~66% of report.json; a frame that carried it would
+        // blow the sidecar budget on its own.
+        const frame = framesFor([LOGS[0]])[0];
+        expect(frame).not.toHaveProperty('replayPayloads');
+        expect(JSON.stringify(frame)).not.toContain('replayFights');
+    });
+
+    it('refuses to export a frame from an aggregator that ingested more than one log', () => {
+        const acc = new IncrementalAggregator();
+        LOGS.forEach((log) => acc.ingestLog(log));
+        expect(() => acc.exportFrame()).toThrow(/exactly one log/i);
+    });
+
+    it('refuses to export a frame from an aggregator that ingested nothing', () => {
+        expect(() => new IncrementalAggregator().exportFrame()).toThrow(/exactly one log/i);
+    });
+
+    describe('originalIndex renumbering', () => {
+        // Every frame is built by a solo aggregator, so every entry in it
+        // claims originalIndex 0. `sortByFightOrder` uses originalIndex as its
+        // only tie-break, so a merged aggregator that left them all at 0 would
+        // be relying on Array.prototype.sort stability for fight order rather
+        // than on the key finalize actually reads.
+        const indexed = ['logMetas', 'timelineEntries', 'fightBreakdowns', 'fightDiffModes'] as const;
+
+        it('every solo frame carries originalIndex 0', () => {
+            const frame = framesFor([LOGS[1]])[0];
+            indexed.forEach((key) => {
+                const entries = (frame as any)[key];
+                expect(entries.length).toBe(1);
+                expect(entries[0].originalIndex).toBe(0);
+            });
+        });
+
+        it('renumbers to the running merge count on every indexed array', () => {
+            const merged = mergeAll(framesFor(LOGS)) as any;
+            indexed.forEach((key) => {
+                expect(merged[key].map((e: any) => e.originalIndex)).toEqual([0, 1, 2, 3]);
+            });
+            expect(merged.logCount).toBe(4);
+            expect(merged.validLogCount).toBe(4);
+        });
+
+        it('matches the originalIndex a direct ingest would have assigned', () => {
+            const direct = new IncrementalAggregator() as any;
+            LOGS.forEach((log) => direct.ingestLog(log));
+            const merged = mergeAll(framesFor(LOGS)) as any;
+            indexed.forEach((key) => {
+                expect(merged[key].map((e: any) => e.originalIndex))
+                    .toEqual(direct[key].map((e: any) => e.originalIndex));
+            });
+        });
+
+        it('breaks ties by merge order when timestamps are equal', () => {
+            // Logs with no roster resolve to timestamp 0, so sortByFightOrder
+            // falls all the way through to originalIndex.
+            const tied = [
+                { id: 'a', filePath: 'a.zevtc', dashboardSummary: { squadCount: 5, enemyCount: 11 } },
+                { id: 'b', filePath: 'b.zevtc', dashboardSummary: { squadCount: 7, enemyCount: 22 } },
+                { id: 'c', filePath: 'c.zevtc', dashboardSummary: { squadCount: 9, enemyCount: 33 } },
+            ];
+            const squadOf = (stats: any) => stats.timelineData.map((row: any) => row.squadCount);
+
+            expect(squadOf(framedStats(tied))).toEqual([5, 7, 9]);
+            expect(squadOf(framedStats([tied[2], tied[0], tied[1]]))).toEqual([9, 5, 7]);
+
+            const frames = framesFor(tied);
+            const merged = mergeAll([frames[2], frames[0], frames[1]]) as any;
+            expect(merged.timelineEntries.map((e: any) => e.originalIndex)).toEqual([0, 1, 2]);
+            expect(squadOf(merged.finalize().stats)).toEqual([9, 5, 7]);
+        });
+    });
+
+    it('unions personalDamageModKeys and first-wins damageModMap across frames', () => {
+        // No native fixture carries personalDamageMods, so inject them onto a
+        // shallow details copy (the players array stays shared by reference).
+        const withMods = (log: any, mods: Record<string, number[]>, modMap: Record<string, any>) => ({
+            ...log,
+            details: { ...log.details, personalDamageMods: mods, damageModMap: modMap },
+        });
+        const logs = [
+            withMods(LOGS[0], { Guardian: [111, 222] }, { d111: { name: 'first', icon: 'a', description: '', incoming: false } }),
+            withMods(LOGS[1], { Necromancer: [222, 333] }, { d111: { name: 'second', icon: 'b', description: '', incoming: true } }),
+        ];
+
+        const frame = framesFor([logs[0]])[0];
+        expect(frame.personalDamageModKeys).toHaveProperty('__set');
+        expect((frame.personalDamageModKeys as any).__set).toEqual(['d111', 'd222']);
+
+        const stats = framedStats(logs);
+        expect(stats.personalDamageModKeys).toEqual(['d111', 'd222', 'd333']);
+        // damageModMap is first-wins on merge exactly as it is on ingest.
+        expect(stats.damageModMap.d111.name).toBe('first');
+        expect(comparable(stats)).toEqual(comparable(computeStatsSync({ logs }).stats));
+    });
+
+    it('sums mapCounts and enemyNameCounts across frames', () => {
+        const merged = mergeAll(framesFor(LOGS)) as any;
+        const direct = new IncrementalAggregator() as any;
+        LOGS.forEach((log) => direct.ingestLog(log));
+        expect(merged.mapCounts).toEqual(direct.mapCounts);
+        expect(merged.enemyNameCounts).toEqual(direct.enemyNameCounts);
+        expect(Object.values(merged.mapCounts).reduce((a: any, b: any) => a + b, 0)).toBe(4);
+    });
+
+    it('concatenates boonTableLogs and the stab-performance accumulator', () => {
+        const merged = mergeAll(framesFor(LOGS)) as any;
+        expect(merged.boonTableLogs).toHaveLength(4);
+        expect(merged.stabPerfAcc.fights).toHaveLength(4);
+        const direct = new IncrementalAggregator() as any;
+        LOGS.forEach((log) => direct.ingestLog(log));
+        expect(merged.stabPerfAcc.fights.map((f: any) => f.id))
+            .toEqual(direct.stabPerfAcc.fights.map((f: any) => f.id));
+    });
+
+    it('renumbers the commander fight-row shortLabel, which finalize never touches', () => {
+        // ingestLogCommanderStats bakes `F${idx + 1}` into every fight row and
+        // finalizeCommanderStats only re-SORTS them, so without the rewrite
+        // every merged fight would report itself as F1.
+        const direct = computeStatsSync({ logs: LOGS }).stats.commanderStats.rows;
+        const framed = framedStats(LOGS).commanderStats.rows;
+        const labels = framed[0].fightsData.map((f: any) => f.shortLabel);
+        expect(labels.length).toBeGreaterThan(1);
+        expect(new Set(labels).size).toBe(labels.length); // not all 'F1'
+        expect(framed.map((r: any) => r.fightsData.map((f: any) => f.shortLabel)))
+            .toEqual(direct.map((r: any) => r.fightsData.map((f: any) => f.shortLabel)));
+    });
+
+    it('keeps the Infinity min sentinel across the JSON boundary', () => {
+        // `min` on a skill breakdown row is seeded to Infinity and JSON has no
+        // Infinity, so a round-tripped frame carries `null` there. If the merge
+        // took that null at face value the sentinel would be lost silently —
+        // and it never surfaces in `stats`, so no output comparison can see it.
+        const nonFinitePaths = (acc: any) => {
+            const found: string[] = [];
+            const walk = (v: any, p: string, d = 0) => {
+                if (d > 25 || found.length > 200) return;
+                if (typeof v === 'number') { if (!Number.isFinite(v)) found.push(`${p}=${v}`); return; }
+                if (v instanceof Map) { v.forEach((x, k) => walk(x, `${p}.${String(k)}`, d + 1)); return; }
+                if (Array.isArray(v)) { v.forEach((x, i) => walk(x, `${p}[${i}]`, d + 1)); return; }
+                if (v && typeof v === 'object') { Object.keys(v).forEach((k) => walk(v[k], `${p}.${k}`, d + 1)); }
+            };
+            walk(acc.playerSkillBreakdownMap, 'playerSkillBreakdownMap');
+            return found.sort();
+        };
+
+        const direct = new IncrementalAggregator() as any;
+        LOGS.forEach((log) => direct.ingestLog(log));
+        const merged = mergeAll(framesFor(LOGS)) as any;
+
+        const expected = nonFinitePaths(direct.playerAcc);
+        expect(expected.length).toBeGreaterThan(0);
+        expect(expected.every((p: string) => p.endsWith('=Infinity'))).toBe(true);
+        expect(nonFinitePaths(merged.playerAcc)).toEqual(expected);
+    });
+
+    it('exports a frame for a log with no detailed roster, omitting module sections', () => {
+        const solo = new IncrementalAggregator();
+        solo.ingestLog({ id: 'x', filePath: 'x.zevtc', dashboardSummary: { squadCount: 3, enemyCount: 4 } });
+        const frame = solo.exportFrame() as any;
+        expect(frame.validLogCount).toBe(0);
+        ['spike', 'allDamage', 'stripSpikes', 'incomingStrike', 'skillUsage',
+            'boonTimeline', 'boonUptime', 'stabPerformance', 'playerAcc', 'commanderStatsAcc']
+            .forEach((key) => expect(frame).not.toHaveProperty(key));
+        expect(frame.logMetas).toHaveLength(1);
+    });
+
+    it('reproduces a mixed valid/invalid roster aggregation', () => {
+        const mixed = [LOGS[0], { id: 'x', filePath: 'x.zevtc', dashboardSummary: { squadCount: 3, enemyCount: 4 } }, LOGS[3]];
+        const direct = computeStatsSync({ logs: mixed }).stats;
+        expect(comparable(framedStats(mixed))).toEqual(comparable(direct));
+    });
+
+    it('survives the JSON boundary for every Map- and Set-shaped section', () => {
+        // encodeState/decodeState is the only thing standing between the
+        // sidecar and a silent `{}` for playerStats, the commander map and
+        // personalDamageModKeys.
+        const raw = new IncrementalAggregator();
+        raw.ingestLog(LOGS[0]);
+        const frame = raw.exportFrame() as any;
+        const roundTripped = JSON.parse(JSON.stringify(frame));
+
+        expect(frame.playerAcc.playerStats).toHaveProperty('__map');
+        expect((frame.playerAcc.playerStats as any).__map.length).toBeGreaterThan(0);
+        expect(frame.commanderStatsAcc).toHaveProperty('__map');
+
+        const direct = computeStatsSync({ logs: [LOGS[0]] }).stats;
+        expect(comparable(mergeAll([roundTripped]).finalize().stats)).toEqual(comparable(direct));
+    });
+});

--- a/src/renderer/stats/slice/__tests__/aggregatorFrames.test.ts
+++ b/src/renderer/stats/slice/__tests__/aggregatorFrames.test.ts
@@ -395,12 +395,26 @@ describe('ordinal-derived labels (the zone-fallback probe)', () => {
         expect(comparable(framed)).toEqual(comparable(direct));
     });
 
-    it('rejects a frame that was serialized without encodeState', () => {
+    it('rejects a frame whose Set sections were serialized without encodeState', () => {
         const solo = new IncrementalAggregator();
         solo.ingestLog(LOGS[0]);
-        // Skipping encodeState is the mistake that flattens every Map and Set
-        // to `{}`; it must fail loudly rather than merge a hollow frame.
-        const hollow = JSON.parse(JSON.stringify({ ...(solo as any), personalDamageModKeys: new Set(['d1']) }));
-        expect(() => new IncrementalAggregator().mergeFrame(hollow)).toThrow(/encodeState|labelSeed/);
+        const frame: any = JSON.parse(JSON.stringify(solo.exportFrame()));
+        // A bare `JSON.stringify` renders a Set as `{}` — the silent, total
+        // data loss `encodeState` exists to prevent. Everything else about this
+        // frame is intact, `labelSeed` included, so it reaches the Set guard
+        // instead of tripping the labelSeed check first; and the matcher has no
+        // alternation that could be satisfied by any other error.
+        frame.personalDamageModKeys = {};
+        expect(() => new IncrementalAggregator().mergeFrame(frame)).toThrow(/encodeState/);
+    });
+
+    it('rejects a frame that carries no labelSeed', () => {
+        const solo = new IncrementalAggregator();
+        solo.ingestLog(LOGS[0]);
+        const frame: any = JSON.parse(JSON.stringify(solo.exportFrame()));
+        delete frame.labelSeed;
+        // Without the seed every ordinal-derived label would silently stay at
+        // the solo aggregator's `Fight 1`.
+        expect(() => new IncrementalAggregator().mergeFrame(frame)).toThrow(/labelSeed/);
     });
 });

--- a/src/renderer/stats/slice/__tests__/aggregatorFrames.test.ts
+++ b/src/renderer/stats/slice/__tests__/aggregatorFrames.test.ts
@@ -53,13 +53,33 @@ const comparable = (stats: any) => {
 };
 
 /**
- * Deep-equal is order-insensitive for object keys but not for arrays, and
- * `toEqual` also treats `undefined` properties as absent. Key order is the
- * defect class this branch keeps hitting, so pin the serialized form too.
+ * Serialize the way the published report.json is serialized, but with every
+ * value JSON would otherwise flatten tagged first. Key order is the defect
+ * class this branch keeps hitting and `toEqual` is order-insensitive for object
+ * keys, so this pins order as well as content.
+ *
+ * Tagged because bare `JSON.stringify` erases them and two genuinely different
+ * results would compare equal: `Set` and `Map` both render as `{}` (there are
+ * Sets inside `stats`), `-0` renders as `0` (real `-0` values occur in
+ * `roleClassifications[].factors[].contribution`), and `Infinity`/`NaN` render
+ * as `null`.
+ *
+ * NOT tagged: `undefined`-valued properties. Those do not exist in the
+ * published artifact on either path — `JSON.stringify` drops them — so tagging
+ * them would fail the comparison on a difference no consumer can observe (the
+ * frame's JSON hop drops `icon: undefined`, the direct path keeps the key with
+ * an undefined value). The paired `toEqual` treats them the same way.
  */
-const canonical = (value: any) => JSON.stringify(value, (_k, v) => (
-    typeof v === 'number' && !Number.isFinite(v) ? `__nonfinite:${String(v)}` : v
-));
+const canonical = (value: any) => JSON.stringify(value, (_k, v) => {
+    if (typeof v === 'number') {
+        if (!Number.isFinite(v)) return `__nonfinite:${String(v)}`;
+        if (Object.is(v, -0)) return '__negzero';
+        return v;
+    }
+    if (v instanceof Set) return { __set: [...v] };
+    if (v instanceof Map) return { __map: [...v.entries()] };
+    return v;
+});
 
 describe('aggregator frame export/merge', () => {
     it('reproduces the all-fights aggregation from per-fight frames', () => {
@@ -78,9 +98,14 @@ describe('aggregator frame export/merge', () => {
         expect(comparable(framedStats([LOGS[2]]))).toEqual(comparable(direct));
     });
 
-    it('reproduces the all-fights aggregation byte-for-byte, key order included', () => {
+    it('reproduces the all-fights aggregation exactly once serialized, key and array order included', () => {
         const direct = computeStatsSync({ logs: LOGS }).stats;
-        expect(canonical(comparable(framedStats(LOGS)))).toBe(canonical(comparable(direct)));
+        const serialized = canonical(comparable(direct));
+        // The tags have to be load-bearing, or this leg would pass on two
+        // different results that merely serialize the same.
+        expect(serialized).toContain('__set');
+        expect(serialized).toContain('__negzero');
+        expect(canonical(comparable(framedStats(LOGS)))).toBe(serialized);
     });
 
     it('reproduces skillUsageData, which finalize returns alongside stats', () => {
@@ -296,5 +321,86 @@ describe('aggregator frame export/merge', () => {
 
         const direct = computeStatsSync({ logs: [LOGS[0]] }).stats;
         expect(comparable(mergeAll([roundTripped]).finalize().stats)).toEqual(comparable(direct));
+    });
+});
+
+describe('ordinal-derived labels (the zone-fallback probe)', () => {
+    /**
+     * Strip the zone names, so every `buildFightLabelV2` call in every module
+     * falls back to `Fight ${ordinal}` and every id chain falls back to
+     * `fight-${ordinal}`. Before the labels were threaded into the module merge
+     * functions this produced 100 divergent strings (128 with the ids also
+     * stripped) across boonTimeline, boonUptimeTimeline, spikeDamage,
+     * stripSpikes, incomingStrikeDamage, allDamage, commanderStats,
+     * healEffectiveness and tagDistanceDeaths — every frame claiming to be
+     * fight 1.
+     */
+    const stripped = (log: any, alsoIds: boolean) => {
+        const { fightName: _fightName, ...details } = log.details;
+        // `fightName` is the only zone source these fixtures have; `fightName`
+        // on the log and `encounterName` are already absent.
+        return alsoIds ? { details } : { id: log.id, filePath: log.filePath, details };
+    };
+
+    it.each([
+        ['with ids intact', false],
+        ['with filePath and id also stripped', true],
+    ])('reproduces the direct aggregation %s', (_name, alsoIds) => {
+        const logs = [LOGS[0], LOGS[1]].map((log) => stripped(log, alsoIds as boolean));
+        const direct = computeStatsSync({ logs }).stats;
+        const framed = framedStats(logs);
+        expect(comparable(framed)).toEqual(comparable(direct));
+        expect(canonical(comparable(framed))).toBe(canonical(comparable(direct)));
+    });
+
+    it('renumbers fullLabel and the peakFightLabel derived from it', () => {
+        const logs = [LOGS[0], LOGS[1]].map((log) => stripped(log, false));
+        const direct = computeStatsSync({ logs }).stats;
+        const framed = framedStats(logs);
+
+        // The fallback really did fire, so these assertions are not vacuous.
+        expect(direct.spikeDamage.fights.map((f: any) => f.fullLabel))
+            .toEqual(['Fight 1 (1:40)', 'Fight 2 (0:49)']);
+        expect(framed.spikeDamage.fights.map((f: any) => f.fullLabel))
+            .toEqual(direct.spikeDamage.fights.map((f: any) => f.fullLabel));
+
+        const peaks = (stats: any) => stats.spikeDamage.players.map((p: any) => p.peakFightLabel);
+        expect(new Set(peaks(direct)).size).toBeGreaterThan(1);
+        expect(peaks(framed)).toEqual(peaks(direct));
+        expect(peaks(framed)).not.toContain('Fight 1 (0:49)');
+
+        expect(framed.stripSpikes.players.map((p: any) => p.peakFightLabel))
+            .toEqual(direct.stripSpikes.players.map((p: any) => p.peakFightLabel));
+        expect(framed.incomingStrikeDamage.players.map((p: any) => p.peakFightLabel))
+            .toEqual(direct.incomingStrikeDamage.players.map((p: any) => p.peakFightLabel));
+        expect(framed.boonTimeline.map((b: any) => b.fights.map((f: any) => f.fullLabel)))
+            .toEqual(direct.boonTimeline.map((b: any) => b.fights.map((f: any) => f.fullLabel)));
+        expect(framed.commanderStats.rows.map((r: any) => r.fightsData.map((f: any) => f.fullLabel)))
+            .toEqual(direct.commanderStats.rows.map((r: any) => r.fightsData.map((f: any) => f.fullLabel)));
+    });
+
+    it('leaves a real zone name alone rather than pattern-matching it', () => {
+        // The retired string matcher rewrote anything that merely LOOKED like
+        // the ordinal fallback. A log genuinely named "Fight 1" must survive.
+        const logs = [LOGS[0], LOGS[1]].map((log) => ({
+            ...log,
+            details: { ...log.details, fightName: 'Fight 1' },
+        }));
+        const direct = computeStatsSync({ logs }).stats;
+        const framed = framedStats(logs);
+        expect(framed.spikeDamage.fights.map((f: any) => f.fullLabel))
+            .toEqual(direct.spikeDamage.fights.map((f: any) => f.fullLabel));
+        // Both fights keep the zone the log gave them; neither is renumbered.
+        expect(framed.spikeDamage.fights.every((f: any) => f.fullLabel.startsWith('Fight 1'))).toBe(true);
+        expect(comparable(framed)).toEqual(comparable(direct));
+    });
+
+    it('rejects a frame that was serialized without encodeState', () => {
+        const solo = new IncrementalAggregator();
+        solo.ingestLog(LOGS[0]);
+        // Skipping encodeState is the mistake that flattens every Map and Set
+        // to `{}`; it must fail loudly rather than merge a hollow frame.
+        const hollow = JSON.parse(JSON.stringify({ ...(solo as any), personalDamageModKeys: new Set(['d1']) }));
+        expect(() => new IncrementalAggregator().mergeFrame(hollow)).toThrow(/encodeState|labelSeed/);
     });
 });

--- a/src/renderer/stats/slice/__tests__/computeIncludedOrdinals.test.ts
+++ b/src/renderer/stats/slice/__tests__/computeIncludedOrdinals.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest';
+import { computeIncludedOrdinals } from '../computeIncludedOrdinals';
+
+const SIDECAR: any = { fights: [{ id: 'a' }, { id: 'b' }, { id: 'c' }] };
+
+describe('computeIncludedOrdinals', () => {
+    it('returns null when no sidecar has loaded', () => {
+        expect(computeIncludedOrdinals(null, new Set(['a']))).toBeNull();
+    });
+
+    it('returns null when nothing is excluded, so the published stats are used', () => {
+        expect(computeIncludedOrdinals(SIDECAR, new Set())).toBeNull();
+    });
+
+    it('returns the ordinals of the fights that survive the exclusion set', () => {
+        expect(computeIncludedOrdinals(SIDECAR, new Set(['b']))).toEqual([0, 2]);
+    });
+
+    /**
+     * C2, and the one case a plain `.filter()` gets wrong. Excluding every
+     * fight is a SLICE THAT SELECTS NOTHING, not "no slice". Folding it into
+     * `null` sent the viewer back to `report.stats` — the full report — under
+     * a banner claiming 0 of N fights.
+     */
+    it('returns an empty array, not null, when every fight is excluded', () => {
+        const result = computeIncludedOrdinals(SIDECAR, new Set(['a', 'b', 'c']));
+        expect(result).not.toBeNull();
+        expect(result).toEqual([]);
+    });
+
+    it('ignores excluded ids that are not in the sidecar', () => {
+        expect(computeIncludedOrdinals(SIDECAR, new Set(['zzz']))).toEqual([0, 1, 2]);
+    });
+});

--- a/src/renderer/stats/slice/__tests__/fetchSliceSidecar.test.ts
+++ b/src/renderer/stats/slice/__tests__/fetchSliceSidecar.test.ts
@@ -1,0 +1,70 @@
+// @vitest-environment node
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { gzipSync } from 'node:zlib';
+import { fetchSliceSidecar } from '../fetchSliceSidecar';
+import { SLICE_SIDECAR_VERSION } from '../sliceTypes';
+
+const SIDECAR = {
+    version: SLICE_SIDECAR_VERSION,
+    settingsHash: 'abc123',
+    fights: [{ id: 'a', label: 'EBG: Klovan', timestamp: 1, duration: '1:00' }],
+    frames: [{}],
+};
+
+/** Serve gzipped bytes the way R2 does: compressed body, no Content-Encoding. */
+const serve = (body: Uint8Array, ok = true) => {
+    vi.stubGlobal('fetch', vi.fn(async () => ({
+        ok,
+        status: ok ? 200 : 404,
+        arrayBuffer: async () => body.buffer.slice(body.byteOffset, body.byteOffset + body.byteLength),
+    })));
+};
+
+const gz = (value: unknown) => new Uint8Array(gzipSync(Buffer.from(JSON.stringify(value), 'utf8')));
+
+afterEach(() => { vi.unstubAllGlobals(); });
+
+describe('fetchSliceSidecar', () => {
+    it('inflates and returns a valid sidecar', async () => {
+        serve(gz(SIDECAR));
+        const result = await fetchSliceSidecar('https://pub-x.r2.dev/slice.json.gz', 'abc123');
+        expect(result.ok).toBe(true);
+        if (result.ok) expect(result.sidecar.fights).toHaveLength(1);
+    });
+
+    it('accepts a sidecar when the report has no settings hash to compare against', async () => {
+        serve(gz(SIDECAR));
+        const result = await fetchSliceSidecar('https://pub-x.r2.dev/slice.json.gz', null);
+        expect(result.ok).toBe(true);
+    });
+
+    it('rejects a settings hash mismatch rather than rendering wrong numbers', async () => {
+        serve(gz(SIDECAR));
+        const result = await fetchSliceSidecar('https://pub-x.r2.dev/slice.json.gz', 'different');
+        expect(result).toMatchObject({ ok: false, reason: 'settings' });
+    });
+
+    it('rejects an unknown sidecar version', async () => {
+        serve(gz({ ...SIDECAR, version: 99 }));
+        const result = await fetchSliceSidecar('https://pub-x.r2.dev/slice.json.gz', 'abc123');
+        expect(result).toMatchObject({ ok: false, reason: 'version' });
+    });
+
+    it('reports a network failure', async () => {
+        serve(gz(SIDECAR), false);
+        const result = await fetchSliceSidecar('https://pub-x.r2.dev/slice.json.gz', 'abc123');
+        expect(result).toMatchObject({ ok: false, reason: 'network' });
+    });
+
+    it('reports malformed bytes rather than throwing', async () => {
+        serve(new Uint8Array([1, 2, 3, 4]));
+        const result = await fetchSliceSidecar('https://pub-x.r2.dev/slice.json.gz', 'abc123');
+        expect(result).toMatchObject({ ok: false, reason: 'malformed' });
+    });
+
+    it('reports a sidecar whose frames do not line up with its fights', async () => {
+        serve(gz({ ...SIDECAR, frames: [] }));
+        const result = await fetchSliceSidecar('https://pub-x.r2.dev/slice.json.gz', 'abc123');
+        expect(result).toMatchObject({ ok: false, reason: 'malformed' });
+    });
+});

--- a/src/renderer/stats/slice/__tests__/mergeAllDamage.test.ts
+++ b/src/renderer/stats/slice/__tests__/mergeAllDamage.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from 'vitest';
+import {
+    createAllDamageAccumulator,
+    ingestLogAllDamage,
+    finalizeAllDamage,
+    extractAllDamageFrame,
+    mergeAllDamageFrame,
+} from '../../computeAllDamageData';
+import { encodeState, decodeState } from '../stateCodec';
+import fixture1 from '../../../../../test-fixtures/native/20260117-175120.json';
+import fixture2 from '../../../../../test-fixtures/native/20260117-180135.json';
+import fixture3 from '../../../../../test-fixtures/native/20260117-180259.json';
+
+const LOGS = [fixture1, fixture2, fixture3].map((details, i) => ({
+    id: `log-${i}`,
+    filePath: `test-${i}.zevtc`,
+    details,
+}));
+
+const OPTS = { splitPlayersByClass: false };
+
+const directFinalize = (logs: any[]) => {
+    const acc = createAllDamageAccumulator();
+    logs.forEach((log) => ingestLogAllDamage(log, acc, OPTS));
+    return finalizeAllDamage(acc);
+};
+
+const framedFinalize = (logs: any[], viaJson = false) => {
+    const frames = logs.map((log) => {
+        const solo = createAllDamageAccumulator();
+        ingestLogAllDamage(log, solo, OPTS);
+        const frame = extractAllDamageFrame(solo);
+        return viaJson ? decodeState(JSON.parse(JSON.stringify(encodeState(frame)))) : frame;
+    });
+    const merged = createAllDamageAccumulator();
+    frames.forEach((frame) => mergeAllDamageFrame(merged, frame));
+    return finalizeAllDamage(merged);
+};
+
+describe('all damage merge equivalence', () => {
+    it('reproduces the all-fights result from per-fight frames', () => {
+        expect(framedFinalize(LOGS)).toEqual(directFinalize(LOGS));
+    });
+
+    it('reproduces a two-fight subset', () => {
+        const subset = [LOGS[0], LOGS[2]];
+        expect(framedFinalize(subset)).toEqual(directFinalize(subset));
+    });
+
+    it('reproduces a single-fight slice', () => {
+        expect(framedFinalize([LOGS[1]])).toEqual(directFinalize([LOGS[1]]));
+    });
+
+    it('survives a JSON round trip through the state codec', () => {
+        expect(framedFinalize(LOGS, true)).toEqual(directFinalize(LOGS));
+    });
+
+    it('sums damage across the slice rather than returning empty state', () => {
+        const all = framedFinalize(LOGS);
+        const one = framedFinalize([LOGS[0]]);
+        expect(all.players.length).toBeGreaterThan(0);
+        expect(all.players[0].totalDamage).toBeGreaterThan(0);
+        expect(all.fights).toHaveLength(3);
+        expect(one.fights).toHaveLength(1);
+    });
+
+    it('refuses to export a frame from an accumulator holding more than one fight', () => {
+        const acc = createAllDamageAccumulator();
+        LOGS.forEach((log) => ingestLogAllDamage(log, acc, OPTS));
+        expect(() => extractAllDamageFrame(acc)).toThrow(/exactly one fight/i);
+    });
+});

--- a/src/renderer/stats/slice/__tests__/mergeAllDamage.test.ts
+++ b/src/renderer/stats/slice/__tests__/mergeAllDamage.test.ts
@@ -70,3 +70,77 @@ describe('all damage merge equivalence', () => {
         expect(() => extractAllDamageFrame(acc)).toThrow(/exactly one fight/i);
     });
 });
+
+/**
+ * Synthetic tie-break case. Player A is always first in *member* order
+ * (native's `entities` array), but B outdamages A in fight 1 and A
+ * outdamages B in fight 2, so each fight's `fight.players` (sorted by
+ * `totalDamage` descending) puts them in the OPPOSITE order from member
+ * order in one of the two fights. Merged totals land on a byte-identical
+ * tie (30 each), so `finalizeAllDamage`'s stable sort cannot break the tie
+ * itself — whichever key entered the player Map first survives to the front
+ * of the output. Member-order folding (the pre-existing, non-slice
+ * behaviour) must insert A before B; a damage-order fold would insert B
+ * before A on fight 1 and keep that order.
+ */
+const makeSyntheticEntity = (id: number, key: string) => ({
+    id,
+    account: key,
+    character: key,
+    role: 'squad',
+    combat_participant: true,
+    profession: 'Guardian',
+});
+
+const makeSyntheticLog = (
+    fightId: string,
+    timeStartMs: number,
+    totals: { a: number; b: number },
+) => ({
+    id: fightId,
+    filePath: `${fightId}.zevtc`,
+    details: {
+        durationMS: 10000,
+        fightName: fightId,
+        timeStart: new Date(timeStartMs).toISOString(),
+        success: false,
+        players: [],
+        native: {
+            entities: [makeSyntheticEntity(1, 'AAAA'), makeSyntheticEntity(2, 'BBBB')],
+            blocks: {
+                damage: {
+                    by_entity: {
+                        '1': { total: totals.a, by_skill: {} },
+                        '2': { total: totals.b, by_skill: {} },
+                    },
+                },
+                series: { by_entity: {} },
+                contribution: { by_entity: {} },
+            },
+            catalogs: { skills: {} },
+        },
+    },
+});
+
+describe('all damage merge — tie-break order matches member order, not damage order', () => {
+    const TIE_LOGS = [
+        makeSyntheticLog('fight-1', 1_000_000, { a: 10, b: 20 }),
+        makeSyntheticLog('fight-2', 2_000_000, { a: 20, b: 10 }),
+    ];
+
+    it('keeps the frame-merged player order identical to direct ingest', () => {
+        const direct = directFinalize(TIE_LOGS);
+        const framed = framedFinalize(TIE_LOGS);
+
+        // Non-vacuous: confirm the tie this test depends on is real.
+        expect(direct.players).toHaveLength(2);
+        expect(direct.players[0].totalDamage).toBe(30);
+        expect(direct.players[1].totalDamage).toBe(30);
+
+        expect(framed).toEqual(direct);
+        expect(framed.players.map((p) => p.key)).toEqual(direct.players.map((p) => p.key));
+        // Member order (native entity order) is A, B — that must survive the
+        // tie, not the damage-sorted order fight 1 would otherwise impose.
+        expect(direct.players.map((p) => p.key)).toEqual(['AAAA', 'BBBB']);
+    });
+});

--- a/src/renderer/stats/slice/__tests__/mergeAllDamage.test.ts
+++ b/src/renderer/stats/slice/__tests__/mergeAllDamage.test.ts
@@ -10,6 +10,7 @@ import { encodeState, decodeState } from '../stateCodec';
 import fixture1 from '../../../../../test-fixtures/native/20260117-175120.json';
 import fixture2 from '../../../../../test-fixtures/native/20260117-180135.json';
 import fixture3 from '../../../../../test-fixtures/native/20260117-180259.json';
+import { buildFrameLabelSeed, resolveFrameFightLabels } from '../frameLabels';
 
 const LOGS = [fixture1, fixture2, fixture3].map((details, i) => ({
     id: `log-${i}`,
@@ -33,7 +34,7 @@ const framedFinalize = (logs: any[], viaJson = false) => {
         return viaJson ? decodeState(JSON.parse(JSON.stringify(encodeState(frame)))) : frame;
     });
     const merged = createAllDamageAccumulator();
-    frames.forEach((frame) => mergeAllDamageFrame(merged, frame));
+    frames.forEach((frame, i) => mergeAllDamageFrame(merged, frame, resolveFrameFightLabels(buildFrameLabelSeed(logs[i]), i)));
     return finalizeAllDamage(merged);
 };
 

--- a/src/renderer/stats/slice/__tests__/mergeBoonTimeline.test.ts
+++ b/src/renderer/stats/slice/__tests__/mergeBoonTimeline.test.ts
@@ -10,6 +10,7 @@ import { encodeState, decodeState } from '../stateCodec';
 import fixture1 from '../../../../../test-fixtures/native/20260117-175120.json';
 import fixture2 from '../../../../../test-fixtures/native/20260117-180135.json';
 import fixture3 from '../../../../../test-fixtures/native/20260117-180259.json';
+import { buildFrameLabelSeed, resolveFrameFightLabels } from '../frameLabels';
 
 const LOGS = [fixture1, fixture2, fixture3].map((details, i) => ({
     id: `log-${i}`,
@@ -31,7 +32,7 @@ const framedFinalize = (logs: any[], viaJson = false) => {
         return viaJson ? decodeState(JSON.parse(JSON.stringify(encodeState(frame)))) : frame;
     });
     const merged = createBoonTimelineAccumulator();
-    frames.forEach((frame) => mergeBoonTimelineFrame(merged, frame));
+    frames.forEach((frame, i) => mergeBoonTimelineFrame(merged, frame, resolveFrameFightLabels(buildFrameLabelSeed(logs[i]), i)));
     return finalizeBoonTimeline(merged);
 };
 

--- a/src/renderer/stats/slice/__tests__/mergeBoonTimeline.test.ts
+++ b/src/renderer/stats/slice/__tests__/mergeBoonTimeline.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'vitest';
+import {
+    createBoonTimelineAccumulator,
+    ingestLogBoonTimeline,
+    finalizeBoonTimeline,
+    extractBoonTimelineFrame,
+    mergeBoonTimelineFrame,
+} from '../../computeBoonTimeline';
+import { encodeState, decodeState } from '../stateCodec';
+import fixture1 from '../../../../../test-fixtures/native/20260117-175120.json';
+import fixture2 from '../../../../../test-fixtures/native/20260117-180135.json';
+import fixture3 from '../../../../../test-fixtures/native/20260117-180259.json';
+
+const LOGS = [fixture1, fixture2, fixture3].map((details, i) => ({
+    id: `log-${i}`,
+    filePath: `test-${i}.zevtc`,
+    details,
+}));
+
+const directFinalize = (logs: any[]) => {
+    const acc = createBoonTimelineAccumulator();
+    logs.forEach((log) => ingestLogBoonTimeline(log, acc));
+    return finalizeBoonTimeline(acc);
+};
+
+const framedFinalize = (logs: any[], viaJson = false) => {
+    const frames = logs.map((log) => {
+        const solo = createBoonTimelineAccumulator();
+        ingestLogBoonTimeline(log, solo);
+        const frame = extractBoonTimelineFrame(solo);
+        return viaJson ? decodeState(JSON.parse(JSON.stringify(encodeState(frame)))) : frame;
+    });
+    const merged = createBoonTimelineAccumulator();
+    frames.forEach((frame) => mergeBoonTimelineFrame(merged, frame));
+    return finalizeBoonTimeline(merged);
+};
+
+describe('boon timeline merge equivalence', () => {
+    it('reproduces the all-fights result from per-fight frames', () => {
+        expect(framedFinalize(LOGS)).toEqual(directFinalize(LOGS));
+    });
+
+    it('reproduces a two-fight subset', () => {
+        const subset = [LOGS[0], LOGS[2]];
+        expect(framedFinalize(subset)).toEqual(directFinalize(subset));
+    });
+
+    it('reproduces a single-fight slice', () => {
+        expect(framedFinalize([LOGS[1]])).toEqual(directFinalize([LOGS[1]]));
+    });
+
+    it('survives a JSON round trip through the state codec', () => {
+        expect(framedFinalize(LOGS, true)).toEqual(directFinalize(LOGS));
+    });
+
+    it('produces non-empty boon output that grows with the slice', () => {
+        const all = framedFinalize(LOGS);
+        const one = framedFinalize([LOGS[0]]);
+        expect(all.length).toBeGreaterThan(0);
+        expect(all[0].fights.length).toBeGreaterThan(one[0].fights.length);
+    });
+
+    it('refuses to export a frame from an accumulator that ingested more than one log', () => {
+        const acc = createBoonTimelineAccumulator();
+        LOGS.forEach((log) => ingestLogBoonTimeline(log, acc));
+        expect(() => extractBoonTimelineFrame(acc)).toThrow(/exactly one log/i);
+    });
+});

--- a/src/renderer/stats/slice/__tests__/mergeBoonUptime.test.ts
+++ b/src/renderer/stats/slice/__tests__/mergeBoonUptime.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from 'vitest';
+import {
+    createBoonUptimeTimelineAccumulator,
+    ingestLogBoonUptimeTimeline,
+    finalizeBoonUptimeTimeline,
+    extractBoonUptimeFrame,
+    mergeBoonUptimeFrame,
+} from '../../computeBoonUptimeTimeline';
+import { encodeState, decodeState } from '../stateCodec';
+import fixture1 from '../../../../../test-fixtures/native/20260117-175120.json';
+import fixture2 from '../../../../../test-fixtures/native/20260117-180135.json';
+import fixture3 from '../../../../../test-fixtures/native/20260117-180259.json';
+
+const LOGS = [fixture1, fixture2, fixture3].map((details, i) => ({
+    id: `log-${i}`,
+    filePath: `test-${i}.zevtc`,
+    details,
+}));
+
+const SETTINGS = { boonBucketIntervalMs: 5000, stackingBoonBucketIntervalMs: 5000 };
+
+const directFinalize = (logs: any[]) => {
+    const acc = createBoonUptimeTimelineAccumulator(SETTINGS);
+    logs.forEach((log) => ingestLogBoonUptimeTimeline(log, acc));
+    return finalizeBoonUptimeTimeline(acc);
+};
+
+const framedFinalize = (logs: any[], viaJson = false) => {
+    const frames = logs.map((log) => {
+        const solo = createBoonUptimeTimelineAccumulator(SETTINGS);
+        ingestLogBoonUptimeTimeline(log, solo);
+        const frame = extractBoonUptimeFrame(solo);
+        return viaJson ? decodeState(JSON.parse(JSON.stringify(encodeState(frame)))) : frame;
+    });
+    const merged = createBoonUptimeTimelineAccumulator(SETTINGS);
+    frames.forEach((frame) => mergeBoonUptimeFrame(merged, frame));
+    return finalizeBoonUptimeTimeline(merged);
+};
+
+describe('boon uptime timeline merge equivalence', () => {
+    it('reproduces the all-fights result from per-fight frames', () => {
+        expect(framedFinalize(LOGS)).toEqual(directFinalize(LOGS));
+    });
+
+    it('reproduces a two-fight subset', () => {
+        const subset = [LOGS[0], LOGS[2]];
+        expect(framedFinalize(subset)).toEqual(directFinalize(subset));
+    });
+
+    it('reproduces a single-fight slice', () => {
+        expect(framedFinalize([LOGS[1]])).toEqual(directFinalize([LOGS[1]]));
+    });
+
+    it('survives a JSON round trip through the state codec', () => {
+        expect(framedFinalize(LOGS, true)).toEqual(directFinalize(LOGS));
+    });
+
+    it('produces non-empty uptime output that grows with the slice', () => {
+        const all = framedFinalize(LOGS);
+        const one = framedFinalize([LOGS[0]]);
+        expect(all.length).toBeGreaterThan(0);
+        expect(all[0].fights.length).toBeGreaterThan(one[0].fights.length);
+    });
+
+    it('refuses to export a frame from an accumulator that ingested more than one log', () => {
+        const acc = createBoonUptimeTimelineAccumulator(SETTINGS);
+        LOGS.forEach((log) => ingestLogBoonUptimeTimeline(log, acc));
+        expect(() => extractBoonUptimeFrame(acc)).toThrow(/exactly one log/i);
+    });
+});

--- a/src/renderer/stats/slice/__tests__/mergeBoonUptime.test.ts
+++ b/src/renderer/stats/slice/__tests__/mergeBoonUptime.test.ts
@@ -10,6 +10,7 @@ import { encodeState, decodeState } from '../stateCodec';
 import fixture1 from '../../../../../test-fixtures/native/20260117-175120.json';
 import fixture2 from '../../../../../test-fixtures/native/20260117-180135.json';
 import fixture3 from '../../../../../test-fixtures/native/20260117-180259.json';
+import { buildFrameLabelSeed, resolveFrameFightLabels } from '../frameLabels';
 
 const LOGS = [fixture1, fixture2, fixture3].map((details, i) => ({
     id: `log-${i}`,
@@ -33,7 +34,7 @@ const framedFinalize = (logs: any[], viaJson = false) => {
         return viaJson ? decodeState(JSON.parse(JSON.stringify(encodeState(frame)))) : frame;
     });
     const merged = createBoonUptimeTimelineAccumulator(SETTINGS);
-    frames.forEach((frame) => mergeBoonUptimeFrame(merged, frame));
+    frames.forEach((frame, i) => mergeBoonUptimeFrame(merged, frame, resolveFrameFightLabels(buildFrameLabelSeed(logs[i]), i)));
     return finalizeBoonUptimeTimeline(merged);
 };
 

--- a/src/renderer/stats/slice/__tests__/mergeCommanderStats.test.ts
+++ b/src/renderer/stats/slice/__tests__/mergeCommanderStats.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect } from 'vitest';
+import {
+    ingestLogCommanderStats,
+    finalizeCommanderStats,
+    mergeCommanderStatsInto,
+    type CommanderEntry,
+} from '../../computeCommanderStats';
+import { encodeState, decodeState } from '../stateCodec';
+import fixture1 from '../../../../../test-fixtures/native/20260117-175120.json';
+import fixture2 from '../../../../../test-fixtures/native/20260117-180135.json';
+import fixture3 from '../../../../../test-fixtures/native/20260117-180259.json';
+
+const LOGS = [fixture1, fixture2, fixture3].map((details, i) => ({
+    id: `log-${i}`,
+    filePath: `test-${i}.zevtc`,
+    details,
+}));
+
+const direct = (logs: any[]) => {
+    const acc = new Map<string, CommanderEntry>();
+    logs.forEach((log, i) => ingestLogCommanderStats(log, i, acc));
+    return finalizeCommanderStats(acc);
+};
+
+const framed = (logs: any[], viaJson = false) => {
+    const target = new Map<string, CommanderEntry>();
+    logs.forEach((log, i) => {
+        const solo = new Map<string, CommanderEntry>();
+        ingestLogCommanderStats(log, i, solo);
+        const source = viaJson ? decodeState(JSON.parse(JSON.stringify(encodeState(solo)))) : solo;
+        mergeCommanderStatsInto(target, source);
+    });
+    return finalizeCommanderStats(target);
+};
+
+describe('commander stats merge equivalence', () => {
+    it('reproduces the all-fights result from per-fight maps', () => {
+        expect(framed(LOGS)).toEqual(direct(LOGS));
+    });
+
+    it('reproduces a two-fight subset', () => {
+        const subset = [LOGS[0], LOGS[2]];
+        expect(framed(subset)).toEqual(direct(subset));
+    });
+
+    it('reproduces a single-fight slice', () => {
+        expect(framed([LOGS[1]])).toEqual(direct([LOGS[1]]));
+    });
+
+    it('survives a JSON round trip through the state codec', () => {
+        expect(framed(LOGS, true)).toEqual(direct(LOGS));
+    });
+});
+
+describe('commander stats merge synthetic pins', () => {
+    it('unions characterNames, sums per-profession time, and folds incoming skill/boon maps entry-by-entry when the same commander account appears across fights (fixture-uncovered rule surface)', () => {
+        const makeCommander = (overrides: Partial<CommanderEntry> = {}): CommanderEntry => ({
+            key: 'Commander.1234',
+            account: 'Commander.1234',
+            characterNames: new Set(['AltOne']),
+            primaryProfession: 'Guardian',
+            professionTimeMs: { Guardian: 1000 },
+            fights: 1,
+            wins: 1,
+            losses: 0,
+            totalDurationMs: 1000,
+            totalSquadCount: 10,
+            totalEnemyCount: 10,
+            totalKills: 5,
+            totalDowns: 5,
+            totalCommanderDowns: 0,
+            totalCommanderDeaths: 0,
+            totalAlliesDown: 1,
+            totalAlliesDead: 0,
+            totalDamageTaken: 1000,
+            totalIncomingBarrierAbsorbed: 100,
+            totalIncomingStrips: 2,
+            totalIncomingCC: 3,
+            boonWeightedPctMs: 50000,
+            boonDurationMs: 1000,
+            boonEntriesSeen: 4,
+            incomingSkillMap: new Map([
+                ['1', { id: '1', name: 'Skill 1', icon: undefined, damage: 100, hits: 2 }],
+            ]),
+            incomingBoonMap: new Map([
+                ['b1', { id: 'b1', name: 'Might', icon: undefined, uptimePctWeightedMs: 50, durationMs: 1000, stacking: true }],
+            ]),
+            fightRows: [],
+            ...overrides,
+        });
+
+        const target = new Map<string, CommanderEntry>();
+        const first = makeCommander();
+        mergeCommanderStatsInto(target, new Map([['Commander.1234', first]]));
+
+        const second = makeCommander({
+            characterNames: new Set(['AltTwo']),
+            professionTimeMs: { Guardian: 500, Firebrand: 200 },
+            fights: 1,
+            wins: 0,
+            losses: 1,
+            incomingSkillMap: new Map([
+                // Same skill id: real name should win over the generic "Skill N" placeholder,
+                // and damage/hits should sum rather than overwrite.
+                ['1', { id: '1', name: 'Real Skill Name', icon: 'icon.png', damage: 50, hits: 1 }],
+            ]),
+            incomingBoonMap: new Map([
+                ['b1', { id: 'b1', name: 'Might', icon: 'might.png', uptimePctWeightedMs: 30, durationMs: 500, stacking: true }],
+            ]),
+        });
+        mergeCommanderStatsInto(target, new Map([['Commander.1234', second]]));
+
+        const merged = target.get('Commander.1234')!;
+        expect(Array.from(merged.characterNames.values()).sort()).toEqual(['AltOne', 'AltTwo']);
+        expect(merged.professionTimeMs).toEqual({ Guardian: 1500, Firebrand: 200 });
+
+        const skill = merged.incomingSkillMap.get('1')!;
+        expect(skill.damage).toBe(150);
+        expect(skill.hits).toBe(3);
+        expect(skill.name).toBe('Real Skill Name');
+        expect(skill.icon).toBe('icon.png');
+
+        const boon = merged.incomingBoonMap.get('b1')!;
+        expect(boon.uptimePctWeightedMs).toBe(80);
+        expect(boon.durationMs).toBe(1500);
+        expect(boon.icon).toBe('might.png');
+
+        expect(merged.fights).toBe(2);
+        expect(merged.wins).toBe(1);
+        expect(merged.losses).toBe(1);
+    });
+});

--- a/src/renderer/stats/slice/__tests__/mergeCommanderStats.test.ts
+++ b/src/renderer/stats/slice/__tests__/mergeCommanderStats.test.ts
@@ -9,6 +9,7 @@ import { encodeState, decodeState } from '../stateCodec';
 import fixture1 from '../../../../../test-fixtures/native/20260117-175120.json';
 import fixture2 from '../../../../../test-fixtures/native/20260117-180135.json';
 import fixture3 from '../../../../../test-fixtures/native/20260117-180259.json';
+import { buildFrameLabelSeed, resolveFrameFightLabels } from '../frameLabels';
 
 const LOGS = [fixture1, fixture2, fixture3].map((details, i) => ({
     id: `log-${i}`,
@@ -28,7 +29,7 @@ const framed = (logs: any[], viaJson = false) => {
         const solo = new Map<string, CommanderEntry>();
         ingestLogCommanderStats(log, i, solo);
         const source = viaJson ? decodeState(JSON.parse(JSON.stringify(encodeState(solo)))) : solo;
-        mergeCommanderStatsInto(target, source);
+        mergeCommanderStatsInto(target, source, resolveFrameFightLabels(buildFrameLabelSeed(log), i));
     });
     return finalizeCommanderStats(target);
 };
@@ -185,11 +186,22 @@ const makeSecondCommander = (overrides: Partial<CommanderEntry> = {}): Commander
     ...overrides,
 });
 
+/**
+ * The synthetic entries below are not built from a log, so their labels are
+ * hand-written. Feed the merge a seed that names a zone and matches each row's
+ * id, so restating the labels at the merge ordinal reproduces exactly what the
+ * fixtures already say and the pins keep testing the merge rules, not labelling.
+ */
+const syntheticLabels = (index: number, fightId: string) => resolveFrameFightLabels({
+    fightName: 'Synthetic Zone', logFightName: '', encounterName: '',
+    filePath: fightId, logId: '', durationMs: 0,
+}, index);
+
 describe('commander stats merge synthetic pins', () => {
     it('sums every counter/total field with values that distinguish sum from first-wins and from last-wins', () => {
         const target = new Map<string, CommanderEntry>();
-        mergeCommanderStatsInto(target, new Map([['Commander.1234', makeCommander()]]));
-        mergeCommanderStatsInto(target, new Map([['Commander.1234', makeSecondCommander()]]));
+        mergeCommanderStatsInto(target, new Map([['Commander.1234', makeCommander()]]), syntheticLabels(0, 'fight-1'));
+        mergeCommanderStatsInto(target, new Map([['Commander.1234', makeSecondCommander()]]), syntheticLabels(1, 'fight-2'));
         const merged = target.get('Commander.1234')!;
 
         expect(merged.fights).toBe(3);
@@ -215,8 +227,8 @@ describe('commander stats merge synthetic pins', () => {
 
     it('unions characterNames, sums per-profession time (including a brand-new key), and keeps primaryProfession first-wins', () => {
         const target = new Map<string, CommanderEntry>();
-        mergeCommanderStatsInto(target, new Map([['Commander.1234', makeCommander()]]));
-        mergeCommanderStatsInto(target, new Map([['Commander.1234', makeSecondCommander()]]));
+        mergeCommanderStatsInto(target, new Map([['Commander.1234', makeCommander()]]), syntheticLabels(0, 'fight-1'));
+        mergeCommanderStatsInto(target, new Map([['Commander.1234', makeSecondCommander()]]), syntheticLabels(1, 'fight-2'));
         const merged = target.get('Commander.1234')!;
 
         expect(Array.from(merged.characterNames.values()).sort()).toEqual(['AltOne', 'AltTwo']);
@@ -228,8 +240,8 @@ describe('commander stats merge synthetic pins', () => {
 
     it('folds incomingSkillMap and incomingBoonMap entry-by-entry, including boon stacking first-wins', () => {
         const target = new Map<string, CommanderEntry>();
-        mergeCommanderStatsInto(target, new Map([['Commander.1234', makeCommander()]]));
-        mergeCommanderStatsInto(target, new Map([['Commander.1234', makeSecondCommander()]]));
+        mergeCommanderStatsInto(target, new Map([['Commander.1234', makeCommander()]]), syntheticLabels(0, 'fight-1'));
+        mergeCommanderStatsInto(target, new Map([['Commander.1234', makeSecondCommander()]]), syntheticLabels(1, 'fight-2'));
         const merged = target.get('Commander.1234')!;
 
         const skill = merged.incomingSkillMap.get('1')!;
@@ -250,8 +262,8 @@ describe('commander stats merge synthetic pins', () => {
 
     it('concatenates fightRows rather than keeping only one frame\'s rows', () => {
         const target = new Map<string, CommanderEntry>();
-        mergeCommanderStatsInto(target, new Map([['Commander.1234', makeCommander()]]));
-        mergeCommanderStatsInto(target, new Map([['Commander.1234', makeSecondCommander()]]));
+        mergeCommanderStatsInto(target, new Map([['Commander.1234', makeCommander()]]), syntheticLabels(0, 'fight-1'));
+        mergeCommanderStatsInto(target, new Map([['Commander.1234', makeSecondCommander()]]), syntheticLabels(1, 'fight-2'));
         const merged = target.get('Commander.1234')!;
 
         expect(merged.fightRows.map((row) => row.id)).toEqual(['fight-1', 'fight-2']);

--- a/src/renderer/stats/slice/__tests__/mergeCommanderStats.test.ts
+++ b/src/renderer/stats/slice/__tests__/mergeCommanderStats.test.ts
@@ -52,67 +52,185 @@ describe('commander stats merge equivalence', () => {
     });
 });
 
+/**
+ * Fix round 1: the native fixtures only ever produce zero (or equal-across-frames)
+ * values for several CommanderEntry fields, so a sum bug that degrades to
+ * first-wins or last-wins would pass silently. Every field below uses two
+ * distinct, positive, per-frame values so that sum(a,b), a, and b are all
+ * pairwise distinct -- a wrong merge rule cannot coincidentally match the
+ * expected sum.
+ */
+const makeFightRow = (overrides: Partial<CommanderEntry['fightRows'][number]> = {}): CommanderEntry['fightRows'][number] => ({
+    id: 'fight-x',
+    shortLabel: 'F1',
+    fullLabel: 'Fight X',
+    timestamp: 0,
+    mapName: 'EBG',
+    durationMs: 1000,
+    duration: '0:01',
+    isWin: true,
+    squadCount: 10,
+    enemyCount: 10,
+    kills: 1,
+    downs: 1,
+    commanderDowns: 0,
+    commanderDeaths: 0,
+    alliesDown: 0,
+    alliesDead: 0,
+    damageTaken: 0,
+    damageTakenPerMinute: 0,
+    incomingBarrierAbsorbed: 0,
+    incomingBarrierAbsorbedPerMinute: 0,
+    incomingStrips: 0,
+    incomingStripsPerMinute: 0,
+    incomingCC: 0,
+    incomingCCPerMinute: 0,
+    timeToFirstEnemyDownMs: null,
+    timeToFirstEnemyDeathMs: null,
+    downToKillConversionMs: null,
+    hadEarlyDown: null,
+    wasStalledPush: null,
+    downToKillConversionPct: null,
+    failedDownEstimate: 0,
+    distanceTraveled: null,
+    movementPerMinute: null,
+    stationaryPct: null,
+    movementBurstCount: null,
+    commanderDiedAtMs: null,
+    squadDeathsAfterTagDeath: null,
+    enemyKillsAfterTagDeath: null,
+    collapsedAfterTagDeath: null,
+    recoveredAfterTagDeath: null,
+    boonUptimePct: 0,
+    boonEntries: 0,
+    incomingDamageBySkill: [],
+    incomingBoonUptimes: [],
+    incomingDamageBuckets5s: [],
+    incomingBoonBuckets5s: [],
+    ...overrides,
+});
+
+const makeCommander = (overrides: Partial<CommanderEntry> = {}): CommanderEntry => ({
+    key: 'Commander.1234',
+    account: 'Commander.1234',
+    characterNames: new Set(['AltOne']),
+    primaryProfession: 'Guardian',
+    professionTimeMs: { Guardian: 1000 },
+    fights: 1,
+    wins: 1,
+    losses: 1,
+    totalDurationMs: 1000,
+    totalSquadCount: 10,
+    totalEnemyCount: 12,
+    totalKills: 14,
+    totalDowns: 16,
+    totalCommanderDowns: 3,
+    totalCommanderDeaths: 2,
+    totalAlliesDown: 18,
+    totalAlliesDead: 4,
+    totalDamageTaken: 1000,
+    totalIncomingBarrierAbsorbed: 100,
+    totalIncomingStrips: 20,
+    totalIncomingCC: 22,
+    boonWeightedPctMs: 50000,
+    boonDurationMs: 1000,
+    boonEntriesSeen: 24,
+    incomingSkillMap: new Map([
+        ['1', { id: '1', name: 'Skill 1', icon: undefined, damage: 100, hits: 2 }],
+    ]),
+    incomingBoonMap: new Map([
+        ['b1', { id: 'b1', name: 'Might', icon: undefined, uptimePctWeightedMs: 50, durationMs: 1000, stacking: false }],
+    ]),
+    fightRows: [makeFightRow({ id: 'fight-1', shortLabel: 'F1' })],
+    ...overrides,
+});
+
+// Frame B's values are all distinct from frame A's (see makeCommander above)
+// and both are positive, so sum(A, B) != A and sum(A, B) != B for every field
+// below -- a first-wins or last-wins bug cannot pass these assertions.
+const makeSecondCommander = (overrides: Partial<CommanderEntry> = {}): CommanderEntry => makeCommander({
+    characterNames: new Set(['AltTwo']),
+    primaryProfession: 'Firebrand',
+    professionTimeMs: { Guardian: 500, Firebrand: 200 },
+    fights: 2,
+    wins: 3,
+    losses: 4,
+    totalDurationMs: 2000,
+    totalSquadCount: 30,
+    totalEnemyCount: 32,
+    totalKills: 34,
+    totalDowns: 36,
+    totalCommanderDowns: 5,
+    totalCommanderDeaths: 7,
+    totalAlliesDown: 38,
+    totalAlliesDead: 6,
+    totalDamageTaken: 3000,
+    totalIncomingBarrierAbsorbed: 200,
+    totalIncomingStrips: 40,
+    totalIncomingCC: 42,
+    boonWeightedPctMs: 30000,
+    boonDurationMs: 500,
+    boonEntriesSeen: 44,
+    incomingSkillMap: new Map([
+        // Same skill id: real name should win over the generic "Skill N" placeholder,
+        // and damage/hits should sum rather than overwrite.
+        ['1', { id: '1', name: 'Real Skill Name', icon: 'icon.png', damage: 50, hits: 1 }],
+    ]),
+    incomingBoonMap: new Map([
+        // Same boon id, stacking DIFFERS from frame A (false) so first-wins is
+        // distinguishable from "always take incoming's stacking" (true).
+        ['b1', { id: 'b1', name: 'Might', icon: 'might.png', uptimePctWeightedMs: 30, durationMs: 500, stacking: true }],
+    ]),
+    fightRows: [makeFightRow({ id: 'fight-2', shortLabel: 'F2', timestamp: 1 })],
+    ...overrides,
+});
+
 describe('commander stats merge synthetic pins', () => {
-    it('unions characterNames, sums per-profession time, and folds incoming skill/boon maps entry-by-entry when the same commander account appears across fights (fixture-uncovered rule surface)', () => {
-        const makeCommander = (overrides: Partial<CommanderEntry> = {}): CommanderEntry => ({
-            key: 'Commander.1234',
-            account: 'Commander.1234',
-            characterNames: new Set(['AltOne']),
-            primaryProfession: 'Guardian',
-            professionTimeMs: { Guardian: 1000 },
-            fights: 1,
-            wins: 1,
-            losses: 0,
-            totalDurationMs: 1000,
-            totalSquadCount: 10,
-            totalEnemyCount: 10,
-            totalKills: 5,
-            totalDowns: 5,
-            totalCommanderDowns: 0,
-            totalCommanderDeaths: 0,
-            totalAlliesDown: 1,
-            totalAlliesDead: 0,
-            totalDamageTaken: 1000,
-            totalIncomingBarrierAbsorbed: 100,
-            totalIncomingStrips: 2,
-            totalIncomingCC: 3,
-            boonWeightedPctMs: 50000,
-            boonDurationMs: 1000,
-            boonEntriesSeen: 4,
-            incomingSkillMap: new Map([
-                ['1', { id: '1', name: 'Skill 1', icon: undefined, damage: 100, hits: 2 }],
-            ]),
-            incomingBoonMap: new Map([
-                ['b1', { id: 'b1', name: 'Might', icon: undefined, uptimePctWeightedMs: 50, durationMs: 1000, stacking: true }],
-            ]),
-            fightRows: [],
-            ...overrides,
-        });
-
+    it('sums every counter/total field with values that distinguish sum from first-wins and from last-wins', () => {
         const target = new Map<string, CommanderEntry>();
-        const first = makeCommander();
-        mergeCommanderStatsInto(target, new Map([['Commander.1234', first]]));
-
-        const second = makeCommander({
-            characterNames: new Set(['AltTwo']),
-            professionTimeMs: { Guardian: 500, Firebrand: 200 },
-            fights: 1,
-            wins: 0,
-            losses: 1,
-            incomingSkillMap: new Map([
-                // Same skill id: real name should win over the generic "Skill N" placeholder,
-                // and damage/hits should sum rather than overwrite.
-                ['1', { id: '1', name: 'Real Skill Name', icon: 'icon.png', damage: 50, hits: 1 }],
-            ]),
-            incomingBoonMap: new Map([
-                ['b1', { id: 'b1', name: 'Might', icon: 'might.png', uptimePctWeightedMs: 30, durationMs: 500, stacking: true }],
-            ]),
-        });
-        mergeCommanderStatsInto(target, new Map([['Commander.1234', second]]));
-
+        mergeCommanderStatsInto(target, new Map([['Commander.1234', makeCommander()]]));
+        mergeCommanderStatsInto(target, new Map([['Commander.1234', makeSecondCommander()]]));
         const merged = target.get('Commander.1234')!;
+
+        expect(merged.fights).toBe(3);
+        expect(merged.wins).toBe(4);
+        expect(merged.losses).toBe(5);
+        expect(merged.totalDurationMs).toBe(3000);
+        expect(merged.totalSquadCount).toBe(40);
+        expect(merged.totalEnemyCount).toBe(44);
+        expect(merged.totalKills).toBe(48);
+        expect(merged.totalDowns).toBe(52);
+        expect(merged.totalCommanderDowns).toBe(8);
+        expect(merged.totalCommanderDeaths).toBe(9);
+        expect(merged.totalAlliesDown).toBe(56);
+        expect(merged.totalAlliesDead).toBe(10);
+        expect(merged.totalDamageTaken).toBe(4000);
+        expect(merged.totalIncomingBarrierAbsorbed).toBe(300);
+        expect(merged.totalIncomingStrips).toBe(60);
+        expect(merged.totalIncomingCC).toBe(64);
+        expect(merged.boonWeightedPctMs).toBe(80000);
+        expect(merged.boonDurationMs).toBe(1500);
+        expect(merged.boonEntriesSeen).toBe(68);
+    });
+
+    it('unions characterNames, sums per-profession time (including a brand-new key), and keeps primaryProfession first-wins', () => {
+        const target = new Map<string, CommanderEntry>();
+        mergeCommanderStatsInto(target, new Map([['Commander.1234', makeCommander()]]));
+        mergeCommanderStatsInto(target, new Map([['Commander.1234', makeSecondCommander()]]));
+        const merged = target.get('Commander.1234')!;
+
         expect(Array.from(merged.characterNames.values()).sort()).toEqual(['AltOne', 'AltTwo']);
         expect(merged.professionTimeMs).toEqual({ Guardian: 1500, Firebrand: 200 });
+        // primaryProfession is first-wins-unless-Unknown: frame A's 'Guardian'
+        // (not 'Unknown') must survive frame B's 'Firebrand'.
+        expect(merged.primaryProfession).toBe('Guardian');
+    });
+
+    it('folds incomingSkillMap and incomingBoonMap entry-by-entry, including boon stacking first-wins', () => {
+        const target = new Map<string, CommanderEntry>();
+        mergeCommanderStatsInto(target, new Map([['Commander.1234', makeCommander()]]));
+        mergeCommanderStatsInto(target, new Map([['Commander.1234', makeSecondCommander()]]));
+        const merged = target.get('Commander.1234')!;
 
         const skill = merged.incomingSkillMap.get('1')!;
         expect(skill.damage).toBe(150);
@@ -124,9 +242,18 @@ describe('commander stats merge synthetic pins', () => {
         expect(boon.uptimePctWeightedMs).toBe(80);
         expect(boon.durationMs).toBe(1500);
         expect(boon.icon).toBe('might.png');
+        // stacking is set only at creation and never revisited by ingest, so
+        // merge must leave frame A's `false` alone even though frame B's
+        // same-id entry carries `true`.
+        expect(boon.stacking).toBe(false);
+    });
 
-        expect(merged.fights).toBe(2);
-        expect(merged.wins).toBe(1);
-        expect(merged.losses).toBe(1);
+    it('concatenates fightRows rather than keeping only one frame\'s rows', () => {
+        const target = new Map<string, CommanderEntry>();
+        mergeCommanderStatsInto(target, new Map([['Commander.1234', makeCommander()]]));
+        mergeCommanderStatsInto(target, new Map([['Commander.1234', makeSecondCommander()]]));
+        const merged = target.get('Commander.1234')!;
+
+        expect(merged.fightRows.map((row) => row.id)).toEqual(['fight-1', 'fight-2']);
     });
 });

--- a/src/renderer/stats/slice/__tests__/mergeIncomingStrike.test.ts
+++ b/src/renderer/stats/slice/__tests__/mergeIncomingStrike.test.ts
@@ -10,6 +10,7 @@ import { encodeState, decodeState } from '../stateCodec';
 import fixture1 from '../../../../../test-fixtures/native/20260117-175120.json';
 import fixture2 from '../../../../../test-fixtures/native/20260117-180135.json';
 import fixture3 from '../../../../../test-fixtures/native/20260117-180259.json';
+import { buildFrameLabelSeed, resolveFrameFightLabels } from '../frameLabels';
 
 const LOGS = [fixture1, fixture2, fixture3].map((details, i) => ({
     id: `log-${i}`,
@@ -31,7 +32,7 @@ const framedFinalize = (logs: any[], viaJson = false) => {
         return viaJson ? decodeState(JSON.parse(JSON.stringify(encodeState(frame)))) : frame;
     });
     const merged = createIncomingStrikeDamageAccumulator();
-    frames.forEach((frame) => mergeIncomingStrikeFrame(merged, frame));
+    frames.forEach((frame, i) => mergeIncomingStrikeFrame(merged, frame, resolveFrameFightLabels(buildFrameLabelSeed(logs[i]), i)));
     return finalizeIncomingStrikeDamage(merged);
 };
 

--- a/src/renderer/stats/slice/__tests__/mergeIncomingStrike.test.ts
+++ b/src/renderer/stats/slice/__tests__/mergeIncomingStrike.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from 'vitest';
+import {
+    createIncomingStrikeDamageAccumulator,
+    ingestLogIncomingStrikeDamage,
+    finalizeIncomingStrikeDamage,
+    extractIncomingStrikeFrame,
+    mergeIncomingStrikeFrame,
+} from '../../computeIncomingStrikeDamageData';
+import { encodeState, decodeState } from '../stateCodec';
+import fixture1 from '../../../../../test-fixtures/native/20260117-175120.json';
+import fixture2 from '../../../../../test-fixtures/native/20260117-180135.json';
+import fixture3 from '../../../../../test-fixtures/native/20260117-180259.json';
+
+const LOGS = [fixture1, fixture2, fixture3].map((details, i) => ({
+    id: `log-${i}`,
+    filePath: `test-${i}.zevtc`,
+    details,
+}));
+
+const directFinalize = (logs: any[]) => {
+    const acc = createIncomingStrikeDamageAccumulator();
+    logs.forEach((log) => ingestLogIncomingStrikeDamage(log, acc));
+    return finalizeIncomingStrikeDamage(acc);
+};
+
+const framedFinalize = (logs: any[], viaJson = false) => {
+    const frames = logs.map((log) => {
+        const solo = createIncomingStrikeDamageAccumulator();
+        ingestLogIncomingStrikeDamage(log, solo);
+        const frame = extractIncomingStrikeFrame(solo);
+        return viaJson ? decodeState(JSON.parse(JSON.stringify(encodeState(frame)))) : frame;
+    });
+    const merged = createIncomingStrikeDamageAccumulator();
+    frames.forEach((frame) => mergeIncomingStrikeFrame(merged, frame));
+    return finalizeIncomingStrikeDamage(merged);
+};
+
+describe('incoming strike damage merge equivalence', () => {
+    it('reproduces the all-fights result from per-fight frames', () => {
+        expect(framedFinalize(LOGS)).toEqual(directFinalize(LOGS));
+    });
+
+    it('reproduces a two-fight subset', () => {
+        const subset = [LOGS[0], LOGS[2]];
+        expect(framedFinalize(subset)).toEqual(directFinalize(subset));
+    });
+
+    it('reproduces a single-fight slice', () => {
+        expect(framedFinalize([LOGS[1]])).toEqual(directFinalize([LOGS[1]]));
+    });
+
+    it('survives a JSON round trip through the state codec', () => {
+        expect(framedFinalize(LOGS, true)).toEqual(directFinalize(LOGS));
+    });
+
+    it('accumulates incoming damage across the slice rather than returning empty state', () => {
+        const all = framedFinalize(LOGS);
+        const one = framedFinalize([LOGS[0]]);
+        expect(all.players.length).toBeGreaterThan(0);
+        expect(all.fights).toHaveLength(3);
+        expect(one.fights).toHaveLength(1);
+        const allTotal = all.players.reduce((sum, p) => sum + p.totalDamage, 0);
+        const oneTotal = one.players.reduce((sum, p) => sum + p.totalDamage, 0);
+        expect(allTotal).toBeGreaterThan(oneTotal);
+    });
+
+    it('refuses to export a frame from an accumulator holding more than one fight', () => {
+        const acc = createIncomingStrikeDamageAccumulator();
+        LOGS.forEach((log) => ingestLogIncomingStrikeDamage(log, acc));
+        expect(() => extractIncomingStrikeFrame(acc)).toThrow(/exactly one fight/i);
+    });
+});

--- a/src/renderer/stats/slice/__tests__/mergePlayerAggregation.test.ts
+++ b/src/renderer/stats/slice/__tests__/mergePlayerAggregation.test.ts
@@ -1,0 +1,396 @@
+import { describe, it, expect } from 'vitest';
+import {
+    createPlayerAggregationAccumulators,
+    precomputeGlobalEnemySkillStats,
+    ingestLogPlayerData,
+    finalizePlayerAggregation,
+    mergePlayerAggregationAccumulators,
+    PLAYER_STATS_MERGE_RULES,
+} from '../../computePlayerAggregation';
+import { encodeState, decodeState } from '../stateCodec';
+import fixture1 from '../../../../../test-fixtures/native/20260117-175120.json';
+import fixture2 from '../../../../../test-fixtures/native/20260117-180135.json';
+import fixture3 from '../../../../../test-fixtures/native/20260117-180259.json';
+
+const LOGS = [fixture1, fixture2, fixture3].map((details, i) => ({
+    id: `log-${i}`,
+    filePath: `test-${i}.zevtc`,
+    details,
+}));
+
+const OPTIONS = { method: 'count' as const, skillDamageSource: 'target', splitPlayersByClass: false };
+
+const soloAcc = (log: any) => {
+    const acc = createPlayerAggregationAccumulators();
+    precomputeGlobalEnemySkillStats(log, acc);
+    ingestLogPlayerData(log, acc, OPTIONS);
+    return acc;
+};
+
+/**
+ * The direct path: every fight's global enemy stats are precomputed first, then
+ * every fight is ingested. That two-pass shape is why the merge has to carry
+ * `globalEnemySkillStats` — a per-fight frame only ever saw its own.
+ */
+const ingestAll = (logs: any[]) => {
+    const acc = createPlayerAggregationAccumulators();
+    logs.forEach((log) => precomputeGlobalEnemySkillStats(log, acc));
+    logs.forEach((log) => ingestLogPlayerData(log, acc, OPTIONS));
+    return acc;
+};
+
+const mergedAcc = (logs: any[], viaJson = false) => {
+    const target = createPlayerAggregationAccumulators();
+    logs.forEach((log) => {
+        const solo = soloAcc(log);
+        const source = viaJson ? decodeState(JSON.parse(JSON.stringify(encodeState(solo)))) : solo;
+        mergePlayerAggregationAccumulators(target, source);
+    });
+    return target;
+};
+
+/** `finalizePlayerAggregation` mutates in place and returns void — compare the accumulator. */
+const finalized = (acc: any) => {
+    finalizePlayerAggregation(acc);
+    return acc;
+};
+
+describe('player aggregation merge equivalence', () => {
+    it('gives every PlayerStats field produced by a real log a merge rule', () => {
+        // Guards the silent failure mode: an upstream field added to PlayerStats
+        // with no rule would otherwise be dropped from every sliced report.
+        const acc = ingestAll([LOGS[0]]);
+        const sample = [...acc.playerStats.values()][0];
+        expect(sample).toBeTruthy();
+        expect(Object.keys(sample).length).toBeGreaterThan(40);
+        const missing = Object.keys(sample).filter((key) => !(key in PLAYER_STATS_MERGE_RULES));
+        expect(missing).toEqual([]);
+    });
+
+    it('has real, non-empty state to compare', () => {
+        const acc = ingestAll(LOGS);
+        expect(acc.playerStats.size).toBeGreaterThan(5);
+        expect([...acc.playerStats.values()].reduce((t, p) => t + p.damage, 0)).toBeGreaterThan(0);
+        expect(Object.keys(acc.skillDamageMap).length).toBeGreaterThan(10);
+        expect(acc.playerSkillBreakdownMap.size).toBeGreaterThan(5);
+        expect(acc.healingBreakdownMap.size).toBeGreaterThan(5);
+        expect(acc.globalEnemySkillStats.size).toBeGreaterThan(0);
+        expect(acc.mitigationCumulativeCounts.size).toBeGreaterThan(100);
+        expect(acc.mitigationMinionCumulativeCounts.size).toBeGreaterThan(10);
+        expect(Object.keys(acc.incomingSkillDamageMap).length).toBeGreaterThan(10);
+        expect(Object.keys(acc.outgoingCondiTotals).length).toBeGreaterThan(0);
+        expect(Object.keys(acc.incomingCondiTotals).length).toBeGreaterThan(0);
+        expect(Object.keys(acc.enemyProfessionCounts).length).toBeGreaterThan(0);
+        expect(acc.pendingSkillCasts.size).toBeGreaterThan(0);
+        // NOT exercised by these fixtures: specialBuffAgg / specialBuffOutputAgg /
+        // specialBuffMeta stay empty on the native fixtures, so those combiners
+        // are pinned synthetically below instead.
+        expect(acc.specialBuffAgg.size).toBe(0);
+    });
+
+    it('reproduces the all-fights player stats from per-fight accumulators', () => {
+        expect(mergedAcc(LOGS).playerStats).toEqual(ingestAll(LOGS).playerStats);
+    });
+
+    it('reproduces every accumulator field, not just playerStats', () => {
+        const merged = mergedAcc(LOGS) as any;
+        const direct = ingestAll(LOGS) as any;
+        Object.keys(direct).forEach((key) => {
+            expect({ [key]: merged[key] }).toEqual({ [key]: direct[key] });
+        });
+    });
+
+    it('preserves player insertion order, which finalize sorts are stable against', () => {
+        expect([...mergedAcc(LOGS).playerStats.keys()]).toEqual([...ingestAll(LOGS).playerStats.keys()]);
+        expect([...mergedAcc(LOGS).playerSkillBreakdownMap.keys()])
+            .toEqual([...ingestAll(LOGS).playerSkillBreakdownMap.keys()]);
+    });
+
+    it('reproduces the all-fights finalize output', () => {
+        expect(finalized(mergedAcc(LOGS))).toEqual(finalized(ingestAll(LOGS)));
+    });
+
+    it('reproduces a two-fight subset', () => {
+        const subset = [LOGS[0], LOGS[2]];
+        expect(finalized(mergedAcc(subset))).toEqual(finalized(ingestAll(subset)));
+    });
+
+    it('reproduces a reversed-order subset', () => {
+        const subset = [LOGS[2], LOGS[1]];
+        expect(finalized(mergedAcc(subset))).toEqual(finalized(ingestAll(subset)));
+    });
+
+    it('survives a JSON round trip through the state codec', () => {
+        // Compared in the codec's own domain: `JSON.stringify` drops keys whose
+        // value is `undefined` (every `icon` a log had no artwork for), so a
+        // decoded frame is missing keys the direct accumulator carries as
+        // explicit `undefined`. Normalising BOTH sides through the same encode
+        // /decode makes that one difference disappear without weakening
+        // anything else — every number, name, Map entry and array order is
+        // still compared exactly, and a value that actually changed still
+        // fails. The Infinity sentinel is pinned separately below, because JSON
+        // turns it into `null` on both sides.
+        const roundTrip = (acc: any) => JSON.parse(JSON.stringify(encodeState(acc)));
+        expect(roundTrip(finalized(mergedAcc(LOGS, true)))).toEqual(roundTrip(finalized(ingestAll(LOGS))));
+    });
+
+    it('replays casts that a per-fight frame could not attribute on its own', () => {
+        // A rotation cast whose skill dealt no damage in its own fight is
+        // dropped by ingest unless an earlier fight already created the row.
+        // Without the pending-cast replay the sliced totals read low here.
+        const merged = mergedAcc(LOGS);
+        const direct = ingestAll(LOGS);
+        const casts = (acc: any) => [...acc.playerSkillBreakdownMap.values()]
+            .reduce((t: number, row: any) => t + [...row.skills.values()]
+                .reduce((n: number, sk: any) => n + sk.casts, 0), 0);
+        expect(casts(direct)).toBeGreaterThan(0);
+        expect(casts(merged)).toBe(casts(direct));
+    });
+
+    it('accumulates rather than replacing — totals grow with the slice', () => {
+        const all = mergedAcc(LOGS);
+        const one = mergedAcc([LOGS[0]]);
+        const sum = (acc: any) => [...acc.playerStats.values()].reduce((t: number, p: any) => t + p.damage, 0);
+        expect(sum(one)).toBeGreaterThan(0);
+        expect(sum(all)).toBeGreaterThan(sum(one));
+        expect(all.wins + all.losses).toBe(3);
+    });
+
+    it('does not mutate the source frame, so one frame can feed several slices', () => {
+        const solo = soloAcc(LOGS[0]);
+        const before = JSON.stringify(encodeState(solo));
+        const target = createPlayerAggregationAccumulators();
+        mergePlayerAggregationAccumulators(target, solo);
+        mergePlayerAggregationAccumulators(createPlayerAggregationAccumulators(), solo);
+        expect(JSON.stringify(encodeState(solo))).toBe(before);
+    });
+
+    it('rejects state that skipped decodeState instead of silently dropping it', () => {
+        const target = createPlayerAggregationAccumulators();
+        const raw = JSON.parse(JSON.stringify(encodeState(soloAcc(LOGS[0]))));
+        expect(() => mergePlayerAggregationAccumulators(target, raw)).toThrow(/decodeState/);
+    });
+});
+
+/**
+ * The fixtures do not happen to exercise every rule: several `first`/`lastKnown`
+ * fields never disagree across these three logs, and the skill `min`/`max`
+ * sentinels never tie. A green fixture test would pass under the wrong rule for
+ * those, so they are pinned by hand here against synthetic accumulators.
+ */
+describe('player aggregation merge rules pinned synthetically', () => {
+    const blankStats = (over: any) => ({
+        name: '', account: '', characterNames: new Set<string>(), downContrib: 0, cleanses: 0, strips: 0,
+        stab: 0, healing: 0, barrier: 0, cc: 0, interrupts: 0, logsJoined: 0, totalDist: 0, distCount: 0,
+        stackedLogCount: 0, dodges: 0, downs: 0, deaths: 0, kills: 0, enemyDowns: 0, damageTaken: 0,
+        breakbar: 0, blocks: 0, evades: 0, misses: 0, totalFightMs: 0, offenseTotals: {}, offenseRateWeights: {},
+        defenseActiveMs: 0, defenseTotals: {}, defenseMinionDamageTaken: {}, supportActiveMs: 0, supportTotals: {},
+        healingActiveMs: 0, healingTotals: {}, hasHealAddon: false, profession: 'Unknown', professions: new Set<string>(),
+        professionTimeMs: {}, squadActiveMs: 0, firstSeenFightTs: 0, lastSeenFightTs: 0, lastSeenFightDurationMs: 0,
+        isCommander: false, damage: 0, dps: 0, revives: 0, outgoingConditions: {}, incomingConditions: {},
+        damageModTotals: {}, incomingDamageModTotals: {},
+        roleClassification: { role: 'damage', supportScore: 0, confidenceScore: 0, threshold: 0, factors: [] },
+        ...over,
+    });
+
+    const mergeStats = (a: any, b: any) => {
+        const target = createPlayerAggregationAccumulators();
+        const source = createPlayerAggregationAccumulators();
+        target.playerStats.set('p', blankStats(a) as any);
+        source.playerStats.set('p', blankStats(b) as any);
+        mergePlayerAggregationAccumulators(target, source);
+        return target.playerStats.get('p') as any;
+    };
+
+    it('keeps the first name and account, and takes the later profession', () => {
+        const out = mergeStats(
+            { name: 'Alpha', account: 'A.1111', profession: 'Guardian' },
+            { name: 'Beta', account: 'B.2222', profession: 'Firebrand' },
+        );
+        expect(out.name).toBe('Alpha');
+        expect(out.account).toBe('A.1111');
+        // ingest reassigns profession per log, so the later log wins...
+        expect(out.profession).toBe('Firebrand');
+        // ...but an unknown profession never overwrites a known one.
+        expect(mergeStats({ profession: 'Guardian' }, { profession: 'Unknown' }).profession).toBe('Guardian');
+        expect(mergeStats({ profession: 'Unknown' }, { profession: 'Scourge' }).profession).toBe('Scourge');
+    });
+
+    it('treats a zero firstSeenFightTs as unset rather than as the minimum', () => {
+        expect(mergeStats({ firstSeenFightTs: 0 }, { firstSeenFightTs: 500 }).firstSeenFightTs).toBe(500);
+        expect(mergeStats({ firstSeenFightTs: 500 }, { firstSeenFightTs: 0 }).firstSeenFightTs).toBe(500);
+        expect(mergeStats({ firstSeenFightTs: 900 }, { firstSeenFightTs: 500 }).firstSeenFightTs).toBe(500);
+        expect(mergeStats({ firstSeenFightTs: 500 }, { firstSeenFightTs: 900 }).firstSeenFightTs).toBe(500);
+    });
+
+    it('pairs lastSeenFightDurationMs with the later fight, longest wins on a tie', () => {
+        // Later source fight: its duration wins even though it is shorter.
+        expect(mergeStats(
+            { lastSeenFightTs: 100, lastSeenFightDurationMs: 9000 },
+            { lastSeenFightTs: 200, lastSeenFightDurationMs: 1000 },
+        ).lastSeenFightDurationMs).toBe(1000);
+        // Earlier source fight: the target keeps its own.
+        expect(mergeStats(
+            { lastSeenFightTs: 200, lastSeenFightDurationMs: 1000 },
+            { lastSeenFightTs: 100, lastSeenFightDurationMs: 9000 },
+        ).lastSeenFightDurationMs).toBe(1000);
+        // Tie: ingest keeps the longer fight.
+        expect(mergeStats(
+            { lastSeenFightTs: 200, lastSeenFightDurationMs: 1000 },
+            { lastSeenFightTs: 200, lastSeenFightDurationMs: 9000 },
+        ).lastSeenFightDurationMs).toBe(9000);
+        expect(mergeStats(
+            { lastSeenFightTs: 200, lastSeenFightDurationMs: 9000 },
+            { lastSeenFightTs: 200, lastSeenFightDurationMs: 1000 },
+        ).lastSeenFightDurationMs).toBe(9000);
+        // A source that never saw a timestamped fight contributes nothing.
+        expect(mergeStats(
+            { lastSeenFightTs: 200, lastSeenFightDurationMs: 9000 },
+            { lastSeenFightTs: 0, lastSeenFightDurationMs: 0 },
+        ).lastSeenFightDurationMs).toBe(9000);
+    });
+
+    it('ors the flags and unions the sets', () => {
+        const out = mergeStats(
+            { isCommander: true, hasHealAddon: false, characterNames: new Set(['A']), professions: new Set(['Guardian']) },
+            { isCommander: false, hasHealAddon: true, characterNames: new Set(['B']), professions: new Set(['Scourge']) },
+        );
+        expect(out.isCommander).toBe(true);
+        expect(out.hasHealAddon).toBe(true);
+        expect([...out.characterNames]).toEqual(['A', 'B']);
+        expect([...out.professions]).toEqual(['Guardian', 'Scourge']);
+    });
+
+    it('sums dps rather than treating it as a derived rate', () => {
+        expect(mergeStats({ dps: 1000 }, { dps: 250 }).dps).toBe(1250);
+    });
+
+    const mergeSkills = (a: any, b: any) => {
+        const target = createPlayerAggregationAccumulators();
+        const source = createPlayerAggregationAccumulators();
+        const row = (skill: any) => ({
+            key: 'p', account: 'p', displayName: 'p', profession: 'Guardian', professionList: ['Guardian'],
+            totalFightMs: 0, skills: new Map([['s1', skill]]),
+        });
+        target.playerSkillBreakdownMap.set('p', row(a) as any);
+        source.playerSkillBreakdownMap.set('p', row(b) as any);
+        mergePlayerAggregationAccumulators(target, source);
+        return (target.playerSkillBreakdownMap.get('p') as any).skills.get('s1');
+    };
+
+    const skill = (over: any) => ({
+        id: 's1', name: 'Skill 1', icon: undefined, damage: 0, downContribution: 0,
+        hits: 0, casts: 0, min: Infinity, max: 0, ...over,
+    });
+
+    it('mins and maxes the skill entry extremes instead of summing them', () => {
+        const out = mergeSkills(skill({ min: 700, max: 900 }), skill({ min: 300, max: 1500 }));
+        expect(out.min).toBe(300);
+        expect(out.max).toBe(1500);
+        const flipped = mergeSkills(skill({ min: 300, max: 1500 }), skill({ min: 700, max: 900 }));
+        expect(flipped.min).toBe(300);
+        expect(flipped.max).toBe(1500);
+        // Ties must not double.
+        expect(mergeSkills(skill({ min: 400, max: 400 }), skill({ min: 400, max: 400 })).max).toBe(400);
+    });
+
+    it('keeps the Infinity min sentinel, including after a JSON round trip turns it into null', () => {
+        expect(mergeSkills(skill({}), skill({})).min).toBe(Infinity);
+        expect(mergeSkills(skill({ min: Infinity }), skill({ min: 250 })).min).toBe(250);
+        expect(mergeSkills(skill({ min: 250 }), skill({ min: null })).min).toBe(250);
+        expect(mergeSkills(skill({ min: null }), skill({ min: null })).min).toBe(Infinity);
+    });
+
+    it('upgrades a placeholder skill name and fills a missing icon', () => {
+        const out = mergeSkills(skill({ name: 'Skill 1' }), skill({ name: 'Fireball', icon: 'i.png' }));
+        expect(out.name).toBe('Fireball');
+        expect(out.icon).toBe('i.png');
+        // A real name is never downgraded back to a placeholder.
+        expect(mergeSkills(skill({ name: 'Fireball' }), skill({ name: 'Skill 1' })).name).toBe('Fireball');
+    });
+
+    it('combines special-buff aggregates, which these fixtures never populate', () => {
+        const entry = (over: any) => ({
+            key: 'p', account: 'p', profession: 'Unknown', professions: new Set<string>(),
+            professionTimeMs: {}, totalMs: 0, uptimeMs: 0, durationMs: 0, ...over,
+        });
+        const target = createPlayerAggregationAccumulators();
+        const source = createPlayerAggregationAccumulators();
+        target.specialBuffMeta.set('b1', { name: 'Merciful Intervention', stacking: false, icon: 'a.png' });
+        source.specialBuffMeta.set('b1', { name: 'CHANGED', stacking: true, icon: 'b.png' });
+        source.specialBuffMeta.set('b2', { name: 'Second', stacking: false, icon: 'c.png' });
+        target.specialBuffAgg.set('b1', new Map([['p', entry({
+            profession: 'Guardian', professions: new Set(['Guardian']),
+            professionTimeMs: { Guardian: 100 }, totalMs: 10, uptimeMs: 5, durationMs: 200,
+        }) as any]]));
+        source.specialBuffAgg.set('b1', new Map([['p', entry({
+            profession: 'Firebrand', professions: new Set(['Firebrand']),
+            professionTimeMs: { Firebrand: 300 }, totalMs: 40, uptimeMs: 20, durationMs: 400,
+        }) as any]]));
+        source.specialBuffOutputAgg.set('b2', new Map([['q', entry({ key: 'q', account: 'q', totalMs: 7 }) as any]]));
+
+        mergePlayerAggregationAccumulators(target, source);
+
+        // Buff metadata is written once and never changes across logs.
+        expect(target.specialBuffMeta.get('b1')).toEqual({ name: 'Merciful Intervention', stacking: false, icon: 'a.png' });
+        expect(target.specialBuffMeta.get('b2')).toEqual({ name: 'Second', stacking: false, icon: 'c.png' });
+        const merged: any = target.specialBuffAgg.get('b1')!.get('p');
+        expect(merged.totalMs).toBe(50);
+        expect(merged.uptimeMs).toBe(25);
+        expect(merged.durationMs).toBe(600);
+        expect(merged.professionTimeMs).toEqual({ Guardian: 100, Firebrand: 300 });
+        expect([...merged.professions]).toEqual(['Guardian', 'Firebrand']);
+        // ingest reassigns agg.profession per log, so the later one wins.
+        expect(merged.profession).toBe('Firebrand');
+        // A buff bucket only the source has is created, not dropped.
+        expect((target.specialBuffOutputAgg.get('b2')!.get('q') as any).totalMs).toBe(7);
+    });
+
+    it('keeps mitigation-row identity first-wins, even when the first value is Unknown', () => {
+        const row = (over: any) => ({
+            account: 'a', name: 'n', profession: 'Unknown', professionList: ['Unknown'],
+            activeMs: 0,
+            mitigationTotals: {
+                totalHits: 0, blocked: 0, evaded: 0, glanced: 0, missed: 0,
+                invulned: 0, interrupted: 0, totalMitigation: 0, minMitigation: 0,
+            },
+            ...over,
+        });
+        const target = createPlayerAggregationAccumulators();
+        const source = createPlayerAggregationAccumulators();
+        target.damageMitigationPlayersMap.set('k', row({}) as any);
+        source.damageMitigationPlayersMap.set('k', row({ profession: 'Guardian', professionList: ['Guardian'] }) as any);
+        mergePlayerAggregationAccumulators(target, source);
+        const out: any = target.damageMitigationPlayersMap.get('k');
+        // ensureMitigationRow writes `profession` only when creating the row.
+        expect(out.profession).toBe('Unknown');
+        expect(out.professionList).toEqual(['Unknown', 'Guardian']);
+    });
+
+    it('sums minMitigation — it accumulates min_avoided_damage, it is not a minimum', () => {
+        const totals = (over: any) => ({
+            totalHits: 0, blocked: 0, evaded: 0, glanced: 0, missed: 0, invulned: 0,
+            interrupted: 0, totalMitigation: 0, minMitigation: 0, ...over,
+        });
+        const target = createPlayerAggregationAccumulators();
+        const source = createPlayerAggregationAccumulators();
+        target.mitigationCumulativeCounts.set('k', totals({ minMitigation: 30, totalMitigation: 100 }) as any);
+        source.mitigationCumulativeCounts.set('k', totals({ minMitigation: 70, totalMitigation: 200 }) as any);
+        mergePlayerAggregationAccumulators(target, source);
+        expect(target.mitigationCumulativeCounts.get('k')).toEqual(
+            totals({ minMitigation: 100, totalMitigation: 300 }),
+        );
+    });
+});
+
+describe('player aggregation frame size', () => {
+    it('reports the per-fight sidecar cost', async () => {
+        const { gzipSync } = await import('node:zlib');
+        const json = JSON.stringify(encodeState(soloAcc(LOGS[0])));
+        const gzipped = gzipSync(Buffer.from(json)).length;
+        // Informational, not a gate — the 200 KB gzipped budget is per fight
+        // across ALL slice modules combined, and this is the largest of them.
+        console.log(`player aggregation frame: ${json.length} bytes JSON, ${gzipped} bytes gzipped`);
+        expect(json.length).toBeGreaterThan(0);
+    });
+});

--- a/src/renderer/stats/slice/__tests__/mergePlayerAggregation.test.ts
+++ b/src/renderer/stats/slice/__tests__/mergePlayerAggregation.test.ts
@@ -55,6 +55,51 @@ const finalized = (acc: any) => {
     return acc;
 };
 
+/**
+ * Structural diff that forgives ONE difference and nothing else: a key missing
+ * on one side versus present-but-`undefined` on the other. That is precisely
+ * what `JSON.stringify` erases (ingest writes an explicit `icon: undefined` for
+ * every skill the log had no artwork for), and it is behaviourally invisible.
+ *
+ * Everything else stays exact. Numbers go through `Object.is`, so `Infinity`,
+ * `NaN` and `-0` are all distinguishable — normalising both sides through the
+ * same lossy JSON pass instead would have hidden a real lost sentinel. Map and
+ * Set iteration order is compared too, because the `finalize*` sorts in this
+ * codebase are stable with no secondary key.
+ */
+const diffNodes = (a: any, b: any, path = '$', out: string[] = []): string[] => {
+    if (a === undefined && b === undefined) return out;
+    if (a instanceof Map || b instanceof Map) {
+        if (!(a instanceof Map) || !(b instanceof Map)) { out.push(`${path}: Map vs non-Map`); return out; }
+        const aKeys = [...a.keys()];
+        const bKeys = [...b.keys()];
+        if (aKeys.length !== bKeys.length || aKeys.some((k, i) => !Object.is(k, bKeys[i]))) {
+            out.push(`${path}: Map keys/order differ`);
+            return out;
+        }
+        aKeys.forEach((k) => diffNodes(a.get(k), b.get(k), `${path}.get(${String(k)})`, out));
+        return out;
+    }
+    if (a instanceof Set || b instanceof Set) {
+        if (!(a instanceof Set) || !(b instanceof Set)) { out.push(`${path}: Set vs non-Set`); return out; }
+        return diffNodes([...a], [...b], path, out);
+    }
+    if (Array.isArray(a) || Array.isArray(b)) {
+        if (!Array.isArray(a) || !Array.isArray(b) || a.length !== b.length) {
+            out.push(`${path}: array shape differs`);
+            return out;
+        }
+        a.forEach((v, i) => diffNodes(v, b[i], `${path}[${i}]`, out));
+        return out;
+    }
+    if (a && b && typeof a === 'object' && typeof b === 'object') {
+        [...new Set([...Object.keys(a), ...Object.keys(b)])].forEach((k) => diffNodes(a[k], b[k], `${path}.${k}`, out));
+        return out;
+    }
+    if (!Object.is(a, b)) out.push(`${path}: ${String(a)} !== ${String(b)}`);
+    return out;
+};
+
 describe('player aggregation merge equivalence', () => {
     it('gives every PlayerStats field produced by a real log a merge rule', () => {
         // Guards the silent failure mode: an upstream field added to PlayerStats
@@ -65,6 +110,20 @@ describe('player aggregation merge equivalence', () => {
         expect(Object.keys(sample).length).toBeGreaterThan(40);
         const missing = Object.keys(sample).filter((key) => !(key in PLAYER_STATS_MERGE_RULES));
         expect(missing).toEqual([]);
+    });
+
+    it('refuses to guess at a PlayerStats field with no rule', () => {
+        // The table is the contract. Defaulting an unknown key to 'sum' would
+        // turn a string field added upstream into NaN in every sliced report.
+        expect(Object.isFrozen(PLAYER_STATS_MERGE_RULES)).toBe(true);
+        const target = createPlayerAggregationAccumulators();
+        const source = createPlayerAggregationAccumulators();
+        const solo = soloAcc(LOGS[0]);
+        const [key, stats] = [...solo.playerStats.entries()][0];
+        target.playerStats.set(key, { ...stats } as any);
+        source.playerStats.set(key, { ...stats, someNewUpstreamField: 'Fresh Air' } as any);
+        expect(() => mergePlayerAggregationAccumulators(target, source))
+            .toThrow(/someNewUpstreamField/);
     });
 
     it('has real, non-empty state to compare', () => {
@@ -121,17 +180,30 @@ describe('player aggregation merge equivalence', () => {
     });
 
     it('survives a JSON round trip through the state codec', () => {
-        // Compared in the codec's own domain: `JSON.stringify` drops keys whose
-        // value is `undefined` (every `icon` a log had no artwork for), so a
-        // decoded frame is missing keys the direct accumulator carries as
-        // explicit `undefined`. Normalising BOTH sides through the same encode
-        // /decode makes that one difference disappear without weakening
-        // anything else — every number, name, Map entry and array order is
-        // still compared exactly, and a value that actually changed still
-        // fails. The Infinity sentinel is pinned separately below, because JSON
-        // turns it into `null` on both sides.
-        const roundTrip = (acc: any) => JSON.parse(JSON.stringify(encodeState(acc)));
-        expect(roundTrip(finalized(mergedAcc(LOGS, true)))).toEqual(roundTrip(finalized(ingestAll(LOGS))));
+        // Compared with `diffNodes`, which forgives exactly one thing —
+        // a key that is missing on one side and `undefined` on the other,
+        // which is all `JSON.stringify` legitimately erases. Every number is
+        // compared with `Object.is`, so `Infinity`, `NaN` and `-0` all stay
+        // exact: a sentinel that decoded to `null` and was not restored shows
+        // up here as a diff rather than being normalised away.
+        expect(diffNodes(finalized(mergedAcc(LOGS, true)), finalized(ingestAll(LOGS)))).toEqual([]);
+    });
+
+    it('restores the Infinity min sentinel on skills only one frame ever saw', () => {
+        // The regression this pins: a skill row present in a single frame is
+        // cloned wholesale, so nothing on the both-sides-present merge path
+        // ever looks at its `min` — after JSON it would keep `null` where the
+        // direct path holds `Infinity`. `computeSpecialTables` tests
+        // `s.min === Infinity`, so that divergence is load-bearing.
+        const merged: any = mergedAcc(LOGS, true);
+        const direct: any = ingestAll(LOGS);
+        const sentinels = (acc: any) => [...acc.playerSkillBreakdownMap.values()]
+            .flatMap((row: any) => [...row.skills.values()].filter((sk: any) => sk.min === Infinity)).length;
+        expect(sentinels(direct)).toBeGreaterThan(0);
+        expect(sentinels(merged)).toBe(sentinels(direct));
+        const nulls = (acc: any) => [...acc.playerSkillBreakdownMap.values()]
+            .flatMap((row: any) => [...row.skills.values()].filter((sk: any) => !Number.isFinite(sk.min) && sk.min !== Infinity)).length;
+        expect(nulls(merged)).toBe(0);
     });
 
     it('replays casts that a per-fight frame could not attribute on its own', () => {
@@ -384,13 +456,35 @@ describe('player aggregation merge rules pinned synthetically', () => {
 });
 
 describe('player aggregation frame size', () => {
-    it('reports the per-fight sidecar cost', async () => {
+    it('reports the per-fight sidecar cost, measured on a real zerg fight', async () => {
         const { gzipSync } = await import('node:zlib');
-        const json = JSON.stringify(encodeState(soloAcc(LOGS[0])));
-        const gzipped = gzipSync(Buffer.from(json)).length;
-        // Informational, not a gate — the 200 KB gzipped budget is per fight
-        // across ALL slice modules combined, and this is the largest of them.
-        console.log(`player aggregation frame: ${json.length} bytes JSON, ${gzipped} bytes gzipped`);
-        expect(json.length).toBeGreaterThan(0);
+        const measure = (log: any, label: string) => {
+            const json = JSON.stringify(encodeState(soloAcc(log)));
+            const gzipped = gzipSync(Buffer.from(json)).length;
+            const players = (log.details.players || []).filter((p: any) => !p.notInSquad).length;
+            console.log(
+                `player aggregation frame [${label}, ${players} players]: `
+                + `${json.length} bytes JSON, ${gzipped} bytes gzipped`,
+            );
+            return gzipped;
+        };
+        measure(LOGS[0], '20260117-175120');
+        // Read at runtime, not `import`ed: this fixture is 30 MB and a static
+        // JSON import of it makes `tsc --noEmit` exhaust an 8 GB heap.
+        const { readFileSync } = await import('node:fs');
+        const biggestFixture = JSON.parse(readFileSync(
+            `${process.cwd()}/test-fixtures/native/20260128-190427.json`,
+            'utf8',
+        ));
+        const biggest = measure(
+            { id: 'big', filePath: 'big.zevtc', details: biggestFixture },
+            '20260128-190427',
+        );
+        // Informational, not a gate. The 200 KB gzipped budget is per fight
+        // across ALL slice modules combined, and this module alone consumes
+        // most of it at full squad size — see task-10-report.md. Deliberately
+        // NOT enforced here: sizing it down is a later design decision, and a
+        // failing assertion would only invite trimming data to make it pass.
+        expect(biggest).toBeGreaterThan(0);
     });
 });

--- a/src/renderer/stats/slice/__tests__/mergePlayerAggregation.test.ts
+++ b/src/renderer/stats/slice/__tests__/mergePlayerAggregation.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import {
     createPlayerAggregationAccumulators,
     precomputeGlobalEnemySkillStats,
@@ -124,6 +124,44 @@ describe('player aggregation merge equivalence', () => {
         source.playerStats.set(key, { ...stats, someNewUpstreamField: 'Fresh Air' } as any);
         expect(() => mergePlayerAggregationAccumulators(target, source))
             .toThrow(/someNewUpstreamField/);
+    });
+
+    /**
+     * The companion to the test above, and the one that pins the SENSE of the
+     * guard. The unknown-field throw must fire only under a test runner and
+     * degrade everywhere else — because "everywhere else" includes the browser
+     * worker that recomputes a published report's slice, where `process` does
+     * not exist. A guard written as `NODE_ENV !== 'production'` reads
+     * "not production" as TRUE in that worker and throws there, stranding the
+     * viewer with no result at all; that is what this asserts cannot happen.
+     * The stub is `NODE_ENV=development`, NOT `production`, and that choice is
+     * the whole discriminator: the old guard was `!IS_PRODUCTION`, which
+     * degrades under `production` too, so a `production` stub would pass
+     * against the broken version as well. A browser worker has no `NODE_ENV`
+     * at all, which lands on exactly this branch — "neither test nor
+     * production" — and it is the branch the old guard got wrong.
+     * Stubbing the env is the only way to reach the non-test branch from
+     * inside a test, so the check is read at call time rather than at module
+     * load.
+     */
+    it('degrades instead of throwing on an unknown field when not under a test runner', () => {
+        vi.stubEnv('NODE_ENV', 'development');
+        vi.stubEnv('VITEST', '');
+        try {
+            const target = createPlayerAggregationAccumulators();
+            const source = createPlayerAggregationAccumulators();
+            const solo = soloAcc(LOGS[0]);
+            const [key, stats] = [...solo.playerStats.entries()][0];
+            target.playerStats.set(key, { ...stats, someNewUpstreamField: 7, someNewStringField: 'a' } as any);
+            source.playerStats.set(key, { ...stats, someNewUpstreamField: 5, someNewStringField: 'b' } as any);
+            expect(() => mergePlayerAggregationAccumulators(target, source)).not.toThrow();
+            const merged = target.playerStats.get(key) as any;
+            // Numbers sum, everything else keeps the value already present.
+            expect(merged.someNewUpstreamField).toBe(12);
+            expect(merged.someNewStringField).toBe('a');
+        } finally {
+            vi.unstubAllEnvs();
+        }
     });
 
     it('has real, non-empty state to compare', () => {

--- a/src/renderer/stats/slice/__tests__/mergeSkillUsage.test.ts
+++ b/src/renderer/stats/slice/__tests__/mergeSkillUsage.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect } from 'vitest';
+import {
+    createSkillUsageAccumulator,
+    ingestLogSkillUsage,
+    finalizeSkillUsage,
+    extractSkillUsageFrame,
+    mergeSkillUsageFrame,
+} from '../../computeSkillUsageData';
+import { encodeState, decodeState } from '../stateCodec';
+import fixture1 from '../../../../../test-fixtures/native/20260117-175120.json';
+import fixture2 from '../../../../../test-fixtures/native/20260117-180135.json';
+import fixture3 from '../../../../../test-fixtures/native/20260117-180259.json';
+
+const LOGS = [fixture1, fixture2, fixture3].map((details, i) => ({
+    id: `log-${i}`,
+    filePath: `test-${i}.zevtc`,
+    details,
+}));
+
+const directFinalize = (logs: any[]) => {
+    const acc = createSkillUsageAccumulator();
+    logs.forEach((log) => ingestLogSkillUsage(log, acc));
+    return finalizeSkillUsage(acc);
+};
+
+const framedFinalize = (logs: any[], viaJson = false) => {
+    const frames = logs.map((log) => {
+        const solo = createSkillUsageAccumulator();
+        ingestLogSkillUsage(log, solo);
+        const frame = extractSkillUsageFrame(solo);
+        return viaJson ? decodeState(JSON.parse(JSON.stringify(encodeState(frame)))) : frame;
+    });
+    const merged = createSkillUsageAccumulator();
+    frames.forEach((frame) => mergeSkillUsageFrame(merged, frame));
+    return finalizeSkillUsage(merged);
+};
+
+// Synthetic logs whose skill metadata for the SAME skill id disagrees across
+// logs. Real fixtures never disagree on icon/autoAttack/proc for a shared
+// skill id (only name occasionally differs), so a test built only on
+// fixtures cannot distinguish "last log wins" from "first log wins" for
+// those three maps. These synthetic logs make each map's winner observable
+// and order-dependent.
+const makeSyntheticLog = (id: string, opts: {
+    name: string;
+    icon: string;
+    autoAttack: boolean;
+    isTraitProc: boolean;
+}) => ({
+    id,
+    filePath: `${id}.zevtc`,
+    details: {
+        fightName: id,
+        durationMS: 1000,
+        timeStartStd: '2026-01-17T17:00:00.000Z',
+        skillMap: {
+            s100: { name: opts.name, icon: opts.icon, autoAttack: opts.autoAttack, isTraitProc: opts.isTraitProc },
+        },
+        players: [
+            {
+                account: 'acct.1234',
+                name: 'Acct',
+                profession: 'Guardian',
+                notInSquad: false,
+                activeTimes: [1000],
+                rotation: [{ id: 100, skills: [{ atTime: 0 }] }],
+            },
+        ],
+    },
+});
+
+const SYN_A = makeSyntheticLog('syn-a', { name: 'NameA', icon: 'iconA.png', autoAttack: true, isTraitProc: true });
+const SYN_B = makeSyntheticLog('syn-b', { name: 'NameB', icon: 'iconB.png', autoAttack: false, isTraitProc: false });
+
+describe('skill usage merge equivalence', () => {
+    it('reproduces the all-fights result from per-fight frames', () => {
+        expect(framedFinalize(LOGS)).toEqual(directFinalize(LOGS));
+    });
+
+    it('reproduces a two-fight subset', () => {
+        const subset = [LOGS[0], LOGS[2]];
+        expect(framedFinalize(subset)).toEqual(directFinalize(subset));
+    });
+
+    it('reproduces a single-fight slice', () => {
+        expect(framedFinalize([LOGS[1]])).toEqual(directFinalize([LOGS[1]]));
+    });
+
+    it('survives a JSON round trip through the state codec', () => {
+        expect(framedFinalize(LOGS, true)).toEqual(directFinalize(LOGS));
+    });
+
+    it('sums cast counts across the slice rather than returning empty state', () => {
+        const all = framedFinalize(LOGS);
+        const one = framedFinalize([LOGS[0]]);
+        expect(all.skillOptions.length).toBeGreaterThan(0);
+        expect(all.logRecords).toHaveLength(3);
+        expect(one.logRecords).toHaveLength(1);
+        const allTotal = all.skillOptions.reduce((sum, s) => sum + s.total, 0);
+        const oneTotal = one.skillOptions.reduce((sum, s) => sum + s.total, 0);
+        expect(allTotal).toBeGreaterThan(oneTotal);
+    });
+
+    it('refuses to export a frame from an accumulator holding more than one log record', () => {
+        const acc = createSkillUsageAccumulator();
+        LOGS.forEach((log) => ingestLogSkillUsage(log, acc));
+        expect(() => extractSkillUsageFrame(acc)).toThrow(/exactly one log/i);
+    });
+
+    it('matches direct ingest on conflicting synthetic metadata, in A-then-B order', () => {
+        const framed = framedFinalize([SYN_A, SYN_B]);
+        const direct = directFinalize([SYN_A, SYN_B]);
+        expect(framed).toEqual(direct);
+    });
+
+    it('matches direct ingest on conflicting synthetic metadata, in B-then-A order', () => {
+        const framed = framedFinalize([SYN_B, SYN_A]);
+        const direct = directFinalize([SYN_B, SYN_A]);
+        expect(framed).toEqual(direct);
+    });
+
+    it('pins last-log-wins for name and first-log-wins for icon/autoAttack/proc', () => {
+        const abResult = framedFinalize([SYN_A, SYN_B]);
+        const abSkill = abResult.skillOptions.find((s) => s.id === 's100')!;
+        // Name: B ingested last -> B's name wins.
+        expect(abSkill.name).toBe('NameB');
+        // Icon/autoAttack/proc: A ingested first -> A's values win.
+        expect(abSkill.icon).toBe('iconA.png');
+        expect(abSkill.autoAttack).toBe(true);
+        expect(abSkill.isTraitProc).toBe(true);
+
+        const baResult = framedFinalize([SYN_B, SYN_A]);
+        const baSkill = baResult.skillOptions.find((s) => s.id === 's100')!;
+        // Reversed order flips both rules, proving they are genuinely
+        // order-dependent rather than hardcoded to a particular log.
+        expect(baSkill.name).toBe('NameA');
+        expect(baSkill.icon).toBe('iconB.png');
+        expect(baSkill.autoAttack).toBe(false);
+        expect(baSkill.isTraitProc).toBe(false);
+    });
+});

--- a/src/renderer/stats/slice/__tests__/mergeSpikeDamage.test.ts
+++ b/src/renderer/stats/slice/__tests__/mergeSpikeDamage.test.ts
@@ -10,6 +10,7 @@ import { encodeState, decodeState } from '../stateCodec';
 import fixture1 from '../../../../../test-fixtures/native/20260117-175120.json';
 import fixture2 from '../../../../../test-fixtures/native/20260117-180135.json';
 import fixture3 from '../../../../../test-fixtures/native/20260117-180259.json';
+import { buildFrameLabelSeed, resolveFrameFightLabels } from '../frameLabels';
 
 const LOGS = [fixture1, fixture2, fixture3].map((details, i) => ({
     id: `log-${i}`,
@@ -35,7 +36,7 @@ const framedFinalize = (logs: any[], viaJson = false) => {
         return viaJson ? decodeState(JSON.parse(JSON.stringify(encodeState(frame)))) : frame;
     });
     const merged = createSpikeDamageAccumulator();
-    frames.forEach((frame) => mergeSpikeDamageFrame(merged, frame));
+    frames.forEach((frame, i) => mergeSpikeDamageFrame(merged, frame, resolveFrameFightLabels(buildFrameLabelSeed(logs[i]), i)));
     return finalizeSpikeDamage(merged);
 };
 

--- a/src/renderer/stats/slice/__tests__/mergeSpikeDamage.test.ts
+++ b/src/renderer/stats/slice/__tests__/mergeSpikeDamage.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from 'vitest';
+import {
+    createSpikeDamageAccumulator,
+    ingestLogSpikeDamage,
+    finalizeSpikeDamage,
+    extractSpikeDamageFrame,
+    mergeSpikeDamageFrame,
+} from '../../computeSpikeDamageData';
+import { encodeState, decodeState } from '../stateCodec';
+import fixture1 from '../../../../../test-fixtures/native/20260117-175120.json';
+import fixture2 from '../../../../../test-fixtures/native/20260117-180135.json';
+import fixture3 from '../../../../../test-fixtures/native/20260117-180259.json';
+
+const LOGS = [fixture1, fixture2, fixture3].map((details, i) => ({
+    id: `log-${i}`,
+    filePath: `test-${i}.zevtc`,
+    details,
+}));
+
+const OPTS = { splitPlayersByClass: false };
+
+/** finalize(ingest A; ingest B; ...) — the reference result. */
+const directFinalize = (logs: any[]) => {
+    const acc = createSpikeDamageAccumulator();
+    logs.forEach((log) => ingestLogSpikeDamage(log, acc, OPTS));
+    return finalizeSpikeDamage(acc);
+};
+
+/** finalize(merge(frame(A), frame(B), ...)) — the slice-mode result. */
+const framedFinalize = (logs: any[], viaJson = false) => {
+    const frames = logs.map((log) => {
+        const solo = createSpikeDamageAccumulator();
+        ingestLogSpikeDamage(log, solo, OPTS);
+        const frame = extractSpikeDamageFrame(solo);
+        return viaJson ? decodeState(JSON.parse(JSON.stringify(encodeState(frame)))) : frame;
+    });
+    const merged = createSpikeDamageAccumulator();
+    frames.forEach((frame) => mergeSpikeDamageFrame(merged, frame));
+    return finalizeSpikeDamage(merged);
+};
+
+describe('spike damage merge equivalence', () => {
+    it('reproduces the all-fights result from per-fight frames', () => {
+        expect(framedFinalize(LOGS)).toEqual(directFinalize(LOGS));
+    });
+
+    it('reproduces a two-fight subset', () => {
+        const subset = [LOGS[0], LOGS[2]];
+        expect(framedFinalize(subset)).toEqual(directFinalize(subset));
+    });
+
+    it('reproduces a single-fight slice', () => {
+        expect(framedFinalize([LOGS[1]])).toEqual(directFinalize([LOGS[1]]));
+    });
+
+    it('survives a JSON round trip through the state codec', () => {
+        expect(framedFinalize(LOGS, true)).toEqual(directFinalize(LOGS));
+    });
+
+    it('produces peak values that actually differ between subsets', () => {
+        // Guards a vacuous pass: if the fold were dropped entirely both sides
+        // would be equal-and-empty and every assertion above would still hold.
+        const all = framedFinalize(LOGS);
+        const one = framedFinalize([LOGS[0]]);
+        expect(all.players.length).toBeGreaterThan(0);
+        expect(all.players[0].peakHit).toBeGreaterThan(0);
+        expect(all.fights).toHaveLength(3);
+        expect(one.fights).toHaveLength(1);
+    });
+
+    it('refuses to export a frame from an accumulator holding more than one fight', () => {
+        const acc = createSpikeDamageAccumulator();
+        LOGS.forEach((log) => ingestLogSpikeDamage(log, acc, OPTS));
+        expect(() => extractSpikeDamageFrame(acc)).toThrow(/exactly one fight/i);
+    });
+});

--- a/src/renderer/stats/slice/__tests__/mergeStripSpikes.test.ts
+++ b/src/renderer/stats/slice/__tests__/mergeStripSpikes.test.ts
@@ -10,6 +10,7 @@ import { encodeState, decodeState } from '../stateCodec';
 import fixture1 from '../../../../../test-fixtures/native/20260117-175120.json';
 import fixture2 from '../../../../../test-fixtures/native/20260117-180135.json';
 import fixture3 from '../../../../../test-fixtures/native/20260117-180259.json';
+import { buildFrameLabelSeed, resolveFrameFightLabels } from '../frameLabels';
 
 const LOGS = [fixture1, fixture2, fixture3].map((details, i) => ({
     id: `log-${i}`,
@@ -33,7 +34,7 @@ const framedFinalize = (logs: any[], viaJson = false) => {
         return viaJson ? decodeState(JSON.parse(JSON.stringify(encodeState(frame)))) : frame;
     });
     const merged = createStripSpikesAccumulator();
-    frames.forEach((frame) => mergeStripSpikesFrame(merged, frame));
+    frames.forEach((frame, i) => mergeStripSpikesFrame(merged, frame, resolveFrameFightLabels(buildFrameLabelSeed(logs[i]), i)));
     return finalizeStripSpikes(merged);
 };
 

--- a/src/renderer/stats/slice/__tests__/mergeStripSpikes.test.ts
+++ b/src/renderer/stats/slice/__tests__/mergeStripSpikes.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from 'vitest';
+import {
+    createStripSpikesAccumulator,
+    ingestLogStripSpikes,
+    finalizeStripSpikes,
+    extractStripSpikesFrame,
+    mergeStripSpikesFrame,
+} from '../../computeStripSpikesData';
+import { encodeState, decodeState } from '../stateCodec';
+import fixture1 from '../../../../../test-fixtures/native/20260117-175120.json';
+import fixture2 from '../../../../../test-fixtures/native/20260117-180135.json';
+import fixture3 from '../../../../../test-fixtures/native/20260117-180259.json';
+
+const LOGS = [fixture1, fixture2, fixture3].map((details, i) => ({
+    id: `log-${i}`,
+    filePath: `test-${i}.zevtc`,
+    details,
+}));
+
+const OPTS = { splitPlayersByClass: false };
+
+const directFinalize = (logs: any[]) => {
+    const acc = createStripSpikesAccumulator();
+    logs.forEach((log) => ingestLogStripSpikes(log, acc, OPTS));
+    return finalizeStripSpikes(acc);
+};
+
+const framedFinalize = (logs: any[], viaJson = false) => {
+    const frames = logs.map((log) => {
+        const solo = createStripSpikesAccumulator();
+        ingestLogStripSpikes(log, solo, OPTS);
+        const frame = extractStripSpikesFrame(solo);
+        return viaJson ? decodeState(JSON.parse(JSON.stringify(encodeState(frame)))) : frame;
+    });
+    const merged = createStripSpikesAccumulator();
+    frames.forEach((frame) => mergeStripSpikesFrame(merged, frame));
+    return finalizeStripSpikes(merged);
+};
+
+describe('strip spikes merge equivalence', () => {
+    it('reproduces the all-fights result from per-fight frames', () => {
+        expect(framedFinalize(LOGS)).toEqual(directFinalize(LOGS));
+    });
+
+    it('reproduces a two-fight subset', () => {
+        const subset = [LOGS[0], LOGS[2]];
+        expect(framedFinalize(subset)).toEqual(directFinalize(subset));
+    });
+
+    it('reproduces a single-fight slice', () => {
+        expect(framedFinalize([LOGS[1]])).toEqual(directFinalize([LOGS[1]]));
+    });
+
+    it('survives a JSON round trip through the state codec', () => {
+        expect(framedFinalize(LOGS, true)).toEqual(directFinalize(LOGS));
+    });
+
+    it('sums strip totals across the slice rather than returning empty state', () => {
+        const all = framedFinalize(LOGS);
+        const one = framedFinalize([LOGS[0]]);
+        expect(all.players.length).toBeGreaterThan(0);
+        expect(all.fights).toHaveLength(3);
+        expect(one.fights).toHaveLength(1);
+        const allTotal = all.players.reduce((sum, p) => sum + p.totalStrips, 0);
+        const oneTotal = one.players.reduce((sum, p) => sum + p.totalStrips, 0);
+        expect(allTotal).toBeGreaterThan(oneTotal);
+    });
+
+    it('refuses to export a frame from an accumulator holding more than one fight', () => {
+        const acc = createStripSpikesAccumulator();
+        LOGS.forEach((log) => ingestLogStripSpikes(log, acc, OPTS));
+        expect(() => extractStripSpikesFrame(acc)).toThrow(/exactly one fight/i);
+    });
+});

--- a/src/renderer/stats/slice/__tests__/replaySlicing.test.ts
+++ b/src/renderer/stats/slice/__tests__/replaySlicing.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest';
+import { isReplayUnsliceable } from '../replaySlicing';
+
+describe('isReplayUnsliceable', () => {
+    it('is false with no slice active, whatever the replay looks like', () => {
+        expect(isReplayUnsliceable({ replayFights: [], excludedFightCount: 0 })).toBe(false);
+        expect(isReplayUnsliceable({ replayFights: undefined, excludedFightCount: 0 })).toBe(false);
+        expect(isReplayUnsliceable({ replayFights: [{ id: 1 }], excludedFightCount: 0 })).toBe(false);
+    });
+
+    /**
+     * M4: the published viewer's slice stats never carry `replayFights` (frames
+     * exclude replay payloads), so the replay falls through to a whole-session
+     * cache fetched from R2. Playing all seven fights next to a three-fight
+     * table, with nothing saying so, is the failure this guards.
+     */
+    it('is true when a slice is active and the aggregation carries no replay of its own', () => {
+        expect(isReplayUnsliceable({ replayFights: [], excludedFightCount: 1 })).toBe(true);
+        expect(isReplayUnsliceable({ replayFights: undefined, excludedFightCount: 1 })).toBe(true);
+        expect(isReplayUnsliceable({ replayFights: null, excludedFightCount: 3 })).toBe(true);
+    });
+
+    /**
+     * The narrowness matters as much as the guard: on the desktop, Phase A
+     * slices the logs before aggregation, so `replayFights` is already the
+     * subset. Hiding the replay there would be a regression, not a fix.
+     */
+    it('is false when the aggregation carries its own already-sliced replay', () => {
+        expect(isReplayUnsliceable({ replayFights: [{ id: 1 }], excludedFightCount: 2 })).toBe(false);
+    });
+});

--- a/src/renderer/stats/slice/__tests__/sliceBitmask.test.ts
+++ b/src/renderer/stats/slice/__tests__/sliceBitmask.test.ts
@@ -44,4 +44,21 @@ describe('sliceBitmask', () => {
     it('ignores ordinals outside the width when encoding', () => {
         expect(decodeSliceMask(encodeSliceMask([0, 99, -1], 3), 3)).toEqual([0]);
     });
+
+    it('rejects a token encoded at width 7 when decoded at width 8 (same-byte-bucket)', () => {
+        const token = encodeSliceMask([0, 2, 5], 7);
+        expect(decodeSliceMask(token, 8)).toBeNull();
+    });
+
+    it('rejects a token encoded at width 8 when decoded at width 7 (same-byte-bucket)', () => {
+        const token = encodeSliceMask([0, 2, 5], 8);
+        expect(decodeSliceMask(token, 7)).toBeNull();
+    });
+
+    it('empty slice rejects at neighboring width', () => {
+        const token7 = encodeSliceMask([], 7);
+        expect(decodeSliceMask(token7, 8)).toBeNull();
+        const token8 = encodeSliceMask([], 8);
+        expect(decodeSliceMask(token8, 7)).toBeNull();
+    });
 });

--- a/src/renderer/stats/slice/__tests__/sliceBitmask.test.ts
+++ b/src/renderer/stats/slice/__tests__/sliceBitmask.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest';
+import { encodeSliceMask, decodeSliceMask } from '../sliceBitmask';
+
+describe('sliceBitmask', () => {
+    it('round-trips a subset', () => {
+        const token = encodeSliceMask([0, 2, 5], 7);
+        expect(decodeSliceMask(token, 7)).toEqual([0, 2, 5]);
+    });
+
+    it('round-trips every fight included', () => {
+        const token = encodeSliceMask([0, 1, 2, 3, 4, 5, 6], 7);
+        expect(decodeSliceMask(token, 7)).toEqual([0, 1, 2, 3, 4, 5, 6]);
+    });
+
+    it('round-trips no fights included', () => {
+        expect(decodeSliceMask(encodeSliceMask([], 7), 7)).toEqual([]);
+    });
+
+    it('keeps fourteen fights inside three characters', () => {
+        expect(encodeSliceMask([0, 3, 13], 14).length).toBeLessThanOrEqual(3);
+    });
+
+    it('keeps sixty fights inside eleven characters', () => {
+        const all = Array.from({ length: 60 }, (_, i) => i);
+        expect(encodeSliceMask(all, 60).length).toBeLessThanOrEqual(11);
+    });
+
+    it('emits URL-safe characters only', () => {
+        const all = Array.from({ length: 60 }, (_, i) => i);
+        expect(encodeSliceMask(all, 60)).toMatch(/^[A-Za-z0-9_-]+$/);
+    });
+
+    it('rejects a token whose width disagrees with the roster', () => {
+        // A stale link must degrade to the truth, not to silently-wrong numbers.
+        const token = encodeSliceMask([0, 2], 7);
+        expect(decodeSliceMask(token, 9)).toBeNull();
+    });
+
+    it('rejects malformed input', () => {
+        expect(decodeSliceMask('!!!!', 7)).toBeNull();
+        expect(decodeSliceMask('', 7)).toBeNull();
+    });
+
+    it('ignores ordinals outside the width when encoding', () => {
+        expect(decodeSliceMask(encodeSliceMask([0, 99, -1], 3), 3)).toEqual([0]);
+    });
+});

--- a/src/renderer/stats/slice/__tests__/sliceSettingsHash.test.ts
+++ b/src/renderer/stats/slice/__tests__/sliceSettingsHash.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest';
+import { hashSliceSettings } from '../sliceSettingsHash';
+
+const halves = (digest: string) => {
+    const [high, low] = digest.split('-');
+    return { high: parseInt(high, 36), low: parseInt(low, 36) };
+};
+
+describe('hashSliceSettings', () => {
+    it('is stable across key insertion order', () => {
+        const a = hashSliceSettings(undefined, { splitPlayersByClass: true, showAll: false }, 'strips');
+        const b = hashSliceSettings(undefined, { showAll: false, splitPlayersByClass: true }, 'strips');
+        expect(a).toBe(b);
+    });
+
+    it('changes when any of the three settings changes', () => {
+        const base = hashSliceSettings(undefined, undefined, undefined);
+        expect(hashSliceSettings({ dps: 1 }, undefined, undefined)).not.toBe(base);
+        expect(hashSliceSettings(undefined, { splitPlayersByClass: true }, undefined)).not.toBe(base);
+        expect(hashSliceSettings(undefined, undefined, 'strips')).not.toBe(base);
+    });
+
+    /**
+     * The two halves must come from structurally different mixers, not one
+     * recurrence under two seeds.
+     *
+     * `h = h*31 + c` is affine in its seed: after n characters
+     * `h_seed(s) = h_0(s) + seed * 31^n (mod 2^32)`. So for any two inputs of
+     * EQUAL LENGTH the seed term cancels and `high(s) - low(s)` is the same
+     * constant `seed * 31^n` for both — the second digest carries no
+     * information the first does not, and every equal-length collision under
+     * one half is a collision under the other. Two inputs of equal canonical
+     * length with a differing half-difference prove the mixers are not related
+     * that way.
+     */
+    it('derives its two halves from mixers that are not seed-shifts of each other', () => {
+        const a = hashSliceSettings(undefined, undefined, 'aaa');
+        const b = hashSliceSettings(undefined, undefined, 'bbb');
+        // Precondition: the canonical strings really are the same length, or
+        // the affine cancellation above would not apply and the assertion
+        // below would pass vacuously.
+        expect(JSON.stringify({ disruptionMethod: 'aaa', mvpWeights: undefined, statsViewSettings: undefined }).length)
+            .toBe(JSON.stringify({ disruptionMethod: 'bbb', mvpWeights: undefined, statsViewSettings: undefined }).length);
+        const ha = halves(a);
+        const hb = halves(b);
+        const diff = (h: { high: number; low: number }) => (h.high - h.low) >>> 0;
+        expect(diff(ha)).not.toBe(diff(hb));
+    });
+});

--- a/src/renderer/stats/slice/__tests__/sliceSidecar.test.ts
+++ b/src/renderer/stats/slice/__tests__/sliceSidecar.test.ts
@@ -4,6 +4,7 @@ import { resolve } from 'node:path';
 import { computeStatsSync } from '../../incrementalAggregation';
 import { buildSliceSidecar } from '../buildSliceSidecar';
 import { mergeSliceFrames, SliceSettingsMismatchError } from '../mergeSliceFrames';
+import { hashSliceSettings } from '../sliceSettingsHash';
 import { statsLogKey } from '../../utils/statsLogKey';
 import { SLICE_SIDECAR_VERSION } from '../sliceTypes';
 
@@ -90,6 +91,34 @@ describe('slice sidecar', () => {
             const merged = mergeSliceFrames({ sidecar: out, includedOrdinals: ordinals, ...SETTINGS }).stats;
             expect(comparable(merged)).toEqual(comparable(direct));
         });
+    });
+
+    /**
+     * Every other equivalence assertion in this file runs under the
+     * all-`undefined` settings triple, which is also the triple that produces
+     * the aggregator's internal defaults — so a merge path that silently
+     * ignored `settings` entirely would pass all of them. This one merges
+     * under a NON-default triple (`splitPlayersByClass: true`, which changes
+     * the player row identity, plus `disruptionMethod: 'duration'`, which
+     * changes how disruption is scored) and demands the same exact equality
+     * against a direct `computeStatsSync` run under those same settings.
+     */
+    it('reproduces a subset exactly under a non-default settings triple', () => {
+        const custom = {
+            mvpWeights: undefined,
+            statsViewSettings: { splitPlayersByClass: true } as any,
+            disruptionMethod: 'duration' as any,
+        };
+        const out = JSON.parse(JSON.stringify(
+            buildSliceSidecar({ logs: LOGS, roster: ROSTER, ...custom }),
+        ));
+        expect(out.settingsHash).toBe(
+            hashSliceSettings(custom.mvpWeights, custom.statsViewSettings, custom.disruptionMethod),
+        );
+        const ordinals = [1, 3, 5];
+        const direct = computeStatsSync({ logs: ordinals.map((i) => LOGS[i]), ...custom }).stats;
+        const merged = mergeSliceFrames({ sidecar: out, includedOrdinals: ordinals, ...custom }).stats;
+        expect(comparable(merged)).toEqual(comparable(direct));
     });
 
     it('reproduces a single-fight slice', () => {

--- a/src/renderer/stats/slice/__tests__/sliceSidecar.test.ts
+++ b/src/renderer/stats/slice/__tests__/sliceSidecar.test.ts
@@ -33,6 +33,21 @@ const ROSTER = LOGS.map((log, i) => ({
     duration: '1:00',
 }));
 
+/**
+ * `computeStabPerformance`'s sibling `combatMetrics` writes `stabGeneration`
+ * back onto `details.players` as a side effect of player aggregation, and
+ * `ingestLogFightDiffMode` reads it — but ingest calls the diff-mode reader
+ * BEFORE player aggregation, so the very first pass over a given `details`
+ * object reports 0 squad stability and every later pass reports the real
+ * number. `LOGS` is a module-level array shared by every aggregation in this
+ * file, so whichever comparison ran first would win — and running any single
+ * test in isolation (`-t`, `.only`, sharding) would make it the "first" pass
+ * and fail. Matches `aggregatorFrames.test.ts`: warm the fixtures once up
+ * front so both sides of every comparison read the same input regardless of
+ * run order.
+ */
+computeStatsSync({ logs: LOGS });
+
 const SETTINGS = { mvpWeights: undefined, statsViewSettings: undefined, disruptionMethod: undefined };
 
 const sidecar = () => buildSliceSidecar({ logs: LOGS, roster: ROSTER, ...SETTINGS });
@@ -105,6 +120,34 @@ describe('slice sidecar', () => {
         expect(comparable(merged)).toEqual(comparable(direct));
     });
 
+    // The three tests above document intended behaviour, but none of them
+    // actually PROVES the range/integer filter in `mergeSliceFrames.ts` does
+    // anything: `frames[-1]`, `frames[1.5]`, `frames[NaN]` and `frames[99]`
+    // are all `undefined` in JS, so the `if (frame)` fallback that already
+    // exists absorbs every one of those cases with or without the filter.
+    // (Review round 1, finding 1 — confirmed by deleting the filter and
+    // re-running the file: all three still passed.)
+    //
+    // The filter's actual, distinguishing job is rejecting a *non-number*
+    // ordinal such as the string `'2'`. JS array indexing coerces a numeric
+    // string key, so `sidecar.frames['2']` resolves to the exact same
+    // element as `sidecar.frames[2]` — `if (frame)` alone would happily
+    // merge it. `Number.isInteger('2')` is `false` (it rejects non-`number`
+    // types outright, no coercion), so the filter drops it. This is the one
+    // case where deleting the filter changes the result, which is what makes
+    // it an actual pin rather than a decoration.
+    it('rejects a non-numeric ordinal instead of resolving it via array string-key coercion', () => {
+        const out = JSON.parse(JSON.stringify(sidecar()));
+        const merged = mergeSliceFrames({ sidecar: out, includedOrdinals: ['2', '2'] as any, ...SETTINGS }).stats;
+        // With the filter: both copies of '2' are dropped (not integers) ->
+        // zero fights merged. Without the filter: dedup collapses the two
+        // '2's to one, `frames['2']` resolves to frame 2, and it merges ->
+        // the single-fight-2 result. These two outcomes are different, so
+        // this assertion distinguishes "filter present" from "filter absent".
+        const direct = computeStatsSync({ logs: [] }).stats;
+        expect(comparable(merged)).toEqual(comparable(direct));
+    });
+
     it('dedupes a duplicated ordinal instead of double-merging it', () => {
         const out = JSON.parse(JSON.stringify(sidecar()));
         const merged = mergeSliceFrames({ sidecar: out, includedOrdinals: [2, 2, 2], ...SETTINGS }).stats;
@@ -138,5 +181,32 @@ describe('slice sidecar', () => {
         const customSettings = { mvpWeights: undefined, statsViewSettings: { splitPlayersByClass: true }, disruptionMethod: undefined };
         const out = JSON.parse(JSON.stringify(buildSliceSidecar({ logs: LOGS, roster: ROSTER, ...customSettings })));
         expect(() => mergeSliceFrames({ sidecar: out, includedOrdinals: [0], ...customSettings })).not.toThrow();
+    });
+
+    it('builds an empty sidecar from an empty log list instead of throwing', () => {
+        const out = buildSliceSidecar({ logs: [], roster: [], ...SETTINGS });
+        expect(out.fights).toEqual([]);
+        expect(out.frames).toEqual([]);
+        const revived = JSON.parse(JSON.stringify(out));
+        expect(() => mergeSliceFrames({ sidecar: revived, includedOrdinals: [0], ...SETTINGS })).not.toThrow();
+        const merged = mergeSliceFrames({ sidecar: revived, includedOrdinals: [0], ...SETTINGS }).stats;
+        const direct = computeStatsSync({ logs: [] }).stats;
+        expect(comparable(merged)).toEqual(comparable(direct));
+    });
+
+    it('does not throw building or merging an unparseable log', () => {
+        const brokenLogs = [{ id: 'broken-0', filePath: 'broken-0.zevtc', details: null }];
+        const brokenRoster = brokenLogs.map((log, i) => ({
+            id: statsLogKey(log, i),
+            label: 'Fight 1',
+            timestamp: i + 1,
+            duration: '--:--',
+        }));
+        let out: ReturnType<typeof buildSliceSidecar> | undefined;
+        expect(() => { out = buildSliceSidecar({ logs: brokenLogs, roster: brokenRoster, ...SETTINGS }); }).not.toThrow();
+        expect(out!.fights).toHaveLength(1);
+        expect(out!.frames).toHaveLength(1);
+        const revived = JSON.parse(JSON.stringify(out));
+        expect(() => mergeSliceFrames({ sidecar: revived, includedOrdinals: [0], ...SETTINGS })).not.toThrow();
     });
 });

--- a/src/renderer/stats/slice/__tests__/sliceSidecar.test.ts
+++ b/src/renderer/stats/slice/__tests__/sliceSidecar.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { computeStatsSync } from '../../incrementalAggregation';
+import { buildSliceSidecar } from '../buildSliceSidecar';
+import { mergeSliceFrames, SliceSettingsMismatchError } from '../mergeSliceFrames';
+import { statsLogKey } from '../../utils/statsLogKey';
+import { SLICE_SIDECAR_VERSION } from '../sliceTypes';
+
+/**
+ * Read at runtime rather than `import`ed: a static import of these fixtures
+ * gives `tsc --noEmit` a multi-megabyte structural literal to infer, and all
+ * seven of them together (~31 MB) push `npm run typecheck` past its 8 GB
+ * heap. See `aggregatorFrames.test.ts` for the same pattern.
+ */
+const fixture = (name: string) => JSON.parse(
+    readFileSync(resolve(process.cwd(), `test-fixtures/native/${name}.json`), 'utf8'),
+);
+
+const LOGS = [
+    '20260117-175120', '20260117-180135', '20260117-180259', '20260117-180458',
+    '20260117-180636', '20260117-180826', '20260117-181030',
+].map(fixture).map((details, i) => ({
+    id: `log-${i}`,
+    filePath: `test-${i}.zevtc`,
+    details,
+}));
+
+const ROSTER = LOGS.map((log, i) => ({
+    id: statsLogKey(log, i),
+    label: `Fight ${i + 1}`,
+    timestamp: i + 1,
+    duration: '1:00',
+}));
+
+const SETTINGS = { mvpWeights: undefined, statsViewSettings: undefined, disruptionMethod: undefined };
+
+const sidecar = () => buildSliceSidecar({ logs: LOGS, roster: ROSTER, ...SETTINGS });
+
+const comparable = (stats: any) => {
+    const { replayFights, ...rest } = stats || {};
+    return rest;
+};
+
+describe('slice sidecar', () => {
+    it('emits one frame per roster fight, in roster order', () => {
+        const out = sidecar();
+        expect(out.version).toBe(SLICE_SIDECAR_VERSION);
+        expect(out.fights).toHaveLength(7);
+        expect(out.frames).toHaveLength(7);
+        expect(out.fights.map((f) => f.id)).toEqual(ROSTER.map((f) => f.id));
+    });
+
+    it('records a settings hash', () => {
+        expect(typeof sidecar().settingsHash).toBe('string');
+        expect(sidecar().settingsHash.length).toBeGreaterThan(0);
+    });
+
+    it('serializes to JSON without losing Map state', () => {
+        const revived = JSON.parse(JSON.stringify(sidecar()));
+        const direct = computeStatsSync({ logs: LOGS }).stats;
+        const merged = mergeSliceFrames({
+            sidecar: revived,
+            includedOrdinals: [0, 1, 2, 3, 4, 5, 6],
+            ...SETTINGS,
+        }).stats;
+        expect(comparable(merged)).toEqual(comparable(direct));
+    });
+
+    it('reproduces every three-fight subset exactly', () => {
+        const out = JSON.parse(JSON.stringify(sidecar()));
+        const subsets = [[0, 1, 2], [0, 3, 6], [4, 5, 6], [1, 3, 5]];
+        subsets.forEach((ordinals) => {
+            const direct = computeStatsSync({ logs: ordinals.map((i) => LOGS[i]) }).stats;
+            const merged = mergeSliceFrames({ sidecar: out, includedOrdinals: ordinals, ...SETTINGS }).stats;
+            expect(comparable(merged)).toEqual(comparable(direct));
+        });
+    });
+
+    it('reproduces a single-fight slice', () => {
+        const out = JSON.parse(JSON.stringify(sidecar()));
+        const direct = computeStatsSync({ logs: [LOGS[3]] }).stats;
+        const merged = mergeSliceFrames({ sidecar: out, includedOrdinals: [3], ...SETTINGS }).stats;
+        expect(comparable(merged)).toEqual(comparable(direct));
+    });
+
+    it('ignores ordinals outside the frame range instead of throwing', () => {
+        const out = JSON.parse(JSON.stringify(sidecar()));
+        const merged = mergeSliceFrames({ sidecar: out, includedOrdinals: [0, 99], ...SETTINGS }).stats;
+        const direct = computeStatsSync({ logs: [LOGS[0]] }).stats;
+        expect(comparable(merged)).toEqual(comparable(direct));
+    });
+
+    it('ignores negative ordinals', () => {
+        const out = JSON.parse(JSON.stringify(sidecar()));
+        const merged = mergeSliceFrames({ sidecar: out, includedOrdinals: [-1, 2], ...SETTINGS }).stats;
+        const direct = computeStatsSync({ logs: [LOGS[2]] }).stats;
+        expect(comparable(merged)).toEqual(comparable(direct));
+    });
+
+    it('ignores non-integer ordinals', () => {
+        const out = JSON.parse(JSON.stringify(sidecar()));
+        const merged = mergeSliceFrames({ sidecar: out, includedOrdinals: [1.5, NaN, 2], ...SETTINGS }).stats;
+        const direct = computeStatsSync({ logs: [LOGS[2]] }).stats;
+        expect(comparable(merged)).toEqual(comparable(direct));
+    });
+
+    it('dedupes a duplicated ordinal instead of double-merging it', () => {
+        const out = JSON.parse(JSON.stringify(sidecar()));
+        const merged = mergeSliceFrames({ sidecar: out, includedOrdinals: [2, 2, 2], ...SETTINGS }).stats;
+        const direct = computeStatsSync({ logs: [LOGS[2]] }).stats;
+        // If dedup did not run, fight 2 would be merged three times, and squad
+        // totals (e.g. wins/losses/kill counts) would be triple-counted against
+        // a single-fight direct computation — this assertion bites on that.
+        expect(comparable(merged)).toEqual(comparable(direct));
+    });
+
+    it('produces a zero-fight result for an empty selection instead of throwing', () => {
+        const out = JSON.parse(JSON.stringify(sidecar()));
+        expect(() => mergeSliceFrames({ sidecar: out, includedOrdinals: [], ...SETTINGS })).not.toThrow();
+        const merged = mergeSliceFrames({ sidecar: out, includedOrdinals: [], ...SETTINGS }).stats;
+        const direct = computeStatsSync({ logs: [] }).stats;
+        expect(comparable(merged)).toEqual(comparable(direct));
+    });
+
+    it('refuses to slice when settingsHash does not match the viewer settings', () => {
+        const out = JSON.parse(JSON.stringify(sidecar()));
+        expect(() => mergeSliceFrames({
+            sidecar: out,
+            includedOrdinals: [0, 1, 2],
+            mvpWeights: undefined,
+            statsViewSettings: { splitPlayersByClass: true },
+            disruptionMethod: undefined,
+        })).toThrow(SliceSettingsMismatchError);
+    });
+
+    it('accepts a matching settingsHash under non-default settings', () => {
+        const customSettings = { mvpWeights: undefined, statsViewSettings: { splitPlayersByClass: true }, disruptionMethod: undefined };
+        const out = JSON.parse(JSON.stringify(buildSliceSidecar({ logs: LOGS, roster: ROSTER, ...customSettings })));
+        expect(() => mergeSliceFrames({ sidecar: out, includedOrdinals: [0], ...customSettings })).not.toThrow();
+    });
+});

--- a/src/renderer/stats/slice/__tests__/sliceSidecarSize.test.ts
+++ b/src/renderer/stats/slice/__tests__/sliceSidecarSize.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from 'vitest';
+import { gzipSync } from 'node:zlib';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { buildSliceSidecar } from '../buildSliceSidecar';
+import { statsLogKey } from '../../utils/statsLogKey';
+
+/**
+ * Read at runtime rather than `import`ed: a static import of these fixtures
+ * gives `tsc --noEmit` a multi-megabyte structural literal to infer, and all
+ * seven of them together (~31 MB) push `npm run typecheck` past its 8 GB
+ * heap. See `sliceSidecar.test.ts`/`aggregatorFrames.test.ts` for the same
+ * pattern — confirmed here by reproducing the OOM with a static-import
+ * version of this file and removing it.
+ */
+const fixture = (name: string) => JSON.parse(
+    readFileSync(resolve(process.cwd(), `test-fixtures/native/${name}.json`), 'utf8'),
+);
+
+const LOGS = [
+    '20260117-175120', '20260117-180135', '20260117-180259', '20260117-180458',
+    '20260117-180636', '20260117-180826', '20260117-181030',
+].map(fixture).map((details, i) => ({
+    id: `log-${i}`,
+    filePath: `test-${i}.zevtc`,
+    details,
+}));
+
+/**
+ * The sidecar's whole reason to exist is that it stays small enough to live on
+ * a free R2 tier. Measured 2026-08-22 on this same 7-fight fixture series:
+ * ~268 KB/fight average, largest single frame ~360 KB gz (37-42 player
+ * rosters). That is above the spec's original ~124 KB/fight aspiration but
+ * nowhere near "a section started carrying raw log details" territory — that
+ * failure mode reads in the MEGABYTES per frame, not hundreds of KB. The
+ * binding cost here is the viewer's tray-open fetch (one gzip download), not
+ * R2 storage, so 400 KB/fight is generous headroom without being a blank
+ * check: a section ballooning to raw `details`/replay-track size would still
+ * blow through it by 10x+.
+ *
+ * A per-section breakdown (see task-15-report.md) found `playerAcc` (~27%)
+ * and `boonTableLogs` (~18%) are the two largest sections, matching Task 12's
+ * prior measurement. Inside `boonTableLogs`, the `native.blocks.boons` payload
+ * carries full per-source state-transition tracks and `.states`/`.uptime_pct`
+ * that `buildBoonTables` never reads (it only reads `.generation.*`) — a
+ * proposed, NOT yet implemented, trim that would cut that payload by ~78%.
+ * See the task-15 report for the numbers; this budget is set independent of
+ * that trim landing.
+ *
+ * If this fails: something now serializes `details` (or a replay track) into a
+ * frame. Find it and narrow the projection. Do NOT raise the budget.
+ */
+const MAX_GZIPPED_BYTES_PER_FIGHT = 400 * 1024;
+
+const ROSTER = LOGS.map((log, i) => ({
+    id: statsLogKey(log, i),
+    label: `Fight ${i + 1}`,
+    timestamp: i + 1,
+    duration: '1:00',
+}));
+
+describe('slice sidecar size', () => {
+    it('stays inside the per-fight gzipped budget', () => {
+        const sidecar = buildSliceSidecar({
+            logs: LOGS, roster: ROSTER,
+            mvpWeights: undefined, statsViewSettings: undefined, disruptionMethod: undefined,
+        });
+        const gzipped = gzipSync(Buffer.from(JSON.stringify(sidecar), 'utf8'), { level: 9 });
+        const perFight = gzipped.length / sidecar.frames.length;
+        // Logged so a regression report carries the number, not just a boolean.
+        console.info(`[slice] ${(gzipped.length / 1024).toFixed(0)} KB gzipped, ${(perFight / 1024).toFixed(0)} KB/fight`);
+        expect(perFight).toBeLessThan(MAX_GZIPPED_BYTES_PER_FIGHT);
+    });
+
+    it('carries no replay tracks', () => {
+        const sidecar = buildSliceSidecar({
+            logs: LOGS, roster: ROSTER,
+            mvpWeights: undefined, statsViewSettings: undefined, disruptionMethod: undefined,
+        });
+        const json = JSON.stringify(sidecar);
+        expect(json).not.toContain('replayFights');
+        expect(json).not.toContain('"tracks"');
+    });
+});

--- a/src/renderer/stats/slice/__tests__/sliceSidecarSize.test.ts
+++ b/src/renderer/stats/slice/__tests__/sliceSidecarSize.test.ts
@@ -31,12 +31,19 @@ const LOGS = [
  * a free R2 tier. Measured 2026-08-22 on this same 7-fight fixture series:
  * ~268 KB/fight average, largest single frame ~360 KB gz (37-42 player
  * rosters). That is above the spec's original ~124 KB/fight aspiration but
- * nowhere near "a section started carrying raw log details" territory — that
- * failure mode reads in the MEGABYTES per frame, not hundreds of KB. The
- * binding cost here is the viewer's tray-open fetch (one gzip download), not
- * R2 storage, so 400 KB/fight is generous headroom without being a blank
- * check: a section ballooning to raw `details`/replay-track size would still
- * blow through it by 10x+.
+ * nowhere near a raw-`details` leak, which reads in the MEGABYTES per frame
+ * (901 KB/fight measured leaking `log.details` wholesale into a frame — a
+ * 2.25x trip of this budget) rather than hundreds of KB. The binding cost
+ * here is the viewer's tray-open fetch (one gzip download), not R2 storage,
+ * so 400 KB/fight is generous headroom without being a blank check for that
+ * failure mode.
+ *
+ * What this assertion does NOT catch: a narrower leak, such as the frame's
+ * own replay track (`this.replayPayloads`), only moved the measured total
+ * from 268 to 316 KB/fight — still comfortably under 400 KB. That leak is
+ * caught by the sibling "carries no replay tracks" test below, via a
+ * substring check, not by size. Size and content are complementary guards;
+ * neither alone is sufficient.
  *
  * A per-section breakdown (see task-15-report.md) found `playerAcc` (~27%)
  * and `boonTableLogs` (~18%) are the two largest sections, matching Task 12's
@@ -47,8 +54,9 @@ const LOGS = [
  * See the task-15 report for the numbers; this budget is set independent of
  * that trim landing.
  *
- * If this fails: something now serializes `details` (or a replay track) into a
- * frame. Find it and narrow the projection. Do NOT raise the budget.
+ * If this fails: something now serializes `details` (or a large amount of
+ * replay-scale data) into a frame. Find it and narrow the projection. Do NOT
+ * raise the budget.
  */
 const MAX_GZIPPED_BYTES_PER_FIGHT = 400 * 1024;
 

--- a/src/renderer/stats/slice/__tests__/stateCodec.test.ts
+++ b/src/renderer/stats/slice/__tests__/stateCodec.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest';
+import { encodeState, decodeState } from '../stateCodec';
+
+const roundTrip = (value: unknown) => decodeState(JSON.parse(JSON.stringify(encodeState(value))));
+
+describe('stateCodec', () => {
+    it('round-trips a Map through JSON', () => {
+        const value = new Map<string, number>([['a', 1], ['b', 2]]);
+        const out = roundTrip(value);
+        expect(out).toBeInstanceOf(Map);
+        expect([...out.entries()]).toEqual([['a', 1], ['b', 2]]);
+    });
+
+    it('round-trips a Set through JSON', () => {
+        const out = roundTrip(new Set(['d1', 'd2']));
+        expect(out).toBeInstanceOf(Set);
+        expect([...out]).toEqual(['d1', 'd2']);
+    });
+
+    it('round-trips Maps nested inside Maps, arrays and plain objects', () => {
+        const value = {
+            buckets: new Map([['b1', { players: new Map([['acct', { n: 3 }]]), fights: [1, 2] }]]),
+            rows: [new Map([['k', 'v']])],
+        };
+        const out = roundTrip(value);
+        expect(out.buckets.get('b1').players.get('acct')).toEqual({ n: 3 });
+        expect(out.buckets.get('b1').fights).toEqual([1, 2]);
+        expect(out.rows[0].get('k')).toBe('v');
+    });
+
+    it('preserves numeric Map keys, which JSON object keys would stringify', () => {
+        const out = roundTrip(new Map<number, string>([[42, 'x']]));
+        expect(out.get(42)).toBe('x');
+        expect(out.get('42')).toBeUndefined();
+    });
+
+    it('leaves plain values untouched', () => {
+        expect(roundTrip({ a: 1, b: 'two', c: null, d: [1, 2], e: true })).toEqual({
+            a: 1, b: 'two', c: null, d: [1, 2], e: true,
+        });
+    });
+
+    it('does not mistake a plain object that happens to have a __map key for an encoded Map', () => {
+        // Guards a real collision: skill maps are keyed by arbitrary strings.
+        const out = roundTrip({ __map: 'not an array' });
+        expect(out).toEqual({ __map: 'not an array' });
+    });
+});

--- a/src/renderer/stats/slice/__tests__/workerMergeFrames.test.ts
+++ b/src/renderer/stats/slice/__tests__/workerMergeFrames.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { IncrementalAggregator, computeStatsSync } from '../../incrementalAggregation';
+import f1 from '../../../../../test-fixtures/native/20260117-175120.json';
+import f2 from '../../../../../test-fixtures/native/20260117-180135.json';
+
+const LOGS = [f1, f2].map((details, i) => ({ id: `log-${i}`, filePath: `t-${i}.zevtc`, details }));
+
+// Warm-up: first pass over shared fixtures mutates players, so we need to initialize
+// the fixture state before running any comparisons.
+computeStatsSync({ logs: LOGS });
+
+const frames = () => LOGS.map((log) => {
+    const solo = new IncrementalAggregator();
+    solo.ingestLog(log);
+    return JSON.parse(JSON.stringify(solo.exportFrame()));
+});
+
+const comparable = (stats: any) => {
+    const { replayFights, ...rest } = stats || {};
+    // Strip undefined values since JSON serialization (frame round-trip) drops them,
+    // but the direct path may have them set explicitly. Both paths are valid and
+    // indistinguishable in the published artifact.
+    const stripUndefined = (obj: any): any => {
+        if (obj === null || typeof obj !== 'object') return obj;
+        if (Array.isArray(obj)) return obj.map(stripUndefined);
+        const result: any = {};
+        for (const [k, v] of Object.entries(obj)) {
+            if (v !== undefined) {
+                result[k] = stripUndefined(v);
+            }
+        }
+        return result;
+    };
+    // Strip skillRows and skillMap like the worker does for transfer
+    const stripHeavyData = (stats: any): any => {
+        if (!stats || typeof stats !== 'object') return stats;
+        const result = stripUndefined(stats);
+        // Remove skillRows from spike/incoming fights like computeAndPost does
+        const stripRowsFromFights = (dataset: any) => {
+            const fights = Array.isArray(dataset?.fights) ? dataset.fights : [];
+            fights.forEach((fight: any) => {
+                if (!fight || typeof fight !== 'object') return;
+                const values = fight.values;
+                if (!values || typeof values !== 'object') return;
+                Object.values(values).forEach((entry: any) => {
+                    if (!entry || typeof entry !== 'object') return;
+                    if (Array.isArray(entry.skillRows)) {
+                        delete entry.skillRows;
+                    }
+                });
+            });
+        };
+        stripRowsFromFights(result.spikeDamage);
+        stripRowsFromFights(result.incomingStrikeDamage);
+        // Remove skillMap from player skill breakdowns
+        const playerSkillBreakdowns = Array.isArray(result.playerSkillBreakdowns) ? result.playerSkillBreakdowns : [];
+        playerSkillBreakdowns.forEach((entry: any) => {
+            if (!entry || typeof entry !== 'object') return;
+            if (entry.skillMap && typeof entry.skillMap === 'object') {
+                delete entry.skillMap;
+            }
+        });
+        return result;
+    };
+    return stripHeavyData(rest);
+};
+
+describe('statsWorker mergeFrames', () => {
+    let posted: any[];
+
+    beforeEach(async () => {
+        posted = [];
+        vi.stubGlobal('self', {
+            postMessage: (msg: any) => posted.push(msg),
+            onmessage: null as any,
+        });
+        vi.stubGlobal('performance', { now: () => 0 });
+        vi.resetModules();
+        await import('../../../workers/statsWorker');
+    });
+
+    const send = (data: any) => (globalThis as any).self.onmessage({ data } as MessageEvent);
+
+    it('posts a result whose stats match a direct aggregation over the same logs', () => {
+        send({ type: 'mergeFrames', token: 0, frames: frames(), settings: {} });
+        const result = posted.find((m) => m.type === 'result');
+        expect(result).toBeTruthy();
+        expect(comparable(result.result.stats)).toEqual(comparable(computeStatsSync({ logs: LOGS }).stats));
+    });
+
+    it('posts a result for a single-frame slice', () => {
+        send({ type: 'mergeFrames', token: 0, frames: [frames()[1]], settings: {} });
+        const result = posted.find((m) => m.type === 'result');
+        expect(comparable(result.result.stats)).toEqual(comparable(computeStatsSync({ logs: [LOGS[1]] }).stats));
+    });
+
+    it('posts a null-stats result for an empty selection rather than throwing', () => {
+        send({ type: 'mergeFrames', token: 0, frames: [], settings: {} });
+        const result = posted.find((m) => m.type === 'result');
+        expect(result).toBeTruthy();
+    });
+
+    it('ignores a mergeFrames message carrying a stale token', () => {
+        send({ type: 'reset', token: 7, totalLogs: 0 });
+        posted.length = 0;
+        send({ type: 'mergeFrames', token: 3, frames: frames(), settings: {} });
+        expect(posted.find((m) => m.type === 'result')).toBeUndefined();
+    });
+});

--- a/src/renderer/stats/slice/__tests__/workerMergeFrames.test.ts
+++ b/src/renderer/stats/slice/__tests__/workerMergeFrames.test.ts
@@ -1,9 +1,23 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
 import { IncrementalAggregator, computeStatsSync } from '../../incrementalAggregation';
-import f1 from '../../../../../test-fixtures/native/20260117-175120.json';
-import f2 from '../../../../../test-fixtures/native/20260117-180135.json';
 
-const LOGS = [f1, f2].map((details, i) => ({ id: `log-${i}`, filePath: `t-${i}.zevtc`, details }));
+/**
+ * Read at runtime rather than `import`ed: a static import hands
+ * `tsc --noEmit` a multi-megabyte structural literal to infer, and these two
+ * fixtures alone are 6.3 MB. Enough of them together push `npm run typecheck`
+ * past its 8 GB heap (ledgered in Task 10). Every sibling slice test —
+ * `sliceSidecar.test.ts`, `sliceSidecarSize.test.ts`, `aggregatorFrames.test.ts`
+ * — uses this pattern for the same reason.
+ */
+const fixture = (name: string) => JSON.parse(
+    readFileSync(resolve(process.cwd(), `test-fixtures/native/${name}.json`), 'utf8'),
+);
+
+const LOGS = ['20260117-175120', '20260117-180135']
+    .map(fixture)
+    .map((details, i) => ({ id: `log-${i}`, filePath: `t-${i}.zevtc`, details }));
 
 // Warm-up: first pass over shared fixtures mutates players, so we need to initialize
 // the fixture state before running any comparisons.
@@ -94,10 +108,39 @@ describe('statsWorker mergeFrames', () => {
         expect(comparable(result.result.stats)).toEqual(comparable(computeStatsSync({ logs: [LOGS[1]] }).stats));
     });
 
-    it('posts a null-stats result for an empty selection rather than throwing', () => {
+    /**
+     * C2: an empty selection is a real zero-fight slice, not an error and not
+     * "no slice". The viewer renders whatever comes back here, so it has to be
+     * the genuine empty aggregation — the same thing a report with no logs
+     * shows — rather than a null the caller would replace with the full report.
+     */
+    it('posts the real zero-fight aggregation for an empty selection', () => {
         send({ type: 'mergeFrames', token: 0, frames: [], settings: {} });
         const result = posted.find((m) => m.type === 'result');
         expect(result).toBeTruthy();
+        expect(result.result.stats).toBeTruthy();
+        expect(comparable(result.result.stats)).toEqual(comparable(computeStatsSync({ logs: [] }).stats));
+    });
+
+    /**
+     * C1: `mergeFrame` has several reachable throw sites and this worker is the
+     * only thing between them and the published viewer. Posting nothing on a
+     * throw leaves the viewer's `computing` flag stuck true and its slice stats
+     * null forever — which renders as the FULL report under a "Sliced view — N
+     * of M fights" banner, with no error anywhere. An explicit `error` reply,
+     * carrying the token so the viewer can match it to its request, is what
+     * lets the viewer say the slice is unavailable instead.
+     */
+    it('posts an error carrying the current token when a frame fails to merge', () => {
+        send({ type: 'reset', token: 4, totalLogs: 0 });
+        posted.length = 0;
+        const exploding = new Proxy({}, { get() { throw new Error('frame is not mergeable'); } });
+        expect(() => send({ type: 'mergeFrames', token: 4, frames: [exploding], settings: {} })).not.toThrow();
+        const error = posted.find((m) => m.type === 'error');
+        expect(error).toBeTruthy();
+        expect(error.token).toBe(4);
+        expect(error.message).toMatch(/not mergeable/);
+        expect(posted.find((m) => m.type === 'result')).toBeUndefined();
     });
 
     it('ignores a mergeFrames message carrying a stale token', () => {

--- a/src/renderer/stats/slice/buildSliceSidecar.ts
+++ b/src/renderer/stats/slice/buildSliceSidecar.ts
@@ -1,6 +1,7 @@
 import { IncrementalAggregator } from '../incrementalAggregation';
-import { hashAggregationSettings, type FightRosterEntry } from '../statsStore';
+import type { FightRosterEntry } from '../statsStore';
 import { statsLogKey } from '../utils/statsLogKey';
+import { hashSliceSettings } from './sliceSettingsHash';
 import { SLICE_SIDECAR_VERSION, type SliceSidecar, type SliceFrame } from './sliceTypes';
 
 /**
@@ -34,6 +35,13 @@ export function buildSliceSidecar({ logs, roster, mvpWeights, statsViewSettings,
     const frames: SliceFrame[] = [];
     roster.forEach((entry) => {
         const log = logsByKey.get(entry.id);
+        // Skipping (not padding) a roster entry with no matching log keeps
+        // `fights`/`frames` aligned to EACH OTHER, which is what ordinal
+        // addressing actually needs — but it means an ordinal is an index
+        // into `sidecar.fights`, never into the published report's own
+        // `fightRoster`. If any entries are ever skipped here, those two
+        // rosters diverge; any viewer/bitmask code must mint and read
+        // ordinals from `sidecar.fights`, not from the report roster.
         if (!log) return;
         const solo = new IncrementalAggregator({ mvpWeights, statsViewSettings, disruptionMethod });
         solo.ingestLog(log);
@@ -43,7 +51,7 @@ export function buildSliceSidecar({ logs, roster, mvpWeights, statsViewSettings,
 
     return {
         version: SLICE_SIDECAR_VERSION,
-        settingsHash: hashAggregationSettings(mvpWeights, statsViewSettings, disruptionMethod),
+        settingsHash: hashSliceSettings(mvpWeights, statsViewSettings, disruptionMethod),
         fights,
         frames,
     };

--- a/src/renderer/stats/slice/buildSliceSidecar.ts
+++ b/src/renderer/stats/slice/buildSliceSidecar.ts
@@ -1,0 +1,50 @@
+import { IncrementalAggregator } from '../incrementalAggregation';
+import { hashAggregationSettings, type FightRosterEntry } from '../statsStore';
+import { statsLogKey } from '../utils/statsLogKey';
+import { SLICE_SIDECAR_VERSION, type SliceSidecar, type SliceFrame } from './sliceTypes';
+
+/**
+ * Build the published report's slice sidecar: one pre-finalize frame per fight.
+ *
+ * Frames are ordered to match `roster`, not `logs` — the roster is the frozen
+ * publish order the viewer's ordinals address, and `mergeFightRoster` sorts it
+ * oldest-first while `logs` arrives in whatever order the session produced.
+ * `frames[i]` therefore corresponds to `fights[i]` (== `roster[i]` restricted to
+ * entries with a matching log), which is what lets the viewer address a fight
+ * purely by its position in the array.
+ *
+ * A roster entry with no matching log (e.g. a log that was pruned after the
+ * roster was built) is skipped rather than emitting a hole — `fights` and
+ * `frames` always stay in lockstep and index-aligned.
+ *
+ * Cost is one fresh single-log aggregation per fight (~23ms each), which is
+ * noise next to the upload it precedes.
+ */
+export function buildSliceSidecar({ logs, roster, mvpWeights, statsViewSettings, disruptionMethod }: {
+    logs: any[];
+    roster: FightRosterEntry[];
+    mvpWeights: any;
+    statsViewSettings: any;
+    disruptionMethod: any;
+}): SliceSidecar {
+    const logsByKey = new Map<string, any>();
+    logs.forEach((log, index) => logsByKey.set(statsLogKey(log, index), log));
+
+    const fights: FightRosterEntry[] = [];
+    const frames: SliceFrame[] = [];
+    roster.forEach((entry) => {
+        const log = logsByKey.get(entry.id);
+        if (!log) return;
+        const solo = new IncrementalAggregator({ mvpWeights, statsViewSettings, disruptionMethod });
+        solo.ingestLog(log);
+        fights.push(entry);
+        frames.push(solo.exportFrame());
+    });
+
+    return {
+        version: SLICE_SIDECAR_VERSION,
+        settingsHash: hashAggregationSettings(mvpWeights, statsViewSettings, disruptionMethod),
+        fights,
+        frames,
+    };
+}

--- a/src/renderer/stats/slice/computeIncludedOrdinals.ts
+++ b/src/renderer/stats/slice/computeIncludedOrdinals.ts
@@ -1,0 +1,29 @@
+import type { SliceSidecar } from './sliceTypes';
+
+/**
+ * Resolve the excluded-fight set into the ordinals a slice includes.
+ *
+ * Extracted from `reportApp` because the three lines that composed it were
+ * pinned by nothing: a re-review reintroduced the exact C2 bug here
+ * (`included.length > 0 ? included : null`) and all 49 web tests stayed green.
+ * The hooks and the worker either side of it are well covered; this seam was
+ * the gap between them.
+ *
+ * The two empty cases are NOT the same thing, and conflating them is the bug:
+ *
+ * - `null` — no slice is active. The viewer renders the published aggregation.
+ * - `[]`   — a slice that selects no fights. Reached by the tray's None button
+ *            and by an all-zero shared bitmask. It must recompute to a real
+ *            zero-fight aggregation; returning `null` here rendered the FULL
+ *            report under a "Sliced view — 0 of N fights" banner.
+ */
+export function computeIncludedOrdinals(
+    sidecar: SliceSidecar | null,
+    excludedFightKeys: Set<string>,
+): number[] | null {
+    if (!sidecar || excludedFightKeys.size === 0) return null;
+    return sidecar.fights
+        .map((fight, ordinal) => ({ fight, ordinal }))
+        .filter(({ fight }) => !excludedFightKeys.has(fight.id))
+        .map(({ ordinal }) => ordinal);
+}

--- a/src/renderer/stats/slice/fetchSliceSidecar.ts
+++ b/src/renderer/stats/slice/fetchSliceSidecar.ts
@@ -1,0 +1,72 @@
+import { SLICE_SIDECAR_VERSION, type SliceSidecar } from './sliceTypes';
+
+export type FetchSliceResult =
+    | { ok: true; sidecar: SliceSidecar }
+    | { ok: false; reason: "network" | "version" | "settings" | "malformed"; message: string };
+
+/**
+ * Inflate gzipped bytes in the browser.
+ *
+ * R2 serves the sidecar as `application/gzip` with no `Content-Encoding`, so
+ * the browser does NOT transparently inflate it — these are the compressed
+ * bytes and this is where they are decompressed. Node's test environment
+ * provides DecompressionStream from Node 18 on, so the same path runs in tests.
+ */
+const inflate = async (buffer: ArrayBuffer): Promise<string> => {
+    const stream = new Blob([buffer]).stream().pipeThrough(new DecompressionStream('gzip'));
+    return new Response(stream).text();
+};
+
+/**
+ * Fetch and validate a published report's slice sidecar.
+ *
+ * Never called on report load — only when the viewer opens the slice tray or
+ * lands on a `slice=` URL. A version or settings mismatch disables slicing
+ * rather than rendering numbers computed under different settings.
+ */
+export async function fetchSliceSidecar(
+    url: string,
+    expectedSettingsHash: string | null,
+): Promise<FetchSliceResult> {
+    let buffer: ArrayBuffer;
+    try {
+        const response = await fetch(url);
+        if (!response.ok) {
+            return { ok: false, reason: "network", message: `Slice data unavailable (HTTP ${response.status}).` };
+        }
+        buffer = await response.arrayBuffer();
+    } catch (err) {
+        return {
+            ok: false,
+            reason: "network",
+            message: `Could not load slice data: ${err instanceof Error ? err.message : String(err)}`,
+        };
+    }
+
+    let sidecar: SliceSidecar;
+    try {
+        sidecar = JSON.parse(await inflate(buffer));
+    } catch {
+        return { ok: false, reason: "malformed", message: "Slice data could not be read." };
+    }
+
+    if (sidecar?.version !== SLICE_SIDECAR_VERSION) {
+        return {
+            ok: false,
+            reason: "version",
+            message: "This report's slice data was published by a different app version.",
+        };
+    }
+    if (!Array.isArray(sidecar.fights) || !Array.isArray(sidecar.frames)
+        || sidecar.fights.length === 0 || sidecar.fights.length !== sidecar.frames.length) {
+        return { ok: false, reason: "malformed", message: "Slice data is incomplete." };
+    }
+    if (expectedSettingsHash && sidecar.settingsHash !== expectedSettingsHash) {
+        return {
+            ok: false,
+            reason: "settings",
+            message: "Slice data does not match this report's settings — slicing is unavailable.",
+        };
+    }
+    return { ok: true, sidecar };
+}

--- a/src/renderer/stats/slice/frameLabels.ts
+++ b/src/renderer/stats/slice/frameLabels.ts
@@ -1,0 +1,118 @@
+import { buildFightLabelV2 } from '../utils/labelUtils';
+
+/**
+ * Slice-only label plumbing.
+ *
+ * `ingestLog*` bakes the running log ordinal into a handful of display strings
+ * that no `finalize*` renumbers — fight ids, `shortLabel`s, and the
+ * `Fight ${n}` zone fallback that feeds `buildFightLabelV2` (and, through the
+ * player fold, `peakFightLabel`). A slice frame is always produced by a solo
+ * aggregator, so every one of those strings is baked at ordinal 0.
+ *
+ * Rather than pattern-match the baked strings, a frame carries the raw
+ * *ingredients* those expressions read — see `FrameLabelSeed` — and
+ * `resolveFrameFightLabels` re-evaluates exactly the same expressions at the
+ * merge ordinal. Nothing in this file is reachable from the non-slice ingest or
+ * finalize path.
+ */
+
+/**
+ * The raw fields `ingestLog*` reads when it derives an id or a label. All
+ * primitives, all cheap: capturing this adds no measurable work to ingest.
+ *
+ * Stored with `|| ''` semantics because every consumer chains them with `||`,
+ * so an empty string and a missing field have to behave identically.
+ */
+export interface FrameLabelSeed {
+    /** `details.fightName` */
+    fightName: string;
+    /** `log.fightName` */
+    logFightName: string;
+    /** `log.encounterName` */
+    encounterName: string;
+    /** `log.filePath` */
+    filePath: string;
+    /** `log.id` */
+    logId: string;
+    /** `Number(details.durationMS || 0)` */
+    durationMs: number;
+}
+
+/**
+ * The ordinal-derived strings, re-evaluated at a merge ordinal.
+ *
+ * The three `fullLabel*` fields are `null` when the log supplied a real zone —
+ * the label ingest baked is then already ordinal-free and MUST be left alone.
+ * A non-null value means the `Fight ${n}` fallback fired and the string is safe
+ * to overwrite wholesale.
+ */
+export interface FrameFightLabels {
+    /** 0-based merge ordinal. */
+    index: number;
+    /** `F${index + 1}` */
+    shortLabel: string;
+    /** `log.filePath || log.id || \`fight-${index + 1}\`` */
+    fightId: string;
+    /** `log.filePath || \`fight-${index}\`` — the file-path-only chain. */
+    filePathFightId: string;
+    /** zone chain `details.fightName || log.fightName` (the eight modules, heal effectiveness). */
+    fullLabel: string | null;
+    /** zone chain `details.fightName || log.fightName || log.encounterName` (commander stats). */
+    fullLabelWithEncounter: string | null;
+    /**
+     * Same zone chain as `fullLabelWithEncounter`, but built WITHOUT a duration:
+     * `ingestLogFightBreakdown` is the one caller that omits `durationMs`, so its
+     * label has no ` (m:ss)` suffix.
+     */
+    breakdownFullLabel: string | null;
+    /** zone chain `details.fightName || log.encounterName` (tag-distance deaths). */
+    fullLabelEncounterOnly: string | null;
+    /** fight breakdown's `label`: `log.encounterName || \`Fight ${index + 1}\`` */
+    breakdownLabel: string | null;
+}
+
+export function buildFrameLabelSeed(log: any): FrameLabelSeed {
+    const details = log?.details;
+    return {
+        fightName: String(details?.fightName || ''),
+        logFightName: String(log?.fightName || ''),
+        encounterName: String(log?.encounterName || ''),
+        filePath: String(log?.filePath || ''),
+        logId: String(log?.id || ''),
+        durationMs: Number(details?.durationMS || 0),
+    };
+}
+
+export function resolveFrameFightLabels(seed: FrameLabelSeed | null | undefined, index: number): FrameFightLabels {
+    if (!seed || typeof seed !== 'object') {
+        throw new Error('resolveFrameFightLabels: frame carries no labelSeed; it was not produced by exportFrame');
+    }
+    const ordinalZone = `Fight ${index + 1}`;
+    /**
+     * `buildFightLabelV2` only consults `avgPosition` when the zone resolves to
+     * a known map, and `Fight ${n}` never does — so the fallback label is a pure
+     * function of the ordinal and the duration, and the frame needs to carry
+     * neither positions nor a second label build.
+     */
+    const ordinalLabel = () => buildFightLabelV2({ zone: ordinalZone, durationMs: seed.durationMs, avgPosition: null });
+    const zoned = (...chain: string[]) => (chain.some(Boolean) ? null : ordinalLabel());
+
+    return {
+        index,
+        shortLabel: `F${index + 1}`,
+        fightId: seed.filePath || seed.logId || `fight-${index + 1}`,
+        filePathFightId: seed.filePath || `fight-${index}`,
+        fullLabel: zoned(seed.fightName, seed.logFightName),
+        fullLabelWithEncounter: zoned(seed.fightName, seed.logFightName, seed.encounterName),
+        breakdownFullLabel: (seed.fightName || seed.logFightName || seed.encounterName)
+            ? null
+            : buildFightLabelV2({ zone: ordinalZone, avgPosition: null }),
+        fullLabelEncounterOnly: zoned(seed.fightName, seed.encounterName),
+        breakdownLabel: seed.encounterName ? null : ordinalZone,
+    };
+}
+
+/** Overwrite `key` on `target` only when `value` is non-null. */
+export function applyLabel(target: any, key: string, value: string | null): void {
+    if (target && value !== null && value !== undefined) target[key] = value;
+}

--- a/src/renderer/stats/slice/mergeSliceFrames.ts
+++ b/src/renderer/stats/slice/mergeSliceFrames.ts
@@ -1,5 +1,5 @@
 import { IncrementalAggregator } from '../incrementalAggregation';
-import { hashAggregationSettings } from '../statsStore';
+import { hashSliceSettings } from './sliceSettingsHash';
 import type { SliceSidecar } from './sliceTypes';
 
 /**
@@ -26,9 +26,16 @@ export class SliceSettingsMismatchError extends Error {
  *
  * `includedOrdinals` is sanitized before use so a malformed selection degrades
  * safely instead of producing silently-wrong numbers:
- *  - out-of-range ordinals (negative, or >= frame count) are dropped;
- *  - non-integer ordinals (floats, NaN) are dropped — `Number.isInteger`
- *    rejects both;
+ *  - the range/integer filter (`Number.isInteger(ordinal) && 0 <= ordinal <
+ *    frames.length`) rejects a value that isn't actually a valid array index
+ *    at all — most importantly a *non-number* like the string `"2"`, which a
+ *    URL/bitmask decode could plausibly hand back. `sidecar.frames['2']`
+ *    resolves via JS's string-coercing property access to the SAME frame as
+ *    `sidecar.frames[2]`, so without this filter a stringly-typed ordinal
+ *    would merge silently instead of being rejected. Actual out-of-range
+ *    integers (negative, or >= frame count) are *also* caught by the `if
+ *    (frame)` guard below on their own — the filter's job is specifically the
+ *    non-number case that guard cannot see;
  *  - duplicate ordinals are deduped so a repeated ordinal is merged exactly
  *    once (merging it twice would double-count that fight's contribution);
  *  - an empty (or entirely-invalid) selection is not an error — it produces
@@ -42,7 +49,7 @@ export function mergeSliceFrames({ sidecar, includedOrdinals, mvpWeights, statsV
     statsViewSettings: any;
     disruptionMethod: any;
 }): { stats: any; skillUsageData: any } {
-    const expectedHash = hashAggregationSettings(mvpWeights, statsViewSettings, disruptionMethod);
+    const expectedHash = hashSliceSettings(mvpWeights, statsViewSettings, disruptionMethod);
     if (expectedHash !== sidecar.settingsHash) {
         throw new SliceSettingsMismatchError();
     }

--- a/src/renderer/stats/slice/mergeSliceFrames.ts
+++ b/src/renderer/stats/slice/mergeSliceFrames.ts
@@ -1,3 +1,11 @@
+/**
+ * NOT DEAD CODE. This is the synchronous oracle the production worker path
+ * (`statsWorker.ts`'s `mergeFrames` handler) is checked against: every merge
+ * equivalence assertion in `sliceSidecar.test.ts` runs through this module, and
+ * `workerMergeFrames.test.ts` proves the worker agrees with it. Its only
+ * "caller" is the test suite by design — deleting it would delete the proof of
+ * the branch's central invariant.
+ */
 import { IncrementalAggregator } from '../incrementalAggregation';
 import { hashSliceSettings } from './sliceSettingsHash';
 import type { SliceSidecar } from './sliceTypes';

--- a/src/renderer/stats/slice/mergeSliceFrames.ts
+++ b/src/renderer/stats/slice/mergeSliceFrames.ts
@@ -1,0 +1,66 @@
+import { IncrementalAggregator } from '../incrementalAggregation';
+import { hashAggregationSettings } from '../statsStore';
+import type { SliceSidecar } from './sliceTypes';
+
+/**
+ * Thrown when the viewer's active settings do not match the settings the
+ * sidecar was built under. Slice mode uses the PUBLISHER's settings — there is
+ * no way to recompute a frame under different ones — so a mismatch must
+ * disable slicing rather than silently render numbers that don't match what
+ * was published. Callers should catch this and fall back to the non-slice
+ * (full-report) view.
+ */
+export class SliceSettingsMismatchError extends Error {
+    constructor() {
+        super('mergeSliceFrames: settingsHash mismatch — sidecar was built under different settings');
+        this.name = 'SliceSettingsMismatchError';
+    }
+}
+
+/**
+ * Recompute stats for a subset of a published report's fights.
+ *
+ * The browser's whole slice path: merge the selected frames into a fresh
+ * aggregator and run the real `finalize()`. Everything derived — leaderboards,
+ * top stats, MVPs — is rebuilt here, which is why frames never carry it.
+ *
+ * `includedOrdinals` is sanitized before use so a malformed selection degrades
+ * safely instead of producing silently-wrong numbers:
+ *  - out-of-range ordinals (negative, or >= frame count) are dropped;
+ *  - non-integer ordinals (floats, NaN) are dropped — `Number.isInteger`
+ *    rejects both;
+ *  - duplicate ordinals are deduped so a repeated ordinal is merged exactly
+ *    once (merging it twice would double-count that fight's contribution);
+ *  - an empty (or entirely-invalid) selection is not an error — it produces
+ *    the same "zero fights" result `finalize()` gives an aggregator that
+ *    never ingested anything, matching what an empty non-slice report shows.
+ */
+export function mergeSliceFrames({ sidecar, includedOrdinals, mvpWeights, statsViewSettings, disruptionMethod }: {
+    sidecar: SliceSidecar;
+    includedOrdinals: number[];
+    mvpWeights: any;
+    statsViewSettings: any;
+    disruptionMethod: any;
+}): { stats: any; skillUsageData: any } {
+    const expectedHash = hashAggregationSettings(mvpWeights, statsViewSettings, disruptionMethod);
+    if (expectedHash !== sidecar.settingsHash) {
+        throw new SliceSettingsMismatchError();
+    }
+
+    const seen = new Set<number>();
+    const ordinals = (includedOrdinals || [])
+        .filter((ordinal) => Number.isInteger(ordinal) && ordinal >= 0 && ordinal < sidecar.frames.length)
+        .filter((ordinal) => {
+            if (seen.has(ordinal)) return false;
+            seen.add(ordinal);
+            return true;
+        })
+        .sort((a, b) => a - b);
+
+    const aggregator = new IncrementalAggregator({ mvpWeights, statsViewSettings, disruptionMethod });
+    ordinals.forEach((ordinal) => {
+        const frame = sidecar.frames[ordinal];
+        if (frame) aggregator.mergeFrame(frame);
+    });
+    return aggregator.finalize();
+}

--- a/src/renderer/stats/slice/replaySlicing.ts
+++ b/src/renderer/stats/slice/replaySlicing.ts
@@ -1,0 +1,29 @@
+/**
+ * Whether the combat replay on screen would show fights the active slice
+ * excludes.
+ *
+ * The replay payload is either carried inline on the aggregation
+ * (`stats.replayFights`) or fetched once from the report's `replayDataUrl` and
+ * cached whole. The cached copy always holds EVERY fight in the session and is
+ * keyed on its own fight identities, not the sidecar's roster ordinals, so it
+ * cannot be narrowed after the fact.
+ *
+ * Sliced stats never carry `replayFights`: slice frames deliberately exclude
+ * replay payloads (they are the bulk of report.json and no merge maths needs
+ * them). So with a slice active and no inline replay, the viewer would play the
+ * whole night while every other section showed the selected subset — silently.
+ * That is the case this returns true for, and the caller replaces the replay
+ * with an explicit note.
+ *
+ * Deliberately narrow: when `replayFights` IS populated the replay came from
+ * the same, already-sliced aggregation as everything else. That is the desktop
+ * path, where Phase A slices the logs before aggregation, and it must keep
+ * working under a slice.
+ */
+export const isReplayUnsliceable = ({ replayFights, excludedFightCount }: {
+    replayFights: unknown;
+    excludedFightCount: number;
+}): boolean => {
+    if (excludedFightCount <= 0) return false;
+    return !(Array.isArray(replayFights) && replayFights.length > 0);
+};

--- a/src/renderer/stats/slice/sliceBitmask.ts
+++ b/src/renderer/stats/slice/sliceBitmask.ts
@@ -3,9 +3,11 @@
  * slice. Bit `i` set means `fights[i]` is included; bytes are little-endian by
  * ordinal, so the first fight is the low bit of the first byte.
  *
- * The first byte of the payload is the width, which is what lets a stale link
- * (a report republished with more fights) be rejected instead of silently
- * decoding into the wrong fights.
+ * The payload is a bitmask of `width + 1` bits: bits [0, width) encode included
+ * ordinals, and bit at index `width` is a terminator bit (always set). This
+ * terminator distinguishes stale links (e.g., width 7 vs 8) within the same byte
+ * bucket, ensuring a report republished with one more fight rejects rather than
+ * silently decoding into the wrong ordinals.
  */
 
 const ALPHABET = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_';
@@ -47,12 +49,14 @@ const fromBase64Url = (token: string): number[] | null => {
 };
 
 export function encodeSliceMask(includedOrdinals: number[], width: number): string {
-    const byteCount = Math.ceil(Math.max(0, width) / 8);
+    const byteCount = Math.ceil((Math.max(0, width) + 1) / 8);
     const bytes = new Array(byteCount).fill(0);
     includedOrdinals.forEach((ordinal) => {
         if (!Number.isInteger(ordinal) || ordinal < 0 || ordinal >= width) return;
         bytes[ordinal >> 3] |= 1 << (ordinal & 7);
     });
+    // Set terminator bit at index width
+    bytes[width >> 3] |= 1 << (width & 7);
     return toBase64Url(bytes);
 }
 
@@ -60,8 +64,24 @@ export function decodeSliceMask(token: string, width: number): number[] | null {
     if (!token) return null;
     const bytes = fromBase64Url(token);
     if (!bytes) return null;
-    const expectedByteCount = Math.ceil(Math.max(0, width) / 8);
-    if (bytes.length !== expectedByteCount) return null;
+
+    // Find the highest set bit (the terminator)
+    let highestBit = -1;
+    for (let i = bytes.length - 1; i >= 0; i--) {
+        if (bytes[i] !== 0) {
+            for (let bit = 7; bit >= 0; bit--) {
+                if (bytes[i] & (1 << bit)) {
+                    highestBit = i * 8 + bit;
+                    break;
+                }
+            }
+            break;
+        }
+    }
+
+    // The terminator bit must be at index width
+    if (highestBit !== width) return null;
+
     const included: number[] = [];
     for (let ordinal = 0; ordinal < width; ordinal++) {
         if (bytes[ordinal >> 3] & (1 << (ordinal & 7))) included.push(ordinal);

--- a/src/renderer/stats/slice/sliceBitmask.ts
+++ b/src/renderer/stats/slice/sliceBitmask.ts
@@ -1,0 +1,70 @@
+/**
+ * Base64url bitmask over fight ordinals — the whole persistence model for a
+ * slice. Bit `i` set means `fights[i]` is included; bytes are little-endian by
+ * ordinal, so the first fight is the low bit of the first byte.
+ *
+ * The first byte of the payload is the width, which is what lets a stale link
+ * (a report republished with more fights) be rejected instead of silently
+ * decoding into the wrong fights.
+ */
+
+const ALPHABET = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_';
+
+const toBase64Url = (bytes: number[]): string => {
+    let out = '';
+    for (let i = 0; i < bytes.length; i += 3) {
+        const b0 = bytes[i];
+        const b1 = i + 1 < bytes.length ? bytes[i + 1] : 0;
+        const b2 = i + 2 < bytes.length ? bytes[i + 2] : 0;
+        const chunk = (b0 << 16) | (b1 << 8) | b2;
+        const chars = [chunk >> 18, (chunk >> 12) & 63, (chunk >> 6) & 63, chunk & 63];
+        const keep = i + 2 < bytes.length ? 4 : (i + 1 < bytes.length ? 3 : 2);
+        for (let c = 0; c < keep; c++) out += ALPHABET[chars[c]];
+    }
+    return out;
+};
+
+const fromBase64Url = (token: string): number[] | null => {
+    const values: number[] = [];
+    for (const ch of token) {
+        const v = ALPHABET.indexOf(ch);
+        if (v < 0) return null;
+        values.push(v);
+    }
+    const bytes: number[] = [];
+    for (let i = 0; i < values.length; i += 4) {
+        const keep = Math.min(4, values.length - i);
+        if (keep === 1) return null;
+        const chunk = (values[i] << 18)
+            | (values[i + 1] << 12)
+            | ((keep > 2 ? values[i + 2] : 0) << 6)
+            | (keep > 3 ? values[i + 3] : 0);
+        bytes.push((chunk >> 16) & 255);
+        if (keep > 2) bytes.push((chunk >> 8) & 255);
+        if (keep > 3) bytes.push(chunk & 255);
+    }
+    return bytes;
+};
+
+export function encodeSliceMask(includedOrdinals: number[], width: number): string {
+    const byteCount = Math.ceil(Math.max(0, width) / 8);
+    const bytes = new Array(byteCount).fill(0);
+    includedOrdinals.forEach((ordinal) => {
+        if (!Number.isInteger(ordinal) || ordinal < 0 || ordinal >= width) return;
+        bytes[ordinal >> 3] |= 1 << (ordinal & 7);
+    });
+    return toBase64Url(bytes);
+}
+
+export function decodeSliceMask(token: string, width: number): number[] | null {
+    if (!token) return null;
+    const bytes = fromBase64Url(token);
+    if (!bytes) return null;
+    const expectedByteCount = Math.ceil(Math.max(0, width) / 8);
+    if (bytes.length !== expectedByteCount) return null;
+    const included: number[] = [];
+    for (let ordinal = 0; ordinal < width; ordinal++) {
+        if (bytes[ordinal >> 3] & (1 << (ordinal & 7))) included.push(ordinal);
+    }
+    return included;
+}

--- a/src/renderer/stats/slice/sliceSettingsHash.ts
+++ b/src/renderer/stats/slice/sliceSettingsHash.ts
@@ -1,0 +1,54 @@
+/**
+ * Slice-local settings hash: sorted-key canonical JSON + a wider digest.
+ *
+ * Deliberately NOT `hashAggregationSettings` from `../statsStore` — that hash
+ * is the desktop aggregation-cache key, keyed on whatever JS object-literal
+ * insertion order the caller happened to construct. That's harmless there:
+ * it's an in-memory cache key, and a false miss just recomputes. This hash is
+ * different in kind — it is persisted into a published `slice.json.gz`
+ * artifact and compared, on every page load, against a settings object built
+ * by a *different* JS engine run. Two semantically-identical settings objects
+ * constructed with keys in a different order would otherwise hash
+ * differently and make a real, correctly-published report un-sliceable for
+ * no reason. So this canonicalizes key order recursively before hashing.
+ *
+ * The wider (64-bit-ish) digest isn't about resisting an adversary — nothing
+ * here is adversarial. It's about the failure mode: `hashAggregationSettings`
+ * is a single 32-bit rolling hash with a documented ~1-in-4-billion converse
+ * (a genuine settings mismatch that happens to hash equal, silently slicing
+ * under the wrong settings). That hash's failure mode is "recompute, no
+ * harm." This one's failure mode is "renders wrong numbers with no visible
+ * error," so it gets two independent 32-bit hashes concatenated rather than
+ * one.
+ */
+
+const canonicalize = (value: unknown): unknown => {
+    if (Array.isArray(value)) return value.map(canonicalize);
+    if (value && typeof value === 'object') {
+        return Object.keys(value as Record<string, unknown>)
+            .sort()
+            .reduce((out: Record<string, unknown>, key) => {
+                out[key] = canonicalize((value as Record<string, unknown>)[key]);
+                return out;
+            }, {} as Record<string, unknown>);
+    }
+    return value;
+};
+
+// A single FNV/djb2-style rolling hash, seeded differently per call so two
+// independent runs over the same string are (in practice) independent.
+const rollingHash = (input: string, seed: number): number => {
+    let hash = seed | 0;
+    for (let i = 0; i < input.length; i++) {
+        hash = ((hash << 5) - hash) + input.charCodeAt(i);
+        hash = hash | 0;
+    }
+    return hash >>> 0;
+};
+
+export function hashSliceSettings(mvpWeights: unknown, statsViewSettings: unknown, disruptionMethod: unknown): string {
+    const canonicalKey = JSON.stringify(canonicalize({ mvpWeights, statsViewSettings, disruptionMethod }));
+    const low = rollingHash(canonicalKey, 0);
+    const high = rollingHash(canonicalKey, 0x9e3779b9);
+    return `${high.toString(36)}-${low.toString(36)}`;
+}

--- a/src/renderer/stats/slice/sliceSettingsHash.ts
+++ b/src/renderer/stats/slice/sliceSettingsHash.ts
@@ -18,8 +18,17 @@
  * (a genuine settings mismatch that happens to hash equal, silently slicing
  * under the wrong settings). That hash's failure mode is "recompute, no
  * harm." This one's failure mode is "renders wrong numbers with no visible
- * error," so it gets two independent 32-bit hashes concatenated rather than
- * one.
+ * error," so it concatenates two 32-bit digests rather than one.
+ *
+ * The two digests must come from *structurally different* mixers, not the same
+ * recurrence under two seeds. Reseeding `h = h*31 + c` buys nothing: the
+ * recurrence is affine in the seed, so for two inputs of equal length
+ * `h_seed(s) - h_seed(t)` is independent of `seed` — every collision under one
+ * seed is a collision under the other, and the concatenation carries 32 bits of
+ * resistance while claiming 64. FNV-1a (xor, then multiply, 16777619) and djb2
+ * (multiply by 33, then xor) differ in operation order, constants and the
+ * position at which the input byte enters the state, so their collision sets
+ * are not related by construction.
  */
 
 const canonicalize = (value: unknown): unknown => {
@@ -35,20 +44,33 @@ const canonicalize = (value: unknown): unknown => {
     return value;
 };
 
-// A single FNV/djb2-style rolling hash, seeded differently per call so two
-// independent runs over the same string are (in practice) independent.
-const rollingHash = (input: string, seed: number): number => {
-    let hash = seed | 0;
+// FNV-1a: xor the input byte into the state, THEN multiply by the FNV prime.
+const fnv1a = (input: string): number => {
+    let hash = 0x811c9dc5;
     for (let i = 0; i < input.length; i++) {
-        hash = ((hash << 5) - hash) + input.charCodeAt(i);
-        hash = hash | 0;
+        const code = input.charCodeAt(i);
+        hash ^= code & 0xff;
+        hash = Math.imul(hash, 0x01000193);
+        hash ^= (code >>> 8) & 0xff;
+        hash = Math.imul(hash, 0x01000193);
+    }
+    return hash >>> 0;
+};
+
+// djb2 (xor variant): multiply the state by 33 FIRST, then xor the input byte
+// in. Different constant, different operation order, different entry point for
+// the input — so a collision here is unrelated to a collision under fnv1a.
+const djb2 = (input: string): number => {
+    let hash = 5381;
+    for (let i = 0; i < input.length; i++) {
+        hash = (Math.imul(hash, 33) ^ input.charCodeAt(i)) | 0;
     }
     return hash >>> 0;
 };
 
 export function hashSliceSettings(mvpWeights: unknown, statsViewSettings: unknown, disruptionMethod: unknown): string {
     const canonicalKey = JSON.stringify(canonicalize({ mvpWeights, statsViewSettings, disruptionMethod }));
-    const low = rollingHash(canonicalKey, 0);
-    const high = rollingHash(canonicalKey, 0x9e3779b9);
+    const low = djb2(canonicalKey);
+    const high = fnv1a(canonicalKey);
     return `${high.toString(36)}-${low.toString(36)}`;
 }

--- a/src/renderer/stats/slice/sliceTypes.ts
+++ b/src/renderer/stats/slice/sliceTypes.ts
@@ -1,0 +1,29 @@
+import type { FightRosterEntry } from '../statsStore';
+
+/** Bumped whenever a frame's internal shape changes. A viewer that sees a
+ *  version it does not know disables slicing rather than guessing. */
+export const SLICE_SIDECAR_VERSION = 1;
+
+/** The tray's view of a fight. Deliberately the Phase A roster shape, so
+ *  `FightSliceTray` renders sidecar fights with no changes at all. */
+export type SliceFightEntry = FightRosterEntry;
+
+/**
+ * Pre-finalize aggregator state for exactly one fight, Map/Set-encoded.
+ * Opaque by design: only `IncrementalAggregator.exportFrame` writes it and
+ * only `IncrementalAggregator.mergeFrame` reads it.
+ */
+export interface SliceFrame {
+    [section: string]: unknown;
+}
+
+export interface SliceSidecar {
+    version: number;
+    /** Hash of the settings the frames were built under. A viewer whose report
+     *  disagrees disables slicing rather than rendering wrong numbers. */
+    settingsHash: string;
+    /** Frozen publish order. Ordinal addressing is stable because of this. */
+    fights: SliceFightEntry[];
+    /** `frames[i]` is the frame for `fights[i]`. */
+    frames: SliceFrame[];
+}

--- a/src/renderer/stats/slice/stateCodec.ts
+++ b/src/renderer/stats/slice/stateCodec.ts
@@ -1,0 +1,48 @@
+/**
+ * JSON codec for accumulator state.
+ *
+ * Accumulators store their state in Maps and Sets, and `JSON.stringify` turns
+ * both into `{}` without complaining — a silent, total data loss. Everything
+ * that crosses the sidecar boundary goes through here first.
+ *
+ * The `__map` / `__set` sentinels are only honoured when their payload is an
+ * array, so a plain object that happens to carry a `__map` string key survives
+ * as itself.
+ */
+
+const MAP_KEY = '__map';
+const SET_KEY = '__set';
+
+export function encodeState(value: unknown): unknown {
+    if (value instanceof Map) {
+        return { [MAP_KEY]: [...value.entries()].map(([k, v]) => [encodeState(k), encodeState(v)]) };
+    }
+    if (value instanceof Set) {
+        return { [SET_KEY]: [...value].map(encodeState) };
+    }
+    if (Array.isArray(value)) return value.map(encodeState);
+    if (value && typeof value === 'object') {
+        const out: Record<string, unknown> = {};
+        for (const [k, v] of Object.entries(value as Record<string, unknown>)) out[k] = encodeState(v);
+        return out;
+    }
+    return value;
+}
+
+export function decodeState(value: unknown): any {
+    if (Array.isArray(value)) return value.map(decodeState);
+    if (value && typeof value === 'object') {
+        const obj = value as Record<string, unknown>;
+        if (Array.isArray(obj[MAP_KEY])) {
+            const entries = obj[MAP_KEY] as Array<[unknown, unknown]>;
+            return new Map(entries.map(([k, v]) => [decodeState(k), decodeState(v)]));
+        }
+        if (Array.isArray(obj[SET_KEY])) {
+            return new Set((obj[SET_KEY] as unknown[]).map(decodeState));
+        }
+        const out: Record<string, unknown> = {};
+        for (const [k, v] of Object.entries(obj)) out[k] = decodeState(v);
+        return out;
+    }
+    return value;
+}

--- a/src/renderer/test/setup.ts
+++ b/src/renderer/test/setup.ts
@@ -86,25 +86,3 @@ if (typeof window !== 'undefined') {
         HTMLCanvasElement.prototype.getContext = () => null;
     }
 }
-
-// Provide Web Stream APIs for tests that need them (e.g., fetchSliceSidecar in jsdom).
-// Note: The fetchSliceSidecar test runs in Node environment (via @vitest-environment node),
-// so it has native access to these APIs. This is for other tests in jsdom that may need them.
-try {
-    const webStreams = require('node:stream/web');
-
-    if (!globalThis.DecompressionStream) {
-        (globalThis as any).DecompressionStream = webStreams.DecompressionStream;
-    }
-    if (!globalThis.ReadableStream) {
-        (globalThis as any).ReadableStream = webStreams.ReadableStream;
-    }
-    if (!globalThis.TransformStream) {
-        (globalThis as any).TransformStream = webStreams.TransformStream;
-    }
-    if (!globalThis.WritableStream) {
-        (globalThis as any).WritableStream = webStreams.WritableStream;
-    }
-} catch {
-    // If node:stream/web is not available, proceed without these polyfills
-}

--- a/src/renderer/test/setup.ts
+++ b/src/renderer/test/setup.ts
@@ -46,40 +46,65 @@ afterAll(() => {
     (console.warn as unknown as { mockRestore?: () => void }).mockRestore?.();
 });
 
-Object.defineProperty(window, 'electronAPI', {
-    value: {
-        openExternal: () => {},
-        mockWebReport: () => Promise.resolve({ success: false }),
-        uploadWebReport: () => Promise.resolve({ success: false })
-    },
-    writable: true
-});
-
-if (!window.matchMedia) {
-    window.matchMedia = () => ({
-        matches: false,
-        media: '',
-        onchange: null,
-        addEventListener: () => {},
-        removeEventListener: () => {},
-        addListener: () => {},
-        removeListener: () => {},
-        dispatchEvent: () => false
+// Skip jsdom-specific setup in Node environment
+if (typeof window !== 'undefined') {
+    Object.defineProperty(window, 'electronAPI', {
+        value: {
+            openExternal: () => {},
+            mockWebReport: () => Promise.resolve({ success: false }),
+            uploadWebReport: () => Promise.resolve({ success: false })
+        },
+        writable: true
     });
+
+    if (!window.matchMedia) {
+        window.matchMedia = () => ({
+            matches: false,
+            media: '',
+            onchange: null,
+            addEventListener: () => {},
+            removeEventListener: () => {},
+            addListener: () => {},
+            removeListener: () => {},
+            dispatchEvent: () => false
+        });
+    }
+
+    class ResizeObserverMock {
+        observe() {}
+        unobserve() {}
+        disconnect() {}
+    }
+
+    if (!('ResizeObserver' in window)) {
+        // @ts-ignore
+        window.ResizeObserver = ResizeObserverMock;
+    }
+
+    if (!HTMLCanvasElement.prototype.getContext) {
+        // @ts-ignore
+        HTMLCanvasElement.prototype.getContext = () => null;
+    }
 }
 
-class ResizeObserverMock {
-    observe() {}
-    unobserve() {}
-    disconnect() {}
-}
+// Provide Web Stream APIs for tests that need them (e.g., fetchSliceSidecar in jsdom).
+// Note: The fetchSliceSidecar test runs in Node environment (via @vitest-environment node),
+// so it has native access to these APIs. This is for other tests in jsdom that may need them.
+try {
+    const webStreams = require('node:stream/web');
 
-if (!('ResizeObserver' in window)) {
-    // @ts-ignore
-    window.ResizeObserver = ResizeObserverMock;
-}
-
-if (!HTMLCanvasElement.prototype.getContext) {
-    // @ts-ignore
-    HTMLCanvasElement.prototype.getContext = () => null;
+    if (!globalThis.DecompressionStream) {
+        (globalThis as any).DecompressionStream = webStreams.DecompressionStream;
+    }
+    if (!globalThis.ReadableStream) {
+        (globalThis as any).ReadableStream = webStreams.ReadableStream;
+    }
+    if (!globalThis.TransformStream) {
+        (globalThis as any).TransformStream = webStreams.TransformStream;
+    }
+    if (!globalThis.WritableStream) {
+        (globalThis as any).WritableStream = webStreams.WritableStream;
+    }
+} catch {
+    // If node:stream/web is not available, proceed without these polyfills
 }

--- a/src/renderer/workers/statsWorker.ts
+++ b/src/renderer/workers/statsWorker.ts
@@ -193,6 +193,26 @@ self.onmessage = (event: MessageEvent) => {
         currentPreciseReplay = Boolean(data.payload?.preciseReplay);
         return;
     }
+    if (data?.type === 'mergeFrames') {
+        // The published web report's slice path: no logs, just pre-finalize
+        // frames for the fights the viewer selected.
+        const settings = data.settings || {};
+        aggregator = new IncrementalAggregator({
+            mvpWeights: settings.mvpWeights,
+            statsViewSettings: settings.statsViewSettings,
+            disruptionMethod: settings.disruptionMethod,
+        });
+        const frames = Array.isArray(data.frames) ? data.frames : [];
+        frames.forEach((frame: any) => aggregator!.mergeFrame(frame));
+        ingestedLogCount = frames.length;
+        ingestedLogIds = frames.map((_: any, i: number) => `slice-${i}`);
+        ingestedOwnedLogIds = [];
+        expectedLogCount = frames.length;
+        droppedLogMessages = 0;
+        // Slice mode never renders the map replay, so skip the replay transfer.
+        computeAndPost(true);
+        return;
+    }
     if (data?.type === 'log') {
         if (!aggregator) {
             aggregator = new IncrementalAggregator();

--- a/src/renderer/workers/statsWorker.ts
+++ b/src/renderer/workers/statsWorker.ts
@@ -196,21 +196,37 @@ self.onmessage = (event: MessageEvent) => {
     if (data?.type === 'mergeFrames') {
         // The published web report's slice path: no logs, just pre-finalize
         // frames for the fights the viewer selected.
-        const settings = data.settings || {};
-        aggregator = new IncrementalAggregator({
-            mvpWeights: settings.mvpWeights,
-            statsViewSettings: settings.statsViewSettings,
-            disruptionMethod: settings.disruptionMethod,
-        });
-        const frames = Array.isArray(data.frames) ? data.frames : [];
-        frames.forEach((frame: any) => aggregator!.mergeFrame(frame));
-        ingestedLogCount = frames.length;
-        ingestedLogIds = frames.map((_: any, i: number) => `slice-${i}`);
-        ingestedOwnedLogIds = [];
-        expectedLogCount = frames.length;
-        droppedLogMessages = 0;
-        // Slice mode never renders the map replay, so skip the replay transfer.
-        computeAndPost(true);
+        //
+        // The whole body is guarded. `mergeFrame` has at least three reachable
+        // throw sites (frame label resolution, the personalDamageModKeys set
+        // guard, and the unknown-field rule-table guard in
+        // mergePlayerAggregation), and this worker is the ONLY thing standing
+        // between them and the viewer. Posting nothing on a throw leaves the
+        // caller's `computing` flag stuck true and its `stats` null forever,
+        // which renders as the full report under a "Sliced view — N of M
+        // fights" banner. An explicit `error` reply lets the viewer say the
+        // slice is unavailable instead of quietly lying.
+        try {
+            const settings = data.settings || {};
+            aggregator = new IncrementalAggregator({
+                mvpWeights: settings.mvpWeights,
+                statsViewSettings: settings.statsViewSettings,
+                disruptionMethod: settings.disruptionMethod,
+            });
+            const frames = Array.isArray(data.frames) ? data.frames : [];
+            frames.forEach((frame: any) => aggregator!.mergeFrame(frame));
+            ingestedLogCount = frames.length;
+            ingestedLogIds = frames.map((_: any, i: number) => `slice-${i}`);
+            ingestedOwnedLogIds = [];
+            expectedLogCount = frames.length;
+            droppedLogMessages = 0;
+            // Slice mode never renders the map replay, so skip the replay transfer.
+            computeAndPost(true);
+        } catch (err) {
+            const message = err instanceof Error ? err.message : String(err);
+            console.error('[StatsWorker] mergeFrames threw:', err);
+            (self as any).postMessage({ type: 'error', token: currentToken, message });
+        }
         return;
     }
     if (data?.type === 'log') {

--- a/src/web/__tests__/reportSliceMode.test.tsx
+++ b/src/web/__tests__/reportSliceMode.test.tsx
@@ -1,0 +1,47 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { StatsView } from '../../renderer/StatsView';
+import { useStatsStore, type FightRosterEntry } from '../../renderer/stats/statsStore';
+
+const ROSTER: FightRosterEntry[] = [
+    { id: 'a', label: 'EBG: Klovan', timestamp: 1_000, duration: '2:41', isWin: true, enemyClassCounts: {} },
+    { id: 'b', label: 'Red BL: Bravost', timestamp: 2_000, duration: '1:20', isWin: false, enemyClassCounts: {} },
+];
+
+beforeEach(() => {
+    useStatsStore.setState((useStatsStore as any).getInitialState());
+    useStatsStore.getState().mergeFightRoster(ROSTER, ['a', 'b']);
+});
+
+const renderEmbedded = (sliceEnabled: boolean) => render(
+    <StatsView
+        logs={[]}
+        onBack={() => {}}
+        mvpWeights={undefined}
+        precomputedStats={{ statsViewSettings: {} }}
+        embedded
+        sliceEnabled={sliceEnabled}
+    />
+);
+
+describe('published report slice mode', () => {
+    it('shows the slice banner in an embedded view when slicing is enabled', () => {
+        useStatsStore.getState().setFightsExcluded(['b'], true);
+        renderEmbedded(true);
+        expect(screen.getByText(/1 of 2 fights/i)).toBeInTheDocument();
+    });
+
+    it('shows no slice banner in an embedded view when slicing is not enabled', () => {
+        // A historical FightReportHistoryView must never surface the live slice.
+        useStatsStore.getState().setFightsExcluded(['b'], true);
+        renderEmbedded(false);
+        expect(screen.queryByText(/1 of 2 fights/i)).not.toBeInTheDocument();
+    });
+
+    it('clears the slice from the embedded banner', () => {
+        useStatsStore.getState().setFightsExcluded(['b'], true);
+        renderEmbedded(true);
+        fireEvent.click(screen.getByRole('button', { name: /clear slice/i }));
+        expect(useStatsStore.getState().excludedFightKeys.size).toBe(0);
+    });
+});

--- a/src/web/__tests__/useSliceRecompute.test.ts
+++ b/src/web/__tests__/useSliceRecompute.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { useSliceRecompute } from '../hooks/useSliceRecompute';
+
+const posted: any[] = [];
+let handler: ((e: any) => void) | null = null;
+
+class FakeWorker {
+    onmessage: ((e: any) => void) | null = null;
+    constructor() { handler = null; }
+    postMessage(msg: any) {
+        posted.push(msg);
+        handler = this.onmessage;
+    }
+    terminate() {}
+}
+
+vi.stubGlobal('Worker', FakeWorker as any);
+
+const SIDECAR: any = {
+    version: 1, settingsHash: 'h',
+    fights: [{ id: 'a' }, { id: 'b' }],
+    frames: [{ n: 1 }, { n: 2 }],
+};
+
+afterEach(() => { posted.length = 0; handler = null; });
+
+describe('useSliceRecompute', () => {
+    it('posts only the selected frames', async () => {
+        renderHook(() => useSliceRecompute({
+            sidecar: SIDECAR, includedOrdinals: [1], mvpWeights: undefined, statsViewSettings: {}, disruptionMethod: undefined,
+        }));
+        await waitFor(() => expect(posted.length).toBeGreaterThan(0));
+        const msg = posted[posted.length - 1];
+        expect(msg.type).toBe('mergeFrames');
+        expect(msg.frames).toEqual([{ n: 2 }]);
+    });
+
+    it('returns null stats and stops computing when nothing is selected', () => {
+        const { result } = renderHook(() => useSliceRecompute({
+            sidecar: SIDECAR, includedOrdinals: null, mvpWeights: undefined, statsViewSettings: {}, disruptionMethod: undefined,
+        }));
+        expect(result.current.stats).toBeNull();
+        expect(result.current.computing).toBe(false);
+        expect(posted).toHaveLength(0);
+    });
+
+    it('surfaces the worker result', async () => {
+        const { result } = renderHook(() => useSliceRecompute({
+            sidecar: SIDECAR, includedOrdinals: [0], mvpWeights: undefined, statsViewSettings: {}, disruptionMethod: undefined,
+        }));
+        await waitFor(() => expect(handler).toBeTruthy());
+        const token = posted[posted.length - 1].token;
+        handler!({ data: { type: 'result', token, result: { stats: { ok: true } } } });
+        await waitFor(() => expect(result.current.stats).toEqual({ ok: true }));
+        expect(result.current.computing).toBe(false);
+    });
+
+    it('ignores a result carrying a stale token', async () => {
+        const { result } = renderHook(() => useSliceRecompute({
+            sidecar: SIDECAR, includedOrdinals: [0], mvpWeights: undefined, statsViewSettings: {}, disruptionMethod: undefined,
+        }));
+        await waitFor(() => expect(handler).toBeTruthy());
+        handler!({ data: { type: 'result', token: 9999, result: { stats: { stale: true } } } });
+        expect(result.current.stats).toBeNull();
+    });
+
+    it('includes the publisher mvpWeights in the posted settings', async () => {
+        const mvpWeights = { dps: 0.5, cleanses: 0.5 };
+        renderHook(() => useSliceRecompute({
+            sidecar: SIDECAR, includedOrdinals: [0], mvpWeights, statsViewSettings: {}, disruptionMethod: undefined,
+        }));
+        await waitFor(() => expect(posted.length).toBeGreaterThan(0));
+        const msg = posted[posted.length - 1];
+        expect(msg.type).toBe('mergeFrames');
+        expect(msg.settings.mvpWeights).toEqual(mvpWeights);
+    });
+});

--- a/src/web/__tests__/useSliceRecompute.test.ts
+++ b/src/web/__tests__/useSliceRecompute.test.ts
@@ -24,7 +24,15 @@ vi.stubGlobal('Worker', FakeWorker as any);
 // The settings triple every test below passes to the hook. The hook re-hashes
 // it and refuses to merge unless it matches the sidecar's own `settingsHash`
 // (M1), so the fixture carries the real hash rather than a placeholder.
-const SETTINGS = { mvpWeights: undefined, statsViewSettings: {}, disruptionMethod: undefined };
+// Every field is NON-DEGENERATE on purpose. With `statsViewSettings: {}` and
+// `disruptionMethod: undefined`, a hash that silently dropped either one still
+// matched — only the mvpWeights position discriminated, so M1's guard was 1/3
+// covered. These values make all three positions load-bearing.
+const SETTINGS = {
+    mvpWeights: { dps: 0.4, cleanses: 0.35, strips: 0.25 },
+    statsViewSettings: { showDowned: true, minDuration: 30 },
+    disruptionMethod: 'cc-duration',
+};
 
 const SIDECAR: any = {
     version: 1,

--- a/src/web/__tests__/useSliceRecompute.test.ts
+++ b/src/web/__tests__/useSliceRecompute.test.ts
@@ -1,34 +1,44 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
 import { act, renderHook, waitFor } from '@testing-library/react';
-import { useSliceRecompute } from '../hooks/useSliceRecompute';
+import { useSliceRecompute, SLICE_UNAVAILABLE_MESSAGE } from '../hooks/useSliceRecompute';
+import { hashSliceSettings } from '../../renderer/stats/slice/sliceSettingsHash';
 
 const posted: any[] = [];
 let handler: ((e: any) => void) | null = null;
+let errorHandler: ((e: any) => void) | null = null;
 
 class FakeWorker {
     onmessage: ((e: any) => void) | null = null;
-    constructor() { handler = null; }
+    onerror: ((e: any) => void) | null = null;
+    constructor() { handler = null; errorHandler = null; }
     postMessage(msg: any) {
         posted.push(msg);
         handler = this.onmessage;
+        errorHandler = this.onerror;
     }
     terminate() {}
 }
 
 vi.stubGlobal('Worker', FakeWorker as any);
 
+// The settings triple every test below passes to the hook. The hook re-hashes
+// it and refuses to merge unless it matches the sidecar's own `settingsHash`
+// (M1), so the fixture carries the real hash rather than a placeholder.
+const SETTINGS = { mvpWeights: undefined, statsViewSettings: {}, disruptionMethod: undefined };
+
 const SIDECAR: any = {
-    version: 1, settingsHash: 'h',
+    version: 1,
+    settingsHash: hashSliceSettings(SETTINGS.mvpWeights, SETTINGS.statsViewSettings, SETTINGS.disruptionMethod),
     fights: [{ id: 'a' }, { id: 'b' }],
     frames: [{ n: 1 }, { n: 2 }],
 };
 
-afterEach(() => { posted.length = 0; handler = null; });
+afterEach(() => { posted.length = 0; handler = null; errorHandler = null; });
 
 describe('useSliceRecompute', () => {
     it('posts only the selected frames', async () => {
         renderHook(() => useSliceRecompute({
-            sidecar: SIDECAR, includedOrdinals: [1], mvpWeights: undefined, statsViewSettings: {}, disruptionMethod: undefined,
+            sidecar: SIDECAR, includedOrdinals: [1], ...SETTINGS,
         }));
         await waitFor(() => expect(posted.length).toBeGreaterThan(0));
         const msg = posted[posted.length - 1];
@@ -36,18 +46,130 @@ describe('useSliceRecompute', () => {
         expect(msg.frames).toEqual([{ n: 2 }]);
     });
 
-    it('returns null stats and stops computing when nothing is selected', () => {
-        const { result } = renderHook(() => useSliceRecompute({
-            sidecar: SIDECAR, includedOrdinals: null, mvpWeights: undefined, statsViewSettings: {}, disruptionMethod: undefined,
+    /**
+     * Ruling R20-2: `mergeFrames` MUST be preceded by a `reset` carrying the
+     * same token, and nothing else pinned that.
+     *
+     * The worker only advances its `currentToken` on a `reset` (statsWorker.ts
+     * `hasMismatchedToken`); a bare `mergeFrames` leaves it at its initial `0`.
+     * The hook's first token is `1`, so without the `reset` EVERY `mergeFrames`
+     * would be dropped by the token guard and no slice would ever recompute —
+     * silently, because the worker replies to a dropped message with nothing.
+     * Every other assertion in this file reads `posted[posted.length - 1]` and
+     * so cannot see the `reset` at all; these two read position 0 explicitly.
+     */
+    it('precedes every mergeFrames with a reset carrying the same token', async () => {
+        renderHook(() => useSliceRecompute({
+            sidecar: SIDECAR, includedOrdinals: [1], ...SETTINGS,
         }));
+        await waitFor(() => expect(posted.length).toBe(2));
+        expect(posted[0].type).toBe('reset');
+        expect(posted[1].type).toBe('mergeFrames');
+        expect(typeof posted[0].token).toBe('number');
+        expect(posted[0].token).toBe(posted[1].token);
+    });
+
+    it('returns null stats and stops computing when no slice is active', () => {
+        const { result } = renderHook(() => useSliceRecompute({
+            sidecar: SIDECAR, includedOrdinals: null, ...SETTINGS,
+        }));
+        expect(result.current.stats).toBeNull();
+        expect(result.current.computing).toBe(false);
+        expect(result.current.error).toBeNull();
+        expect(posted).toHaveLength(0);
+    });
+
+    /**
+     * C2: an empty selection is a SLICE THAT SELECTS NOTHING, not "no slice".
+     * It must round-trip through the worker with `frames: []` so the viewer
+     * renders the real zero-fight aggregation. Short-circuiting it to
+     * `stats: null` made the caller fall back to `report.stats` — the FULL
+     * report — under a "Sliced view — 0 of N fights" banner.
+     */
+    it('recomputes an empty selection as a zero-fight slice instead of skipping it', async () => {
+        const { result } = renderHook(() => useSliceRecompute({
+            sidecar: SIDECAR, includedOrdinals: [], ...SETTINGS,
+        }));
+        await waitFor(() => expect(posted.length).toBe(2));
+        expect(posted[1].type).toBe('mergeFrames');
+        expect(posted[1].frames).toEqual([]);
+        expect(result.current.computing).toBe(true);
+
+        const token = posted[1].token;
+        await act(async () => {
+            handler!({ data: { type: 'result', token, result: { stats: { zeroFight: true } } } });
+        });
+        // A real (empty) aggregation, not a null that the caller would replace
+        // with the full report.
+        expect(result.current.stats).toEqual({ zeroFight: true });
+        expect(result.current.error).toBeNull();
+    });
+
+    /**
+     * M1: slice mode has no settings of its own — it merges under the values
+     * the publisher wrote into report.json. Task 20 moved production onto the
+     * worker's `mergeFrames`, which builds its aggregator from whatever
+     * settings it is handed and verifies nothing, so this re-hash is the only
+     * surviving check that report.json and the sidecar actually agree. On a
+     * mismatch the hook must refuse to merge and say so — never merge under
+     * settings the sidecar was not built for.
+     */
+    it('refuses to merge when the published settings do not hash to the sidecar hash', async () => {
+        const { result } = renderHook(() => useSliceRecompute({
+            sidecar: { ...SIDECAR, settingsHash: 'built-under-something-else' },
+            includedOrdinals: [0], ...SETTINGS,
+        }));
+        await waitFor(() => expect(result.current.error).toBe(SLICE_UNAVAILABLE_MESSAGE));
         expect(result.current.stats).toBeNull();
         expect(result.current.computing).toBe(false);
         expect(posted).toHaveLength(0);
     });
 
+    it('surfaces a worker error message as an unavailable slice', async () => {
+        const { result } = renderHook(() => useSliceRecompute({
+            sidecar: SIDECAR, includedOrdinals: [0], ...SETTINGS,
+        }));
+        await waitFor(() => expect(handler).toBeTruthy());
+        const token = posted[posted.length - 1].token;
+        await act(async () => {
+            handler!({ data: { type: 'error', token, message: 'boom' } });
+        });
+        expect(result.current.error).toBe(SLICE_UNAVAILABLE_MESSAGE);
+        expect(result.current.stats).toBeNull();
+        expect(result.current.computing).toBe(false);
+    });
+
+    it('surfaces an uncaught worker failure via onerror', async () => {
+        const { result } = renderHook(() => useSliceRecompute({
+            sidecar: SIDECAR, includedOrdinals: [0], ...SETTINGS,
+        }));
+        await waitFor(() => expect(errorHandler).toBeTruthy());
+        await act(async () => {
+            errorHandler!({ message: 'module load failed' });
+        });
+        expect(result.current.error).toBe(SLICE_UNAVAILABLE_MESSAGE);
+        expect(result.current.stats).toBeNull();
+        // Not left stuck on "Recomputing…" forever.
+        expect(result.current.computing).toBe(false);
+    });
+
+    it('treats a result carrying null stats as an unavailable slice', async () => {
+        const { result } = renderHook(() => useSliceRecompute({
+            sidecar: SIDECAR, includedOrdinals: [0], ...SETTINGS,
+        }));
+        await waitFor(() => expect(handler).toBeTruthy());
+        const token = posted[posted.length - 1].token;
+        await act(async () => {
+            // What computeAndPost posts when finalize() throws.
+            handler!({ data: { type: 'result', token, result: { stats: null, skillUsageData: null } } });
+        });
+        expect(result.current.error).toBe(SLICE_UNAVAILABLE_MESSAGE);
+        expect(result.current.computing).toBe(false);
+    });
+
     it('surfaces the worker result', async () => {
         const { result } = renderHook(() => useSliceRecompute({
-            sidecar: SIDECAR, includedOrdinals: [0], mvpWeights: undefined, statsViewSettings: {}, disruptionMethod: undefined,
+            sidecar: SIDECAR, includedOrdinals: [0], ...SETTINGS,
         }));
         await waitFor(() => expect(handler).toBeTruthy());
         const token = posted[posted.length - 1].token;
@@ -58,7 +180,7 @@ describe('useSliceRecompute', () => {
 
     it('ignores a result carrying a stale token', async () => {
         const { result } = renderHook(() => useSliceRecompute({
-            sidecar: SIDECAR, includedOrdinals: [0], mvpWeights: undefined, statsViewSettings: {}, disruptionMethod: undefined,
+            sidecar: SIDECAR, includedOrdinals: [0], ...SETTINGS,
         }));
         await waitFor(() => expect(handler).toBeTruthy());
 
@@ -85,8 +207,9 @@ describe('useSliceRecompute', () => {
 
     it('includes the publisher mvpWeights in the posted settings', async () => {
         const mvpWeights = { dps: 0.5, cleanses: 0.5 };
+        const sidecar = { ...SIDECAR, settingsHash: hashSliceSettings(mvpWeights, {}, undefined) };
         renderHook(() => useSliceRecompute({
-            sidecar: SIDECAR, includedOrdinals: [0], mvpWeights, statsViewSettings: {}, disruptionMethod: undefined,
+            sidecar, includedOrdinals: [0], mvpWeights, statsViewSettings: {}, disruptionMethod: undefined,
         }));
         await waitFor(() => expect(posted.length).toBeGreaterThan(0));
         const msg = posted[posted.length - 1];

--- a/src/web/__tests__/useSliceRecompute.test.ts
+++ b/src/web/__tests__/useSliceRecompute.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
-import { renderHook, waitFor } from '@testing-library/react';
+import { act, renderHook, waitFor } from '@testing-library/react';
 import { useSliceRecompute } from '../hooks/useSliceRecompute';
 
 const posted: any[] = [];
@@ -61,8 +61,26 @@ describe('useSliceRecompute', () => {
             sidecar: SIDECAR, includedOrdinals: [0], mvpWeights: undefined, statsViewSettings: {}, disruptionMethod: undefined,
         }));
         await waitFor(() => expect(handler).toBeTruthy());
-        handler!({ data: { type: 'result', token: 9999, result: { stats: { stale: true } } } });
+
+        // `act` is load-bearing: without it the assertion runs before React has
+        // flushed, so `stats` reads null whether the token guard exists or not
+        // and the test passes for the wrong reason.
+        await act(async () => {
+            handler!({ data: { type: 'result', token: 9999, result: { stats: { stale: true } } } });
+        });
         expect(result.current.stats).toBeNull();
+        // A superseded reply must not end the computing state either — the
+        // request it belonged to is not the one still outstanding.
+        expect(result.current.computing).toBe(true);
+
+        // Discriminator: the same handler, with the live token, DOES apply.
+        // Without this the test cannot tell a working guard from a dead handler.
+        const token = posted[posted.length - 1].token;
+        await act(async () => {
+            handler!({ data: { type: 'result', token, result: { stats: { fresh: true } } } });
+        });
+        expect(result.current.stats).toEqual({ fresh: true });
+        expect(result.current.computing).toBe(false);
     });
 
     it('includes the publisher mvpWeights in the posted settings', async () => {

--- a/src/web/__tests__/useSliceSidecarLoader.test.ts
+++ b/src/web/__tests__/useSliceSidecarLoader.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { act, renderHook } from '@testing-library/react';
+
+const fetchSliceSidecar = vi.fn();
+vi.mock('../../renderer/stats/slice/fetchSliceSidecar', () => ({
+    fetchSliceSidecar: (...args: any[]) => fetchSliceSidecar(...args),
+}));
+
+import { useSliceSidecarLoader } from '../hooks/useSliceSidecarLoader';
+
+const SIDECAR: any = { version: 1, settingsHash: 'h', fights: [{ id: 'a' }], frames: [{ n: 1 }] };
+
+const setup = (url: string | null = 'https://r2.example/slice.json.gz') => renderHook(
+    () => useSliceSidecarLoader({ url, settingsHash: 'h', onSidecar: () => {} }),
+);
+
+beforeEach(() => { fetchSliceSidecar.mockReset(); });
+
+describe('useSliceSidecarLoader', () => {
+    it('issues no request until asked', () => {
+        setup();
+        // The cold-load guarantee: rendering a published report must not fetch.
+        expect(fetchSliceSidecar).not.toHaveBeenCalled();
+    });
+
+    it('surfaces a loading message while the sidecar downloads', async () => {
+        let release: (v: any) => void = () => {};
+        fetchSliceSidecar.mockReturnValue(new Promise((r) => { release = r; }));
+        const { result } = setup();
+
+        let pending!: Promise<any>;
+        act(() => { pending = result.current.loadSliceSidecar(); });
+
+        // The tray is blank until the fetch lands, so the status strip is the
+        // only feedback the user gets for a multi-megabyte download.
+        expect(result.current.sliceState.status).toBe('loading');
+        expect(result.current.sliceState.message).toMatch(/loading slice data/i);
+
+        await act(async () => { release({ ok: true, sidecar: SIDECAR }); await pending; });
+        expect(result.current.sliceState.status).toBe('ready');
+        expect(result.current.sliceState.message).toBeNull();
+    });
+
+    it('shares one request between concurrent callers', async () => {
+        let release: (v: any) => void = () => {};
+        fetchSliceSidecar.mockReturnValue(new Promise((r) => { release = r; }));
+        const { result } = setup();
+
+        // A slice= deep link and a tray click both call this. Guarding only on
+        // the settled sidecar let each start its own multi-megabyte download.
+        let a!: Promise<any>; let b!: Promise<any>;
+        act(() => { a = result.current.loadSliceSidecar(); b = result.current.loadSliceSidecar(); });
+        expect(fetchSliceSidecar).toHaveBeenCalledTimes(1);
+
+        await act(async () => { release({ ok: true, sidecar: SIDECAR }); await Promise.all([a, b]); });
+        expect(await a).toBe(SIDECAR);
+        expect(await b).toBe(SIDECAR);
+
+        // And a later call reuses the settled sidecar rather than refetching.
+        await act(async () => { await result.current.loadSliceSidecar(); });
+        expect(fetchSliceSidecar).toHaveBeenCalledTimes(1);
+    });
+
+    it('reports a rejected fetch instead of hanging on loading', async () => {
+        fetchSliceSidecar.mockRejectedValue(new Error('network down'));
+        const { result } = setup();
+        await act(async () => { await result.current.loadSliceSidecar(); });
+        expect(result.current.sliceState.status).toBe('unavailable');
+        expect(result.current.sliceState.message).toMatch(/could not load slice data/i);
+    });
+
+    it('reports a report published without slice data', async () => {
+        const { result } = setup(null);
+        await act(async () => { await result.current.loadSliceSidecar(); });
+        expect(result.current.sliceState.status).toBe('unavailable');
+        expect(fetchSliceSidecar).not.toHaveBeenCalled();
+    });
+});

--- a/src/web/hooks/useSliceRecompute.ts
+++ b/src/web/hooks/useSliceRecompute.ts
@@ -1,5 +1,15 @@
 import { useEffect, useRef, useState } from 'react';
+import { hashSliceSettings } from '../../renderer/stats/slice/sliceSettingsHash';
 import type { SliceSidecar } from '../../renderer/stats/slice/sliceTypes';
+
+/**
+ * What the caller renders instead of the slice when the recompute cannot be
+ * trusted. It must never fall back to the full-report aggregation while still
+ * claiming a slice is active — showing all seven fights' numbers under a
+ * "Sliced view — 3 of 7 fights" banner is the one outcome the spec forbids.
+ */
+export const SLICE_UNAVAILABLE_MESSAGE =
+    'Fight slicing is unavailable for this report — showing all fights.';
 
 /**
  * Recompute a slice in the stats worker.
@@ -33,9 +43,10 @@ export function useSliceRecompute({ sidecar, includedOrdinals, mvpWeights, stats
     mvpWeights: any;
     statsViewSettings: any;
     disruptionMethod: any;
-}): { stats: any | null; computing: boolean } {
+}): { stats: any | null; computing: boolean; error: string | null } {
     const [stats, setStats] = useState<any | null>(null);
     const [computing, setComputing] = useState(false);
+    const [error, setError] = useState<string | null>(null);
     const workerRef = useRef<Worker | null>(null);
     const tokenRef = useRef(0);
 
@@ -55,9 +66,35 @@ export function useSliceRecompute({ sidecar, includedOrdinals, mvpWeights, stats
     const settingsKey = JSON.stringify({ mvpWeights, statsViewSettings, disruptionMethod });
 
     useEffect(() => {
-        if (!sidecar || !includedOrdinals || includedOrdinals.length === 0) {
+        // `includedOrdinals === null` means "no slice active" — the caller is
+        // rendering the full report and there is nothing to recompute.
+        // An EMPTY ARRAY is a different thing: a slice that selects no fights.
+        // That is a legitimate, representable state (the tray's None button
+        // reaches it in one click, and an empty bitmask decodes to it), and it
+        // must recompute to the real zero-fight aggregation. Collapsing the two
+        // used to make a 0-fight slice render the FULL report under a
+        // "Sliced view — 0 of N fights" banner. The worker handles `frames: []`
+        // correctly — it finalizes an aggregator that ingested nothing.
+        if (!sidecar || !includedOrdinals) {
             setStats(null);
             setComputing(false);
+            setError(null);
+            return;
+        }
+        // The viewer has no settings of its own in slice mode: it merges under
+        // the values the publisher wrote into report.json. Re-hashing them here
+        // and comparing against the sidecar's own hash is the only surviving
+        // check that the two actually agree — the worker's `mergeFrames`
+        // handler builds its aggregator from whatever settings it is handed and
+        // cannot verify anything. Without this, a report.json whose settings
+        // drifted from the sidecar (a partial re-publish, a hand-edited file, a
+        // future trim step that drops one of the three) would merge silently
+        // under the wrong settings and render numbers that do not match what
+        // was published. Costs ~1 ms.
+        if (hashSliceSettings(mvpWeights, statsViewSettings, disruptionMethod) !== sidecar.settingsHash) {
+            setStats(null);
+            setComputing(false);
+            setError(SLICE_UNAVAILABLE_MESSAGE);
             return;
         }
         if (!workerRef.current) {
@@ -69,11 +106,39 @@ export function useSliceRecompute({ sidecar, includedOrdinals, mvpWeights, stats
         const worker = workerRef.current;
         const token = ++tokenRef.current;
         setComputing(true);
+        setError(null);
         worker.onmessage = (event: MessageEvent) => {
             const data = event.data;
-            if (data?.type !== 'result' || data.token !== tokenRef.current) return;
-            setStats(data.result?.stats ?? null);
+            if (data?.token !== tokenRef.current) return;
+            if (data?.type === 'error') {
+                setStats(null);
+                setComputing(false);
+                setError(SLICE_UNAVAILABLE_MESSAGE);
+                return;
+            }
+            if (data?.type !== 'result') return;
+            const nextStats = data.result?.stats ?? null;
+            if (!nextStats) {
+                // `computeAndPost` posts `stats: null` when `finalize()` throws.
+                // Treating that as "no stats yet" would leave `computing` false
+                // and `stats` null forever, which the caller renders as the full
+                // report under a slice banner.
+                setStats(null);
+                setComputing(false);
+                setError(SLICE_UNAVAILABLE_MESSAGE);
+                return;
+            }
+            setStats(nextStats);
             setComputing(false);
+            setError(null);
+        };
+        // A throw inside `mergeFrame` that escapes the worker's own try/catch
+        // (a module-load failure, say) arrives here and nowhere else. Without
+        // this handler `computing` would stay true and `stats` null forever.
+        worker.onerror = () => {
+            setStats(null);
+            setComputing(false);
+            setError(SLICE_UNAVAILABLE_MESSAGE);
         };
         // See the JSDoc above: `reset` establishes the worker's currentToken
         // before `mergeFrames` is allowed to run under it.
@@ -92,5 +157,5 @@ export function useSliceRecompute({ sidecar, includedOrdinals, mvpWeights, stats
         // re-render triggered by `setComputing`/`setStats` below.
     }, [sidecar, key, settingsKey]);
 
-    return { stats, computing };
+    return { stats, computing, error };
 }

--- a/src/web/hooks/useSliceRecompute.ts
+++ b/src/web/hooks/useSliceRecompute.ts
@@ -1,0 +1,96 @@
+import { useEffect, useRef, useState } from 'react';
+import type { SliceSidecar } from '../../renderer/stats/slice/sliceTypes';
+
+/**
+ * Recompute a slice in the stats worker.
+ *
+ * Merging 25 frames and running `finalize()` costs about what a full
+ * aggregation costs, so it does not belong on the main thread. Results carry
+ * the token of the request that asked for them; a late reply from a superseded
+ * selection is dropped rather than painted.
+ *
+ * Every request is preceded by a `reset` message carrying the same token.
+ * This is not optional bookkeeping: `statsWorker.ts` only updates its
+ * internal `currentToken` on a `reset` message (see `statsWorker.ts:151-152`
+ * and the `hasMismatchedToken` guard at `statsWorker.ts:26-27,181`). A
+ * `mergeFrames` message alone never changes `currentToken` — it stays at its
+ * initial value of `0` for the life of the worker — so a second `mergeFrames`
+ * call carrying any other token would be silently dropped, and every
+ * `result` the worker ever posts would carry `token: 0` regardless of what
+ * was requested, defeating staleness detection. Pairing `reset` +
+ * `mergeFrames` with the same token threads the token through both the
+ * request-acceptance check and the reply, exactly like the desktop
+ * aggregation hook (`useStatsAggregationWorker.ts:430-441`) and exactly what
+ * `workerMergeFrames.test.ts`'s "ignores a mergeFrames message carrying a
+ * stale token" case pins.
+ *
+ * The worker URL is resolved the same way the desktop hook resolves it
+ * (`useStatsAggregationWorker.ts:256`), so the bundler emits one shared chunk.
+ */
+export function useSliceRecompute({ sidecar, includedOrdinals, mvpWeights, statsViewSettings, disruptionMethod }: {
+    sidecar: SliceSidecar | null;
+    includedOrdinals: number[] | null;
+    mvpWeights: any;
+    statsViewSettings: any;
+    disruptionMethod: any;
+}): { stats: any | null; computing: boolean } {
+    const [stats, setStats] = useState<any | null>(null);
+    const [computing, setComputing] = useState(false);
+    const workerRef = useRef<Worker | null>(null);
+    const tokenRef = useRef(0);
+
+    useEffect(() => () => {
+        workerRef.current?.terminate();
+        workerRef.current = null;
+    }, []);
+
+    const key = includedOrdinals ? includedOrdinals.join(',') : '';
+    // Same reasoning as `key` above, extended to the settings objects: a
+    // caller that reconstructs `statsViewSettings`/`disruptionMethod`/
+    // `mvpWeights` with a new identity on every render (this hook's own test
+    // does, via inline object literals) would otherwise re-fire this effect
+    // on every render the effect itself causes via `setComputing`/`setStats`
+    // — content-equal but reference-unequal settings must not restart the
+    // worker round-trip.
+    const settingsKey = JSON.stringify({ mvpWeights, statsViewSettings, disruptionMethod });
+
+    useEffect(() => {
+        if (!sidecar || !includedOrdinals || includedOrdinals.length === 0) {
+            setStats(null);
+            setComputing(false);
+            return;
+        }
+        if (!workerRef.current) {
+            workerRef.current = new Worker(
+                new URL('../../renderer/workers/statsWorker.ts', import.meta.url),
+                { type: 'module' },
+            );
+        }
+        const worker = workerRef.current;
+        const token = ++tokenRef.current;
+        setComputing(true);
+        worker.onmessage = (event: MessageEvent) => {
+            const data = event.data;
+            if (data?.type !== 'result' || data.token !== tokenRef.current) return;
+            setStats(data.result?.stats ?? null);
+            setComputing(false);
+        };
+        // See the JSDoc above: `reset` establishes the worker's currentToken
+        // before `mergeFrames` is allowed to run under it.
+        worker.postMessage({ type: 'reset', token, totalLogs: 0 });
+        worker.postMessage({
+            type: 'mergeFrames',
+            token,
+            frames: includedOrdinals.map((ordinal) => sidecar.frames[ordinal]).filter(Boolean),
+            settings: { mvpWeights, statsViewSettings, disruptionMethod },
+        });
+        // `includedOrdinals` is deliberately NOT a dependency here — it is a
+        // fresh array on every caller render even when its contents are
+        // unchanged (reportApp.tsx rebuilds it from a Set each render). `key`
+        // is its content-stable proxy; depending on the array itself would
+        // re-fire this effect (and re-post to the worker) on every unrelated
+        // re-render triggered by `setComputing`/`setStats` below.
+    }, [sidecar, key, settingsKey]);
+
+    return { stats, computing };
+}

--- a/src/web/hooks/useSliceSidecarLoader.ts
+++ b/src/web/hooks/useSliceSidecarLoader.ts
@@ -1,0 +1,73 @@
+import { useCallback, useRef, useState } from 'react';
+import { fetchSliceSidecar } from '../../renderer/stats/slice/fetchSliceSidecar';
+import type { SliceSidecar } from '../../renderer/stats/slice/sliceTypes';
+
+export type SliceLoadState = {
+    status: 'idle' | 'loading' | 'ready' | 'unavailable';
+    sidecar: SliceSidecar | null;
+    message: string | null;
+};
+
+/**
+ * Fetch the slice sidecar on demand.
+ *
+ * Extracted from `reportApp` so the two properties below can be pinned by a
+ * test — inline, there was no seam and both regressed unnoticed:
+ *
+ * 1. `loading` carries a real message. The tray reads `fightRoster`, which
+ *    stays empty until this resolves, so a silent load leaves the user staring
+ *    at an empty tray for a multi-megabyte download.
+ * 2. Concurrent callers share one request. A deep link and a tray click both
+ *    call this, and guarding only on the settled `sidecar` let them each start
+ *    their own download.
+ *
+ * The caller must only invoke this from a real user intent (tray open) or an
+ * explicit `slice=` deep link: a cold report load has to issue ZERO sidecar
+ * requests.
+ */
+export function useSliceSidecarLoader({ url, settingsHash, onSidecar }: {
+    url: string | null | undefined;
+    settingsHash: string | null;
+    onSidecar: (sidecar: SliceSidecar) => void;
+}): { sliceState: SliceLoadState; loadSliceSidecar: () => Promise<SliceSidecar | null> } {
+    const [sliceState, setSliceState] = useState<SliceLoadState>({ status: 'idle', sidecar: null, message: null });
+    const inFlightRef = useRef<Promise<SliceSidecar | null> | null>(null);
+    const sidecarRef = useRef<SliceSidecar | null>(null);
+
+    const loadSliceSidecar = useCallback((): Promise<SliceSidecar | null> => {
+        if (sidecarRef.current) return Promise.resolve(sidecarRef.current);
+        // A second caller joins the first request rather than starting its own.
+        if (inFlightRef.current) return inFlightRef.current;
+        if (!url) {
+            setSliceState({ status: 'unavailable', sidecar: null, message: 'This report was published without slice data.' });
+            return Promise.resolve(null);
+        }
+        setSliceState({ status: 'loading', sidecar: null, message: 'Loading slice data…' });
+        const request = (async () => {
+            try {
+                const result = await fetchSliceSidecar(url, settingsHash || null);
+                if (!result.ok) {
+                    setSliceState({ status: 'unavailable', sidecar: null, message: result.message });
+                    return null;
+                }
+                sidecarRef.current = result.sidecar;
+                onSidecar(result.sidecar);
+                setSliceState({ status: 'ready', sidecar: result.sidecar, message: null });
+                return result.sidecar;
+            } catch {
+                setSliceState({
+                    status: 'unavailable',
+                    sidecar: null,
+                    message: 'Could not load slice data — showing all fights.',
+                });
+                return null;
+            } finally {
+                inFlightRef.current = null;
+            }
+        })();
+        inFlightRef.current = request;
+        return request;
+    }, [url, settingsHash, onSidecar]);
+
+    return { sliceState, loadSliceSidecar };
+}

--- a/src/web/reportApp.tsx
+++ b/src/web/reportApp.tsx
@@ -20,6 +20,7 @@ import { encodeSliceMask, decodeSliceMask } from '../renderer/stats/slice/sliceB
 import { useStatsStore } from '../renderer/stats/statsStore';
 import type { SliceSidecar } from '../renderer/stats/slice/sliceTypes';
 import { useSliceRecompute } from './hooks/useSliceRecompute';
+import { computeIncludedOrdinals } from '../renderer/stats/slice/computeIncludedOrdinals';
 import { useSliceSidecarLoader } from './hooks/useSliceSidecarLoader';
 import {
     ShieldCheck,
@@ -690,20 +691,10 @@ export function ReportApp() {
         onSidecar: handleSidecarLoaded,
     });
 
-    const includedOrdinals = useMemo(() => {
-        const sidecar = sliceState.sidecar;
-        if (!sidecar || excludedFightKeys.size === 0) return null;
-        // An EMPTY array is returned deliberately. `null` here means "no slice
-        // active"; `[]` means "the slice selects no fights", which the tray's
-        // None button and an empty shared bitmask both reach. Folding `[]` into
-        // `null` used to make a zero-fight slice render the FULL report under a
-        // "Sliced view — 0 of N fights" banner. The recompute handles the empty
-        // selection and returns the real zero-fight aggregation.
-        return sidecar.fights
-            .map((fight, ordinal) => ({ fight, ordinal }))
-            .filter(({ fight }) => !excludedFightKeys.has(fight.id))
-            .map(({ ordinal }) => ordinal);
-    }, [sliceState.sidecar, excludedFightKeys]);
+    const includedOrdinals = useMemo(
+        () => computeIncludedOrdinals(sliceState.sidecar, excludedFightKeys),
+        [sliceState.sidecar, excludedFightKeys],
+    );
 
     // Task 15 review round 2 (R15-6): the viewer has no settings of its own
     // in slice mode, so it must hash/merge from the SAME published values the

--- a/src/web/reportApp.tsx
+++ b/src/web/reportApp.tsx
@@ -764,9 +764,26 @@ export function ReportApp() {
         // Query, not hash: the hash is the section-anchor channel, and a slice
         // has to survive jumping to a section.
         url.searchParams.set('slice', encodeSliceMask(included, sidecar.fights.length));
-        void navigator.clipboard?.writeText(url.toString());
-        setSliceLinkStatus('Slice link copied.');
-        window.setTimeout(() => setSliceLinkStatus(null), 2000);
+        // Only claim success once the write actually resolves. The clipboard API
+        // is absent outside a secure context and can reject on a denied
+        // permission, and telling someone their link is copied when it is not
+        // costs them the slice they just built.
+        const written = navigator.clipboard?.writeText(url.toString());
+        if (!written) {
+            setSliceLinkStatus('Could not copy — copy the address bar URL instead.');
+            window.setTimeout(() => setSliceLinkStatus(null), 4000);
+            return;
+        }
+        void written.then(
+            () => {
+                setSliceLinkStatus('Slice link copied.');
+                window.setTimeout(() => setSliceLinkStatus(null), 2000);
+            },
+            () => {
+                setSliceLinkStatus('Could not copy — copy the address bar URL instead.');
+                window.setTimeout(() => setSliceLinkStatus(null), 4000);
+            },
+        );
     }, [sliceState.sidecar, excludedFightKeys]);
 
     const scrollToSection = (id: string) => {

--- a/src/web/reportApp.tsx
+++ b/src/web/reportApp.tsx
@@ -17,6 +17,7 @@ import type { SquadStatPlayer } from '../shared/squadStats';
 import type { ReportPayload, ReportIndexEntry } from '../shared/reportTypes';
 import { expandIconIndex, normalizeCommanderDistance, normalizeTopDownContribution } from '../shared/reportNormalization';
 import { fetchSliceSidecar } from '../renderer/stats/slice/fetchSliceSidecar';
+import { encodeSliceMask, decodeSliceMask } from '../renderer/stats/slice/sliceBitmask';
 import { mergeSliceFrames } from '../renderer/stats/slice/mergeSliceFrames';
 import { useStatsStore } from '../renderer/stats/statsStore';
 import type { SliceSidecar } from '../renderer/stats/slice/sliceTypes';
@@ -722,6 +723,52 @@ export function ReportApp() {
             disruptionMethod: (report?.stats as any)?.disruptionMethod,
         }).stats;
     }, [sliceState.sidecar, excludedFightKeys, report]);
+
+    const requestedSlice = useMemo(() => (initialSearchParams.get('slice') || '').trim(), [initialSearchParams]);
+    const [sliceLinkStatus, setSliceLinkStatus] = useState<string | null>(null);
+    const deepLinkApplied = useRef(false);
+
+    // Landing on a slice= URL paints the full report first, then applies the
+    // slice once the sidecar resolves — blocking first paint on a multi-megabyte
+    // fetch is a worse trade than a brief flash of unsliced numbers.
+    useEffect(() => {
+        if (!requestedSlice || deepLinkApplied.current || !report) return;
+        deepLinkApplied.current = true;
+        setSliceLinkStatus('Applying slice…');
+        void (async () => {
+            const sidecar = await loadSliceSidecar();
+            if (!sidecar) { setSliceLinkStatus(null); return; }
+            const included = decodeSliceMask(requestedSlice, sidecar.fights.length);
+            if (!included) {
+                // A stale link degrades to the truth, never to wrong numbers.
+                setSliceLinkStatus('This slice link does not match the report — showing all fights.');
+                return;
+            }
+            const includedIds = new Set(included.map((ordinal) => sidecar.fights[ordinal]?.id).filter(Boolean));
+            useStatsStore.getState().setFightsExcluded(
+                sidecar.fights.filter((f) => !includedIds.has(f.id)).map((f) => f.id),
+                true,
+            );
+            setSliceLinkStatus(null);
+        })();
+    }, [requestedSlice, report, loadSliceSidecar]);
+
+    const handleCopySliceLink = useCallback(() => {
+        const sidecar = sliceState.sidecar;
+        if (!sidecar) return;
+        const included = sidecar.fights
+            .map((fight, ordinal) => ({ fight, ordinal }))
+            .filter(({ fight }) => !excludedFightKeys.has(fight.id))
+            .map(({ ordinal }) => ordinal);
+        const url = new URL(window.location.href);
+        // Query, not hash: the hash is the section-anchor channel, and a slice
+        // has to survive jumping to a section.
+        url.searchParams.set('slice', encodeSliceMask(included, sidecar.fights.length));
+        void navigator.clipboard?.writeText(url.toString());
+        setSliceLinkStatus('Slice link copied.');
+        window.setTimeout(() => setSliceLinkStatus(null), 2000);
+    }, [sliceState.sidecar, excludedFightKeys]);
+
     const scrollToSection = (id: string) => {
         if (id === 'report-top') {
             window.scrollTo({ top: 0, behavior: 'smooth' });
@@ -1823,6 +1870,11 @@ export function ReportApp() {
                     </div>
                     <div ref={statsWrapperRef} onWheelCapture={handleStatsWheel} className="flex-1 min-w-0">
                         <div id="stats-view-top">
+                            {(sliceLinkStatus || sliceState.message) && (
+                                <div className="mb-3 rounded-xl border border-white/10 bg-white/5 px-3 py-2 text-[11px] font-semibold uppercase tracking-widest text-gray-300">
+                                    {sliceLinkStatus || sliceState.message}
+                                </div>
+                            )}
                             <StatsView
                                 logs={[]}
                                 onBack={() => { }}
@@ -1832,6 +1884,7 @@ export function ReportApp() {
                                 embedded
                                 sliceEnabled={Boolean((report.stats as any)?.sliceDataUrl)}
                                 onOpenSliceTray={loadSliceSidecar}
+                                onCopySliceLink={handleCopySliceLink}
                                 sectionVisibility={sectionVisibilityFn}
                                 dashboardTitle={dashboardTitleText}
                                 onRequestCategory={(categoryId) => startTransition(() => setActiveGroup(categoryId))}

--- a/src/web/reportApp.tsx
+++ b/src/web/reportApp.tsx
@@ -18,9 +18,9 @@ import type { ReportPayload, ReportIndexEntry } from '../shared/reportTypes';
 import { expandIconIndex, normalizeCommanderDistance, normalizeTopDownContribution } from '../shared/reportNormalization';
 import { fetchSliceSidecar } from '../renderer/stats/slice/fetchSliceSidecar';
 import { encodeSliceMask, decodeSliceMask } from '../renderer/stats/slice/sliceBitmask';
-import { mergeSliceFrames } from '../renderer/stats/slice/mergeSliceFrames';
 import { useStatsStore } from '../renderer/stats/statsStore';
 import type { SliceSidecar } from '../renderer/stats/slice/sliceTypes';
+import { useSliceRecompute } from './hooks/useSliceRecompute';
 import {
     ShieldCheck,
     CalendarDays,
@@ -703,26 +703,29 @@ export function ReportApp() {
         return result.sidecar;
     }, [report, sliceState.sidecar, mergeFightRoster]);
 
-    const slicedStats = useMemo(() => {
+    const includedOrdinals = useMemo(() => {
         const sidecar = sliceState.sidecar;
         if (!sidecar || excludedFightKeys.size === 0) return null;
         const included = sidecar.fights
             .map((fight, ordinal) => ({ fight, ordinal }))
             .filter(({ fight }) => !excludedFightKeys.has(fight.id))
             .map(({ ordinal }) => ordinal);
-        if (included.length === 0) return null;
-        return mergeSliceFrames({
-            sidecar,
-            includedOrdinals: included,
-            // Task 15 review round 2 (R15-6): the viewer has no settings of
-            // its own in slice mode, so it must hash/merge from the SAME
-            // published values the sidecar was built under, or its
-            // settingsHash can never agree with the publisher's.
-            mvpWeights: (report?.stats as any)?.mvpWeights,
-            statsViewSettings: (report?.stats as any)?.statsViewSettings,
-            disruptionMethod: (report?.stats as any)?.disruptionMethod,
-        }).stats;
-    }, [sliceState.sidecar, excludedFightKeys, report]);
+        return included.length > 0 ? included : null;
+    }, [sliceState.sidecar, excludedFightKeys]);
+
+    // Task 15 review round 2 (R15-6): the viewer has no settings of its own
+    // in slice mode, so it must hash/merge from the SAME published values the
+    // sidecar was built under, or its settingsHash can never agree with the
+    // publisher's. Merging 25 frames and running finalize() costs about what
+    // a full aggregation costs, so — unlike Task 18's synchronous useMemo —
+    // this now round-trips through the stats worker (Task 20).
+    const { stats: slicedStats, computing: sliceComputing } = useSliceRecompute({
+        sidecar: sliceState.sidecar,
+        includedOrdinals,
+        mvpWeights: (report?.stats as any)?.mvpWeights,
+        statsViewSettings: (report?.stats as any)?.statsViewSettings,
+        disruptionMethod: (report?.stats as any)?.disruptionMethod,
+    });
 
     const requestedSlice = useMemo(() => (initialSearchParams.get('slice') || '').trim(), [initialSearchParams]);
     const [sliceLinkStatus, setSliceLinkStatus] = useState<string | null>(null);
@@ -1887,9 +1890,9 @@ export function ReportApp() {
                     </div>
                     <div ref={statsWrapperRef} onWheelCapture={handleStatsWheel} className="flex-1 min-w-0">
                         <div id="stats-view-top">
-                            {(sliceLinkStatus || sliceState.message) && (
+                            {(sliceLinkStatus || sliceState.message || sliceComputing) && (
                                 <div className="mb-3 rounded-xl border border-white/10 bg-white/5 px-3 py-2 text-[11px] font-semibold uppercase tracking-widest text-gray-300">
-                                    {sliceLinkStatus || sliceState.message}
+                                    {sliceLinkStatus || sliceState.message || (sliceComputing ? 'Recomputing…' : null)}
                                 </div>
                             )}
                             <StatsView

--- a/src/web/reportApp.tsx
+++ b/src/web/reportApp.tsx
@@ -16,11 +16,11 @@ import { MetricDistributionCard } from '../renderer/stats/components/MetricDistr
 import type { SquadStatPlayer } from '../shared/squadStats';
 import type { ReportPayload, ReportIndexEntry } from '../shared/reportTypes';
 import { expandIconIndex, normalizeCommanderDistance, normalizeTopDownContribution } from '../shared/reportNormalization';
-import { fetchSliceSidecar } from '../renderer/stats/slice/fetchSliceSidecar';
 import { encodeSliceMask, decodeSliceMask } from '../renderer/stats/slice/sliceBitmask';
 import { useStatsStore } from '../renderer/stats/statsStore';
 import type { SliceSidecar } from '../renderer/stats/slice/sliceTypes';
 import { useSliceRecompute } from './hooks/useSliceRecompute';
+import { useSliceSidecarLoader } from './hooks/useSliceSidecarLoader';
 import {
     ShieldCheck,
     CalendarDays,
@@ -322,11 +322,6 @@ export function ReportApp() {
     const [logoUrl, setLogoUrl] = useState<string | null>(null);
     const [logoIsDefault, setLogoIsDefault] = useState(false);
     const [tocOpen, setTocOpen] = useState(false);
-    const [sliceState, setSliceState] = useState<{
-        status: 'idle' | 'loading' | 'ready' | 'unavailable';
-        sidecar: SliceSidecar | null;
-        message: string | null;
-    }>({ status: 'idle', sidecar: null, message: null });
     const requestedView = useMemo(() => (initialSearchParams.get('view') || '').trim().toLowerCase(), [initialSearchParams]);
     const reportId = useMemo(
         () => initialSearchParams.get('report') || window.location.pathname.match(/\/reports\/([^/]+)\/?$/)?.[1] || null,
@@ -683,25 +678,17 @@ export function ReportApp() {
     const excludedFightKeys = useStatsStore((s) => s.excludedFightKeys);
     const mergeFightRoster = useStatsStore((s) => s.mergeFightRoster);
 
-    const loadSliceSidecar = useCallback(async (): Promise<SliceSidecar | null> => {
-        if (sliceState.sidecar) return sliceState.sidecar;
-        const url = (report?.stats as any)?.sliceDataUrl;
-        if (!url) {
-            setSliceState({ status: 'unavailable', sidecar: null, message: 'This report was published without slice data.' });
-            return null;
-        }
-        setSliceState({ status: 'loading', sidecar: null, message: null });
-        const result = await fetchSliceSidecar(url, (report?.stats as any)?.sliceSettingsHash || null);
-        if (!result.ok) {
-            setSliceState({ status: 'unavailable', sidecar: null, message: result.message });
-            return null;
-        }
-        // The tray reads fightRoster, so the sidecar's frozen publish order
-        // becomes the roster — ordinals and tray cards agree by construction.
-        mergeFightRoster(result.sidecar.fights, result.sidecar.fights.map((f) => f.id));
-        setSliceState({ status: 'ready', sidecar: result.sidecar, message: null });
-        return result.sidecar;
-    }, [report, sliceState.sidecar, mergeFightRoster]);
+    // The tray reads fightRoster, so the sidecar's frozen publish order becomes
+    // the roster — ordinals and tray cards agree by construction.
+    const handleSidecarLoaded = useCallback((sidecar: SliceSidecar) => {
+        mergeFightRoster(sidecar.fights, sidecar.fights.map((f) => f.id));
+    }, [mergeFightRoster]);
+
+    const { sliceState, loadSliceSidecar } = useSliceSidecarLoader({
+        url: (report?.stats as any)?.sliceDataUrl,
+        settingsHash: (report?.stats as any)?.sliceSettingsHash || null,
+        onSidecar: handleSidecarLoaded,
+    });
 
     const includedOrdinals = useMemo(() => {
         const sidecar = sliceState.sidecar;

--- a/src/web/reportApp.tsx
+++ b/src/web/reportApp.tsx
@@ -706,11 +706,16 @@ export function ReportApp() {
     const includedOrdinals = useMemo(() => {
         const sidecar = sliceState.sidecar;
         if (!sidecar || excludedFightKeys.size === 0) return null;
-        const included = sidecar.fights
+        // An EMPTY array is returned deliberately. `null` here means "no slice
+        // active"; `[]` means "the slice selects no fights", which the tray's
+        // None button and an empty shared bitmask both reach. Folding `[]` into
+        // `null` used to make a zero-fight slice render the FULL report under a
+        // "Sliced view — 0 of N fights" banner. The recompute handles the empty
+        // selection and returns the real zero-fight aggregation.
+        return sidecar.fights
             .map((fight, ordinal) => ({ fight, ordinal }))
             .filter(({ fight }) => !excludedFightKeys.has(fight.id))
             .map(({ ordinal }) => ordinal);
-        return included.length > 0 ? included : null;
     }, [sliceState.sidecar, excludedFightKeys]);
 
     // Task 15 review round 2 (R15-6): the viewer has no settings of its own
@@ -719,7 +724,7 @@ export function ReportApp() {
     // publisher's. Merging 25 frames and running finalize() costs about what
     // a full aggregation costs, so — unlike Task 18's synchronous useMemo —
     // this now round-trips through the stats worker (Task 20).
-    const { stats: slicedStats, computing: sliceComputing } = useSliceRecompute({
+    const { stats: slicedStats, computing: sliceComputing, error: sliceError } = useSliceRecompute({
         sidecar: sliceState.sidecar,
         includedOrdinals,
         mvpWeights: (report?.stats as any)?.mvpWeights,
@@ -1890,9 +1895,9 @@ export function ReportApp() {
                     </div>
                     <div ref={statsWrapperRef} onWheelCapture={handleStatsWheel} className="flex-1 min-w-0">
                         <div id="stats-view-top">
-                            {(sliceLinkStatus || sliceState.message || sliceComputing) && (
+                            {(sliceLinkStatus || sliceError || sliceState.message || sliceComputing) && (
                                 <div className="mb-3 rounded-xl border border-white/10 bg-white/5 px-3 py-2 text-[11px] font-semibold uppercase tracking-widest text-gray-300">
-                                    {sliceLinkStatus || sliceState.message || (sliceComputing ? 'Recomputing…' : null)}
+                                    {sliceLinkStatus || sliceError || sliceState.message || (sliceComputing ? 'Recomputing…' : null)}
                                 </div>
                             )}
                             <StatsView
@@ -1903,6 +1908,10 @@ export function ReportApp() {
                                 statsViewSettings={report.stats?.statsViewSettings}
                                 embedded
                                 sliceEnabled={Boolean((report.stats as any)?.sliceDataUrl)}
+                                // The recompute failed or refused, so the numbers
+                                // on screen are the full report's. Tell the banner,
+                                // so it says so instead of claiming a slice.
+                                sliceUnavailable={Boolean(sliceError)}
                                 onOpenSliceTray={loadSliceSidecar}
                                 onCopySliceLink={handleCopySliceLink}
                                 sectionVisibility={sectionVisibilityFn}

--- a/src/web/reportApp.tsx
+++ b/src/web/reportApp.tsx
@@ -16,6 +16,10 @@ import { MetricDistributionCard } from '../renderer/stats/components/MetricDistr
 import type { SquadStatPlayer } from '../shared/squadStats';
 import type { ReportPayload, ReportIndexEntry } from '../shared/reportTypes';
 import { expandIconIndex, normalizeCommanderDistance, normalizeTopDownContribution } from '../shared/reportNormalization';
+import { fetchSliceSidecar } from '../renderer/stats/slice/fetchSliceSidecar';
+import { mergeSliceFrames } from '../renderer/stats/slice/mergeSliceFrames';
+import { useStatsStore } from '../renderer/stats/statsStore';
+import type { SliceSidecar } from '../renderer/stats/slice/sliceTypes';
 import {
     ShieldCheck,
     CalendarDays,
@@ -317,6 +321,11 @@ export function ReportApp() {
     const [logoUrl, setLogoUrl] = useState<string | null>(null);
     const [logoIsDefault, setLogoIsDefault] = useState(false);
     const [tocOpen, setTocOpen] = useState(false);
+    const [sliceState, setSliceState] = useState<{
+        status: 'idle' | 'loading' | 'ready' | 'unavailable';
+        sidecar: SliceSidecar | null;
+        message: string | null;
+    }>({ status: 'idle', sidecar: null, message: null });
     const requestedView = useMemo(() => (initialSearchParams.get('view') || '').trim().toLowerCase(), [initialSearchParams]);
     const reportId = useMemo(
         () => initialSearchParams.get('report') || window.location.pathname.match(/\/reports\/([^/]+)\/?$/)?.[1] || null,
@@ -670,6 +679,49 @@ export function ReportApp() {
         () => `Statistics Dashboard - ${activeGroupDef?.label || 'Overview'}`,
         [activeGroupDef]
     );
+    const excludedFightKeys = useStatsStore((s) => s.excludedFightKeys);
+    const mergeFightRoster = useStatsStore((s) => s.mergeFightRoster);
+
+    const loadSliceSidecar = useCallback(async (): Promise<SliceSidecar | null> => {
+        if (sliceState.sidecar) return sliceState.sidecar;
+        const url = (report?.stats as any)?.sliceDataUrl;
+        if (!url) {
+            setSliceState({ status: 'unavailable', sidecar: null, message: 'This report was published without slice data.' });
+            return null;
+        }
+        setSliceState({ status: 'loading', sidecar: null, message: null });
+        const result = await fetchSliceSidecar(url, (report?.stats as any)?.sliceSettingsHash || null);
+        if (!result.ok) {
+            setSliceState({ status: 'unavailable', sidecar: null, message: result.message });
+            return null;
+        }
+        // The tray reads fightRoster, so the sidecar's frozen publish order
+        // becomes the roster — ordinals and tray cards agree by construction.
+        mergeFightRoster(result.sidecar.fights, result.sidecar.fights.map((f) => f.id));
+        setSliceState({ status: 'ready', sidecar: result.sidecar, message: null });
+        return result.sidecar;
+    }, [report, sliceState.sidecar, mergeFightRoster]);
+
+    const slicedStats = useMemo(() => {
+        const sidecar = sliceState.sidecar;
+        if (!sidecar || excludedFightKeys.size === 0) return null;
+        const included = sidecar.fights
+            .map((fight, ordinal) => ({ fight, ordinal }))
+            .filter(({ fight }) => !excludedFightKeys.has(fight.id))
+            .map(({ ordinal }) => ordinal);
+        if (included.length === 0) return null;
+        return mergeSliceFrames({
+            sidecar,
+            includedOrdinals: included,
+            // Task 15 review round 2 (R15-6): the viewer has no settings of
+            // its own in slice mode, so it must hash/merge from the SAME
+            // published values the sidecar was built under, or its
+            // settingsHash can never agree with the publisher's.
+            mvpWeights: (report?.stats as any)?.mvpWeights,
+            statsViewSettings: (report?.stats as any)?.statsViewSettings,
+            disruptionMethod: (report?.stats as any)?.disruptionMethod,
+        }).stats;
+    }, [sliceState.sidecar, excludedFightKeys, report]);
     const scrollToSection = (id: string) => {
         if (id === 'report-top') {
             window.scrollTo({ top: 0, behavior: 'smooth' });
@@ -1775,9 +1827,11 @@ export function ReportApp() {
                                 logs={[]}
                                 onBack={() => { }}
                                 mvpWeights={undefined}
-                                precomputedStats={report.stats}
+                                precomputedStats={slicedStats || report.stats}
                                 statsViewSettings={report.stats?.statsViewSettings}
                                 embedded
+                                sliceEnabled={Boolean((report.stats as any)?.sliceDataUrl)}
+                                onOpenSliceTray={loadSliceSidecar}
                                 sectionVisibility={sectionVisibilityFn}
                                 dashboardTitle={dashboardTitleText}
                                 onRequestCategory={(categoryId) => startTransition(() => setActiveGroup(categoryId))}

--- a/tests/e2e/web/fight-slice.spec.ts
+++ b/tests/e2e/web/fight-slice.spec.ts
@@ -1,0 +1,20 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('published report fight slicer', () => {
+    test('a cold report load issues no sidecar request', async ({ page }) => {
+        // The feature must be free for the overwhelming majority of views.
+        const sidecarRequests: string[] = [];
+        page.on('request', (req) => {
+            if (req.url().includes('slice.json')) sidecarRequests.push(req.url());
+        });
+        await page.goto('/');
+        await page.waitForLoadState('networkidle');
+        expect(sidecarRequests).toEqual([]);
+    });
+
+    test('a report without slice data shows no slice pill', async ({ page }) => {
+        await page.goto('/');
+        await page.waitForLoadState('networkidle');
+        await expect(page.getByRole('button', { name: /slice fights/i })).toHaveCount(0);
+    });
+});


### PR DESCRIPTION
Phase B of the fight slicer: slice a **published** web report down to a subset of fights and share the result as a link. Implements `docs/superpowers/specs/2026-08-22-fight-slicer-phase-b-design.md` (Phase A shipped the desktop-side slicer).

## How it works

The published report ships one frozen aggregation and no per-fight inputs, so slicing needs new payload. Rather than shipping raw logs, the publisher writes a **slice sidecar** — one *pre-finalize* snapshot of the `IncrementalAggregator` per fight (a "frame").

The correctness invariant the whole feature rests on:

```
finalize(merge(frame(A), frame(B))) === finalize(ingest(A); ingest(B))
```

Because frames are captured before `finalize()`, everything derived — leaderboards, MVPs, top stats, role classifications, boon leaderboards — recomputes in the browser for free and is *never* stored in a frame. Merging the selected frames and finalizing happens on the existing stats worker via a new `mergeFrames` message, not on the main thread.

A slice is addressed by a base64url bitmask over stable fight ordinals in the `slice` query parameter (query, not hash — the hash is already the section-anchor channel and a slice has to survive jumping to a section).

## Cost model

Four constraints held throughout:

- **Byte-identical without R2.** A report published without R2 configured produces the same bytes it did before this branch. No GitHub payload growth — an earlier 1.9x proposal was rejected because it halves how many reports a repo can hold.
- **Sidecar is R2-only,** per-user configured, never GitHub Pages.
- **Cold-load guarantee.** Zero sidecar requests unless the URL carries `slice=` or the user opens the tray. Pinned by e2e.
- **No derived sections in frames.**

Landing on a `slice=` link paints the full report first, then applies the slice — a brief flash of unsliced numbers beats blocking first paint on a multi-megabyte fetch. A stale or mismatched link degrades to the truth ("showing all fights"), never to wrong numbers under a slice banner.

## Review

Executed as 21 tasks under subagent-driven development: fresh implementer per task, spec+quality review after each, then a whole-branch review and a scoped re-review.

The dominant failure mode on this branch was **tests that passed for the wrong reason** — twelve of them, caught by flip-testing (break the rule, confirm the *specific* test fails, restore). Notable finds:

- **C2** — an empty selection was short-circuited to "no slice", so excluding every fight rendered the *full* report under a "Sliced view — 0 of N fights" banner. `null` (no slice) and `[]` (a slice selecting nothing) are not the same thing.
- **C1** — the unknown-field guard's `IS_PRODUCTION` check was false in a browser worker, so the `throw` fired in exactly the environment whose comment promised graceful degradation.
- **M1** — slice mode has no settings of its own; it must hash and merge under the *published* values the sidecar was built for. The hook re-hashes and refuses to merge on mismatch.
- The final re-review's flip-test showed the three lines of `reportApp` composing the hooks were pinned by *nothing* — reintroducing C2 there left all 49 web tests green. Fixed by extracting `computeIncludedOrdinals` with its own pins.

Findings not fixed are ruled and recorded rather than dropped — see the rulings in the branch ledger. The parked ones are display-only (a banner saying the wrong thing while the numbers stay correct) or need a test harness that doesn't exist yet.

## Verification

- `npm run test:unit` — **236 files / 2025 tests pass**
- `npm run validate` — typecheck + eslint clean (`--max-warnings 0`)
- `npm run audit:boons` / `audit:metrics` / `audit:conditions` / `audit:conditions:consistency` — all PASS (the check that folding player loops into seven metric modules changed no numbers)
- `npm run test:e2e:web` — passes, including `fight-slice.spec.ts`

## Known follow-ups

- The cold-load e2e assertions are meaningful but the *positive* path is untested: the local fixture publishes without R2, so it carries no `sliceDataUrl`. A positive-path e2e needs a fixture report plus a served `slice.json.gz`.
- Frames are re-cloned to the worker on every selection change.
- `boonTableLogs` is ~18% of the sidecar (~34 KB/frame) and measured safe to trim — deferred as a payload change late on a long branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
