### PR TITLE
docs: phase C design — sign in with Cloudflare to provision R2

### DIFF
--- a/docs/superpowers/plans/2026-08-22-fight-slicer-phase-b.md
+++ b/docs/superpowers/plans/2026-08-22-fight-slicer-phase-b.md
@@ -1,5 +1,11 @@
 # Fight Slicer Phase B — Web Report Slicing Implementation Plan
 
+> **Status: SHIPPED.** All 21 tasks landed and merged to `main` in PR #41
+> (merge commit `4149e1f8`, 2026-08-23). The checkboxes below were never ticked
+> during subagent-driven implementation — the commit log, not this file, is the
+> record of what was built. Kept for the design rationale and the global
+> constraints, which still bind.
+
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
 **Goal:** Let a viewer of a published AxiBridge web report select a subset of fights and see every stat recomputed for just those fights, and share that selection as a URL.

--- a/docs/superpowers/specs/2026-08-23-r2-oauth-phase-c-design.md
+++ b/docs/superpowers/specs/2026-08-23-r2-oauth-phase-c-design.md
@@ -40,22 +40,99 @@ this phase.
 
 - **Hosting `report.json` itself on R2.** Pages serves the report URL; moving the
   payload off it is a separate design with CORS and share-link implications.
-- **Replacing SigV4 uploads.** See below — OAuth cannot do this.
+- **Replacing SigV4 uploads.** Manual mode keeps its hand-rolled SigV4 path unchanged.
+  OAuth mode gets a second, bearer-token transport beside it — not a migration.
 - **Removing the manual fields.** They stay, as fallback and for custom domains.
 
-## Constraint: OAuth cannot authenticate the uploads
+## Verified against the live API, 2026-08-23
 
-R2's data plane is the S3-compatible API, authenticated with AWS Signature Version 4.
-There is no documented Cloudflare REST endpoint for putting an object into a bucket —
-the [REST API](https://developers.cloudflare.com/r2/platform/limits/) is bucket
-management and configuration, rate limited to 1,200 requests per five minutes, and
-Cloudflare's own troubleshooting page notes that object-level tokens fail against it
-entirely. An OAuth access token is a bearer token and cannot sign a SigV4 request.
+Everything in this section was checked directly rather than inferred from prose. Two
+findings reverse the first draft of this design.
 
-**Therefore OAuth is a provisioning mechanism, not an upload credential.** The app
-still ends up holding an access key pair; it just mints one instead of asking for it.
-`r2SignedRequest`, `r2PutObject`, `r2DeleteObject` and `r2EnsureBucketCors`
-(`githubHandlers.ts:486-650`) are unchanged by this phase.
+### OAuth *can* carry the uploads — via the REST API, not SigV4
+
+The first draft asserted "there is no documented Cloudflare REST endpoint for putting
+an object into a bucket." That is wrong. The endpoint exists:
+
+```
+PUT /accounts/{account_id}/r2/buckets/{bucket_name}/objects/{object_key}
+```
+
+> "Uploads an object to an R2 bucket. The object body is provided as the request body.
+> The maximum upload size for this endpoint is 300 MB. For most workloads, we recommend
+> using R2's S3-compatible API or a Worker with an R2 binding instead."
+
+It takes a plain `Authorization: Bearer` token. So an OAuth access token holding
+`workers-r2.write` can upload a sidecar with **no API token and no SigV4 at all**.
+
+Confirmed empirically: an OAuth access token (Wrangler's, as a stand-in) authenticates
+successfully against `GET /accounts/{id}/r2/buckets`. OAuth bearer → R2 REST API works.
+
+Constraints that come with this path:
+
+| | |
+|---|---|
+| Max object size | **300 MB** per request (vs 5 GiB single-part on S3) |
+| Rate limit | 1,200 requests / 5 min across *all* R2 REST operations on the account |
+| Object-scoped tokens | Not supported by the REST API — admin-level `workers-r2.write` required |
+
+Both limits are comfortable for AxiBridge: a publish writes two or three objects, and
+`replay.json` — the largest artifact — sits well under 300 MB after the trim pass. It is
+not comfortable for anything that grows, so the ceiling belongs in a check, not a
+comment.
+
+### OAuth *cannot* mint an API token — the scope does not exist
+
+This was open question 2, and it resolves **no**.
+
+`GET /client/v4/oauth/scopes` returns **383 scopes**. None of them grants API token
+management. Searching the full catalog for `token`, `iam`, `permission`, `credential`
+or `api-key` yields exactly one unrelated hit (`access-service-token.*`, Zero Trust
+service tokens). There is no `api-tokens.write` equivalent to request.
+
+Confirmed empirically: `GET /user/tokens` with an OAuth access token returns
+
+```json
+{"success": false, "errors": [{"code": 9109, "message": "Unauthorized to access requested resource"}]}
+```
+
+while `GET /accounts` on the same token succeeds. The token is valid; token management
+is simply not reachable through OAuth.
+
+The R2 scopes that *do* exist:
+
+| scope id | name |
+|---|---|
+| `workers-r2.write` | Workers R2 Storage Write (admin) |
+| `workers-r2.read` | Workers R2 Storage Read |
+| `workers-r2.metadata_read` | Workers R2 Storage Metadata Read |
+| `workers-r2-bucket-item.write` | Workers R2 Storage Bucket Item Write |
+| `workers-r2-bucket-item.read` | Workers R2 Storage Bucket Item Read |
+
+`POST /accounts/{id}/r2/temp-access-credentials` is not a way around this: it requires
+`parentAccessKeyId`, so it derives from an API token that must already exist.
+
+### What this changes
+
+The first draft's plan — OAuth mints an API token, we derive an S3 key pair from it,
+every existing upload path stays untouched — **is not buildable**. The replacement is
+better in one way and worse in two:
+
+- **Better:** no long-lived credential is ever created, stored, or leaked. Nothing to
+  revoke on disconnect except the OAuth grant itself, which the user can already do from
+  their Cloudflare profile.
+- **Worse:** AxiBridge grows a *second* upload path. `r2SignedRequest`, `r2PutObject`,
+  `r2DeleteObject` and `r2EnsureBucketCors` (`githubHandlers.ts:486-650`) stay for manual
+  mode, and an OAuth mode adds bearer-token REST equivalents beside them.
+- **Worse:** publishing now depends on a live OAuth session. The first draft's key pair
+  outlived the grant; a bearer token does not. Access tokens must be refreshed before
+  each publish, and a rejected refresh token breaks publishing until the user re-signs-in.
+
+The consent scope is also coarser than the first draft implied. `workers-r2.write` is
+account-wide R2 admin — it cannot be narrowed to one bucket at consent time. The screen
+will say AxiBridge can read and write *all* R2 storage in the selected account. That is
+a real thing to disclose, and an argument for keeping manual mode prominent for anyone
+who would rather hand over a bucket-scoped key.
 
 ## Design
 
@@ -77,12 +154,29 @@ Registration is a one-time act by the maintainer, not the user:
 - `grant_types: ["authorization_code"]`, `response_types: ["code"]`,
   `token_endpoint_auth_method: "none"`
 - Redirect URI: a loopback listener, `http://127.0.0.1:<ephemeral>/oauth/callback`
-- Scopes: the R2 admin permission (scope names correspond to API token permission
-  names) plus whatever is needed to create an API token
+- Scopes: `workers-r2.write` (account-wide R2 admin — the REST object endpoints do not
+  accept object-scoped grants), `memberships.read` to enumerate authorizable accounts,
+  and `offline_access` for a refresh token
 - **Domain verification is required before the client can be made public.** A private
   client only works for members of the registering account, which is useless here.
   This needs a DNS TXT record on a domain we control, plus a logo, client URL, policy
   URL and ToS URL for the consent screen.
+
+Endpoints, from Cloudflare's
+[discovery document](https://dash.cloudflare.com/.well-known/openid-configuration):
+
+```
+authorize  https://dash.cloudflare.com/oauth2/auth
+token      https://dash.cloudflare.com/oauth2/token
+revoke     https://dash.cloudflare.com/oauth2/revoke
+jwks       https://dash.cloudflare.com/.well-known/jwks.json
+```
+
+The document advertises `code_challenge_methods_supported: ["plain", "S256"]` and
+`token_endpoint_auth_methods_supported` including `"none"`, so the public-client +
+PKCE-S256 shape is supported at the protocol level. (It also advertises `implicit`,
+`client_credentials` and device code — those are first-party only; the docs state
+plainly that third-party clients get authorization code and nothing else.)
 
 ### 2. The provisioning flow
 
@@ -96,22 +190,36 @@ Registration is a one-time act by the maintainer, not the user:
 3. On callback: validate `state`, exchange the code + verifier for an access token
    (and refresh token) at the token endpoint.
 4. Call the REST API with the access token to:
-   a. list accounts the user authorized, and let them pick if more than one;
-   b. create the bucket (default name `axibridge-reports`, adopt it if it already
-      exists and is empty-or-ours);
-   c. enable the bucket's public development URL and read back the
-      `pub-<hash>.r2.dev` hostname;
-   d. create an R2 API token scoped to that bucket with object read+write.
-5. Derive the S3 credentials from the token response, per
-   [R2 Tokens](https://developers.cloudflare.com/r2/api/tokens/):
-   - `r2AccessKeyId` = the token's `id`
-   - `r2SecretAccessKey` = **SHA-256 hex of the token's `value`**
-6. Write all five settings fields, then run the existing `r2EnsureBucketCors` and a
-   round-trip put/delete to prove the credentials actually work before reporting
-   success.
+   a. `GET /accounts` — list accounts the user authorized, and let them pick if more
+      than one;
+   b. `POST /accounts/{id}/r2/buckets` — create the bucket (default name
+      `axibridge-reports`, adopt it if it already exists and is ours);
+   c. `PUT /accounts/{id}/r2/buckets/{bucket}/domains/managed` — enable the public
+      development URL, then `GET` it back for the `pub-<hash>.r2.dev` hostname;
+   d. `PUT /accounts/{id}/r2/buckets/{bucket}/cors` — the OAuth-mode equivalent of
+      `r2EnsureBucketCors`.
+5. Persist `r2AccountId`, `r2BucketName`, `r2PublicUrl`, the refresh token, and
+   `r2AuthMode: 'oauth'`. **No access key pair is created** — see the verified
+   section above; there is no scope that would allow it.
+6. Prove it works before reporting success: `PUT` a small object through
+   `/accounts/{id}/r2/buckets/{bucket}/objects/{key}` with the bearer token, `GET` it
+   back over the public `r2.dev` URL to confirm the bucket really is public, then
+   `DELETE` it.
 
-Step 6 matters: today a bad credential is discovered at publish time. This flow should
-never report "connected" without having completed one real signed request.
+Step 6 matters: today a bad configuration is discovered at publish time. This flow
+should never report "connected" without having completed one real round trip.
+
+Publishing then diverges by mode. `planSidecarHosting` is unchanged — it still decides
+*whether* a sidecar goes to R2 — but the transport differs:
+
+| mode | transport |
+|---|---|
+| `manual` | existing `r2PutObject` / `r2DeleteObject`, hand-rolled SigV4 |
+| `oauth` | `PUT`/`DELETE` on the REST object endpoints, `Authorization: Bearer` |
+
+Both must go through one seam, not two call sites that drift. The natural shape is an
+uploader interface resolved once from `r2AuthMode`, with `planSidecarHosting` and its
+callers (`githubHandlers.ts:1862`, `:1911`) unaware of which one they got.
 
 ### 3. `r2.dev` is the right default
 
@@ -129,19 +237,24 @@ Connecting a custom domain is therefore an **optional later upgrade**, surfaced 
 hint rather than a step, and the manual `r2PublicUrl` field remains editable for
 anyone who has one.
 
-### 4. Credential storage and revocation
+### 4. Credential storage and session lifetime
 
-The derived key pair goes where the current fields go — same store, same shape — so
-nothing downstream changes. Additionally stored: the refresh token, the account ID
-chosen, the created API token's `id` (so it can be revoked), and an `r2AuthMode`
-discriminator of `manual | oauth`.
+OAuth mode stores the refresh token, the chosen account ID, the bucket name, the public
+URL, and an `r2AuthMode` discriminator of `manual | oauth`. `r2AccessKeyId` and
+`r2SecretAccessKey` stay **empty** in OAuth mode — which means `resolveR2Config`
+(`githubHandlers.ts:468`), whose entire contract is "all five fields non-empty", has to
+learn about the discriminator. That is the one place this phase genuinely reaches into
+existing logic, and it should be a widening of the config type rather than a special
+case sprinkled through the callers.
 
-- **Disconnect** revokes the created API token via the API and clears all five fields,
-  rather than just forgetting them locally. A token we minted and abandoned is a
-  credential the user cannot see in a list they think of as theirs.
-- If the refresh token is rejected, the app does **not** silently degrade: publishes
-  still work, because the derived S3 key pair is independent of the OAuth session and
-  outlives it. Re-auth is only needed to re-provision.
+- **Disconnect** clears the stored tokens and calls the revoke endpoint. There is no
+  minted API token to clean up — a strict improvement over the first draft, which would
+  have left a credential behind on any failed disconnect.
+- **Refresh is on the publish path.** Unlike a derived key pair, a bearer token expires.
+  Publishing must refresh before use and surface a clear "sign in to Cloudflare again"
+  state when the refresh token is rejected — not a SigV4-shaped error, and not a silent
+  drop of the sidecar. This is a genuine regression in robustness versus manual mode and
+  should be stated in the UI, not hidden.
 - Manual mode is untouched, and switching to manual entry drops the OAuth state.
 
 ### 5. Failure and fallback
@@ -152,32 +265,50 @@ than dead-ending. In particular: consent declined, no accounts authorized, R2 no
 enabled on the account, bucket name taken by an unrelated bucket, and insufficient
 permissions on the granted scopes.
 
+One failure mode is invisible from the client side and worth handling by name:
+**account administrators can disable OAuth access to account resources** entirely
+(*Manage Account → Members → Settings → Public OAuth App access*). The symptom is an
+account that simply does not appear in the consent screen's account list. A user in a
+guild-owned Cloudflare account may hit this and have no idea why their account is
+missing; the empty-account-list message should name it.
+
 ## Open questions
+
+Questions 2 and 4 from the first draft are now answered — see the verified section
+above. What remains:
 
 1. **Does enabling R2 on a fresh account require a payment method?** The docs say
    "You must purchase R2 before you can generate an API token", which is Cloudflare's
    wording for the free-tier enable click — R2's free tier is 10 GB with no egress
    charges. Whether a card must be on file is unverified and decides whether the flow
    is fully hands-off or ends in one unavoidable dashboard deep-link. **Verify against
-   a genuinely fresh account before building.**
-2. **Exact scope IDs.** Scope names correspond to API token permission names, fetched
-   from `GET /client/v4/oauth/scopes` (requires auth). Need the concrete IDs for R2
-   admin read+write and for token creation — and confirmation that an OAuth-issued
-   token is permitted to mint an API token at all, which is the load-bearing
-   assumption of step 4d.
-3. **Access/refresh token lifetimes**, and whether refresh tokens rotate.
-4. **Loopback redirect URIs** — confirm Cloudflare accepts `http://127.0.0.1` with a
-   dynamic port for public clients. If only fixed ports are allowed, the listener
-   needs a reserved port with a fallback.
-5. **Bucket adoption semantics** when `axibridge-reports` already exists — adopt,
+   a genuinely fresh account before building.** This is now the only remaining
+   prerequisite.
+2. **Does `PUT .../objects/{key}` actually accept an OAuth bearer token?** Reads were
+   confirmed (`GET /accounts/{id}/r2/buckets` succeeds on an OAuth token); the write
+   was not tested, because testing it means writing an object into a real bucket. This
+   is load-bearing for the whole design and needs one round-trip put/delete against a
+   scratch bucket before anything is built.
+3. **Whether the 1,200-per-5-minutes REST limit counts object operations.** The limit
+   is stated as "across all R2 REST API operations on your account", while a separate
+   footnote says the bucket-management rate limit does *not* apply to object reads and
+   writes. AxiBridge writes two or three objects per publish either way, so this is a
+   sizing question, not a blocker.
+4. **Access/refresh token lifetimes**, and whether refresh tokens rotate. Now more
+   important than in the first draft: publishing depends on refresh succeeding.
+5. **Loopback redirect URIs** — confirm Cloudflare accepts `http://127.0.0.1` with a
+   dynamic port for public clients. The docs show only an `https://example.com`
+   example. If only fixed ports are allowed, the listener needs a reserved port with a
+   fallback.
+6. **Bucket adoption semantics** when `axibridge-reports` already exists — adopt,
    suffix, or ask.
-
-Questions 1 and 2 are prerequisites: if OAuth-issued tokens cannot create API tokens,
-the entire design collapses to "OAuth logs you in and then still asks for five
-fields", which is not worth building.
 
 ## What this does not change
 
-`resolveR2Config`, `planSidecarHosting`, the sidecar encoding contract, the SigV4
-implementation, and the Phase B rule that **sidecars never fall back to GitHub Pages**.
-Phase C changes only how the five values get into the store.
+`planSidecarHosting` and its routing table, the sidecar encoding contract
+(`slice.json.gz`, `Content-Type: application/gzip`, no `Content-Encoding`), the SigV4
+implementation used by manual mode, and the Phase B rule that **sidecars never fall
+back to GitHub Pages**.
+
+`resolveR2Config` *does* change, narrowly: it can no longer treat "five non-empty
+fields" as the definition of "R2 is configured", because OAuth mode has no key pair.

--- a/docs/superpowers/specs/2026-08-23-r2-oauth-phase-c-design.md
+++ b/docs/superpowers/specs/2026-08-23-r2-oauth-phase-c-design.md
@@ -1,0 +1,183 @@
+# R2 Setup Phase C — Sign in with Cloudflare (design)
+
+Phase A shipped an ephemeral fight slicer in the desktop app
+(`docs/superpowers/specs/2026-08-22-fight-slicer-design.md`). Phase B put a slicer in
+the published web report and made a slice a shareable link
+(`docs/superpowers/specs/2026-08-22-fight-slicer-phase-b-design.md`). Both leaned on
+Cloudflare R2 being configured. Phase C attacks the reason most users never configure
+it: the setup is five hand-copied fields and a trip through the Cloudflare dashboard.
+
+## Problem
+
+R2 is not a feature toggle — it is a credential-presence check. `resolveR2Config`
+(`src/main/handlers/githubHandlers.ts:468`) returns `null` unless all five of
+`R2_FIELDS` are non-empty:
+
+```
+r2AccountId  r2AccessKeyId  r2SecretAccessKey  r2BucketName  r2PublicUrl
+```
+
+Getting those five values means: create a Cloudflare account, enable R2, create a
+bucket, enable the bucket's public development URL, open **Manage R2 API Tokens**,
+create a token, and copy four opaque strings plus a `pub-<hash>.r2.dev` hostname into
+Settings — with the secret access key shown exactly once. Any transcription error
+surfaces later as a SigV4 signature failure at publish time, not at entry time.
+
+The cost of not doing it is asymmetric and, until recently, undocumented in the UI.
+Per `planSidecarHosting` (`githubHandlers.ts:677`):
+
+| artifact | R2 configured | not configured |
+|---|---|---|
+| `report.json` + viewer | Pages | Pages |
+| `replay.json` | R2 | Pages, or dropped if over `MAX_GITHUB_BLOB_BYTES` |
+| `slice.json.gz` | R2 | **dropped — no web slicer at all** |
+
+So a user who skips R2 silently loses the entire Phase B feature. Making that
+consequence legible was a copy fix (commit `4edfb31b`). Making it *not happen* is
+this phase.
+
+## Non-goals
+
+- **Hosting `report.json` itself on R2.** Pages serves the report URL; moving the
+  payload off it is a separate design with CORS and share-link implications.
+- **Replacing SigV4 uploads.** See below — OAuth cannot do this.
+- **Removing the manual fields.** They stay, as fallback and for custom domains.
+
+## Constraint: OAuth cannot authenticate the uploads
+
+R2's data plane is the S3-compatible API, authenticated with AWS Signature Version 4.
+There is no documented Cloudflare REST endpoint for putting an object into a bucket —
+the [REST API](https://developers.cloudflare.com/r2/platform/limits/) is bucket
+management and configuration, rate limited to 1,200 requests per five minutes, and
+Cloudflare's own troubleshooting page notes that object-level tokens fail against it
+entirely. An OAuth access token is a bearer token and cannot sign a SigV4 request.
+
+**Therefore OAuth is a provisioning mechanism, not an upload credential.** The app
+still ends up holding an access key pair; it just mints one instead of asking for it.
+`r2SignedRequest`, `r2PutObject`, `r2DeleteObject` and `r2EnsureBucketCors`
+(`githubHandlers.ts:486-650`) are unchanged by this phase.
+
+## Design
+
+### 1. The OAuth client
+
+Cloudflare shipped [self-managed OAuth clients](https://developers.cloudflare.com/changelog/post/2026-06-03-public-oauth-clients/)
+GA on 2026-06-03. Desktop applications are an explicitly supported client type:
+
+| client type | flow | token endpoint auth | PKCE |
+|---|---|---|---|
+| Browser, mobile, **desktop**, CLI | Authorization Code | `none` | Required, S256 |
+
+So AxiBridge registers its own public client — no client secret shipped in the
+binary, no borrowing of Wrangler's client ID.
+
+Registration is a one-time act by the maintainer, not the user:
+
+- Create the client under **Manage account → OAuth clients**
+- `grant_types: ["authorization_code"]`, `response_types: ["code"]`,
+  `token_endpoint_auth_method: "none"`
+- Redirect URI: a loopback listener, `http://127.0.0.1:<ephemeral>/oauth/callback`
+- Scopes: the R2 admin permission (scope names correspond to API token permission
+  names) plus whatever is needed to create an API token
+- **Domain verification is required before the client can be made public.** A private
+  client only works for members of the registering account, which is useless here.
+  This needs a DNS TXT record on a domain we control, plus a logo, client URL, policy
+  URL and ToS URL for the consent screen.
+
+### 2. The provisioning flow
+
+"Sign in with Cloudflare" in the R2 settings section runs, in the main process:
+
+1. Start a loopback HTTP listener on an ephemeral port; generate `state` and a PKCE
+   verifier/challenge.
+2. Open the system browser to Cloudflare's authorize endpoint. **Not** a
+   `BrowserWindow` — an embedded browser for a third-party consent screen is both a
+   phishing-training pattern and increasingly blocked by identity providers.
+3. On callback: validate `state`, exchange the code + verifier for an access token
+   (and refresh token) at the token endpoint.
+4. Call the REST API with the access token to:
+   a. list accounts the user authorized, and let them pick if more than one;
+   b. create the bucket (default name `axibridge-reports`, adopt it if it already
+      exists and is empty-or-ours);
+   c. enable the bucket's public development URL and read back the
+      `pub-<hash>.r2.dev` hostname;
+   d. create an R2 API token scoped to that bucket with object read+write.
+5. Derive the S3 credentials from the token response, per
+   [R2 Tokens](https://developers.cloudflare.com/r2/api/tokens/):
+   - `r2AccessKeyId` = the token's `id`
+   - `r2SecretAccessKey` = **SHA-256 hex of the token's `value`**
+6. Write all five settings fields, then run the existing `r2EnsureBucketCors` and a
+   round-trip put/delete to prove the credentials actually work before reporting
+   success.
+
+Step 6 matters: today a bad credential is discovered at publish time. This flow should
+never report "connected" without having completed one real signed request.
+
+### 3. `r2.dev` is the right default
+
+Cloudflare labels the `r2.dev` public development URL as non-production and
+[rate limits it](https://developers.cloudflare.com/r2/platform/limits/) —
+hundreds of requests/second yields `429`, and throughput may be throttled.
+
+That warning is worth stating and worth *not* over-weighting. The reference
+installation already runs on `r2.dev` (`pub-f64d7fbe….r2.dev`) and serves real
+published reports from it. A guild opening a report is single-digit requests per
+reader, not hundreds per second. Auto-provisioning to `r2.dev` gives a new user
+exactly the working setup an existing user has.
+
+Connecting a custom domain is therefore an **optional later upgrade**, surfaced as a
+hint rather than a step, and the manual `r2PublicUrl` field remains editable for
+anyone who has one.
+
+### 4. Credential storage and revocation
+
+The derived key pair goes where the current fields go — same store, same shape — so
+nothing downstream changes. Additionally stored: the refresh token, the account ID
+chosen, the created API token's `id` (so it can be revoked), and an `r2AuthMode`
+discriminator of `manual | oauth`.
+
+- **Disconnect** revokes the created API token via the API and clears all five fields,
+  rather than just forgetting them locally. A token we minted and abandoned is a
+  credential the user cannot see in a list they think of as theirs.
+- If the refresh token is rejected, the app does **not** silently degrade: publishes
+  still work, because the derived S3 key pair is independent of the OAuth session and
+  outlives it. Re-auth is only needed to re-provision.
+- Manual mode is untouched, and switching to manual entry drops the OAuth state.
+
+### 5. Failure and fallback
+
+Every step above can fail against someone else's account. The flow must degrade to
+"here are the five fields, and here's a deep link to the exact dashboard page" rather
+than dead-ending. In particular: consent declined, no accounts authorized, R2 not
+enabled on the account, bucket name taken by an unrelated bucket, and insufficient
+permissions on the granted scopes.
+
+## Open questions
+
+1. **Does enabling R2 on a fresh account require a payment method?** The docs say
+   "You must purchase R2 before you can generate an API token", which is Cloudflare's
+   wording for the free-tier enable click — R2's free tier is 10 GB with no egress
+   charges. Whether a card must be on file is unverified and decides whether the flow
+   is fully hands-off or ends in one unavoidable dashboard deep-link. **Verify against
+   a genuinely fresh account before building.**
+2. **Exact scope IDs.** Scope names correspond to API token permission names, fetched
+   from `GET /client/v4/oauth/scopes` (requires auth). Need the concrete IDs for R2
+   admin read+write and for token creation — and confirmation that an OAuth-issued
+   token is permitted to mint an API token at all, which is the load-bearing
+   assumption of step 4d.
+3. **Access/refresh token lifetimes**, and whether refresh tokens rotate.
+4. **Loopback redirect URIs** — confirm Cloudflare accepts `http://127.0.0.1` with a
+   dynamic port for public clients. If only fixed ports are allowed, the listener
+   needs a reserved port with a fallback.
+5. **Bucket adoption semantics** when `axibridge-reports` already exists — adopt,
+   suffix, or ask.
+
+Questions 1 and 2 are prerequisites: if OAuth-issued tokens cannot create API tokens,
+the entire design collapses to "OAuth logs you in and then still asks for five
+fields", which is not worth building.
+
+## What this does not change
+
+`resolveR2Config`, `planSidecarHosting`, the sidecar encoding contract, the SigV4
+implementation, and the Phase B rule that **sidecars never fall back to GitHub Pages**.
+Phase C changes only how the five values get into the store.

--- a/docs/superpowers/specs/2026-08-23-r2-oauth-phase-c-design.md
+++ b/docs/superpowers/specs/2026-08-23-r2-oauth-phase-c-design.md
@@ -17,11 +17,16 @@ R2 is not a feature toggle — it is a credential-presence check. `resolveR2Conf
 r2AccountId  r2AccessKeyId  r2SecretAccessKey  r2BucketName  r2PublicUrl
 ```
 
-Getting those five values means: create a Cloudflare account, enable R2, create a
-bucket, enable the bucket's public development URL, open **Manage R2 API Tokens**,
-create a token, and copy four opaque strings plus a `pub-<hash>.r2.dev` hostname into
-Settings — with the secret access key shown exactly once. Any transcription error
-surfaces later as a SigV4 signature failure at publish time, not at entry time.
+Getting those five values means: create a Cloudflare account, **put a credit card on
+file**, enable R2, create a bucket, enable the bucket's public development URL, open
+**Manage R2 API Tokens**, create a token, and copy four opaque strings plus a
+`pub-<hash>.r2.dev` hostname into Settings — with the secret access key shown exactly
+once. Any transcription error surfaces later as a SigV4 signature failure at publish
+time, not at entry time.
+
+The card is not a detail, and it is the step this design cannot remove — see
+"Enabling R2 needs a payment method" below. Phase C removes the *copying*, not the
+*signing up*.
 
 The cost of not doing it is asymmetric and, until recently, undocumented in the UI.
 Per `planSidecarHosting` (`githubHandlers.ts:677`):
@@ -116,6 +121,43 @@ verified in probe 2.
 
 `POST /accounts/{id}/r2/temp-access-credentials` is not a way around this: it requires
 `parentAccessKeyId`, so it derives from an API token that must already exist.
+
+### Enabling R2 needs a payment method — verified on a genuinely fresh account
+
+This was open question 1, and it resolves **yes**.
+
+On a brand-new Cloudflare account that had never touched R2, an OAuth bearer with the
+full first-party scope set gets the same answer from both the read and the write call:
+
+```
+GET  /accounts/{id}/r2/buckets   -> 403
+POST /accounts/{id}/r2/buckets   -> 403
+{"success":false,"errors":[{"code":10042,
+  "message":"Please enable R2 through the Cloudflare Dashboard."}],"result":null}
+```
+
+And the dashboard's enable flow **requires a credit card on file**, even though R2's
+free tier is 10 GB with no egress charges. There is no API path around it: no scope, no
+endpoint, and the error is returned before any bucket-management logic runs.
+
+Two consequences, one narrow and one that goes to the premise:
+
+- **Narrow:** `10042` is a stable, matchable error code. Provisioning must detect it
+  specifically and deep-link to the account's R2 dashboard page, rather than surfacing a
+  generic 403 that reads like a permissions problem.
+- **Broad:** "Sign in with Cloudflare" cannot be hands-off for a user who does not
+  already have R2 enabled. The honest before/after is not "seven steps become one":
+
+  | | today | with Phase C |
+  |---|---|---|
+  | user already has R2 enabled | 5 copied fields | one button |
+  | user does not | account + card + enable + bucket + public URL + token + 5 copied fields | account + card + enable, then one button |
+
+  The remaining manual steps are the ones with the highest drop-off. Phase C is a large
+  win for the first row and a modest one for the second, and the second row is the
+  population the phase was pitched at. That does not kill the design, but it should be
+  weighed against the cost — a second upload path, a live-session dependency on the
+  publish path, and a domain purchase for OAuth client verification — before building.
 
 ### What this changes
 
@@ -280,6 +322,12 @@ than dead-ending. In particular: consent declined, no accounts authorized, R2 no
 enabled on the account, bucket name taken by an unrelated bucket, and insufficient
 permissions on the granted scopes.
 
+**R2-not-enabled is the common case, not an edge case** — it is where every new user
+starts. Detect error code `10042` by code and say what is actually required, including
+the card, with a deep link to the account's R2 page. Do not let a user consent, wait,
+and then receive a bare 403; and do not promise a setup that is free of the dashboard
+when it is not.
+
 One failure mode is invisible from the client side and worth handling by name:
 **account administrators can disable OAuth access to account resources** entirely
 (*Manage Account → Members → Settings → Public OAuth App access*). The symptom is an
@@ -296,18 +344,12 @@ user's session for nothing.
 
 ## Open questions
 
-Questions 2 and 4 from the first draft are now answered — see the verified section
-above — and the "does the third-party scope actually work" question is now answered
-too, by the second probe below. What remains:
+The first draft's questions 2 and 4 are answered in the verified section above; "does
+the third-party scope actually work" is answered by probe 2 below; and "does R2 need a
+payment method" is answered — yes — by the fresh-account test above. **Every technical
+prerequisite is now settled.** What remains is one product decision and four details:
 
-1. **Does enabling R2 on a fresh account require a payment method?** The docs say
-   "You must purchase R2 before you can generate an API token", which is Cloudflare's
-   wording for the free-tier enable click — R2's free tier is 10 GB with no egress
-   charges. Whether a card must be on file is unverified and decides whether the flow
-   is fully hands-off or ends in one unavoidable dashboard deep-link. **Verify against
-   a genuinely fresh account before building.** This is now the only remaining
-   prerequisite.
-2. **Making the client public is irreversible, and needs a domain we do not own.**
+1. **Making the client public is irreversible, and needs a domain we do not own.**
    New OAuth clients default to `visibility: private`, and a private client can only be
    authorized by members of the registering account — useless for shipping. Promotion is
    `PATCH /accounts/{id}/oauth_clients/{cid} {"visibility":"public"}` and is **permanent**;
@@ -319,18 +361,18 @@ too, by the second probe below. What remains:
    prerequisite for Phase C**, alongside the logo, client URL, policy URL and ToS URL the
    consent screen requires. Decide the domain before registering the production client,
    because the choice cannot be undone.
-3. **Whether the 1,200-per-5-minutes REST limit counts object operations.** The limit
+2. **Whether the 1,200-per-5-minutes REST limit counts object operations.** The limit
    is stated as "across all R2 REST API operations on your account", while a separate
    footnote says the bucket-management rate limit does *not* apply to object reads and
    writes. AxiBridge writes two or three objects per publish either way, so this is a
    sizing question, not a blocker.
-4. **Access/refresh token lifetimes**, and whether refresh tokens rotate. Now more
+3. **Access/refresh token lifetimes**, and whether refresh tokens rotate. Now more
    important than in the first draft: publishing depends on refresh succeeding.
-5. **Loopback redirect URIs** — confirm Cloudflare accepts `http://127.0.0.1` with a
+4. **Loopback redirect URIs** — confirm Cloudflare accepts `http://127.0.0.1` with a
    dynamic port for public clients. The docs show only an `https://example.com`
    example. If only fixed ports are allowed, the listener needs a reserved port with a
    fallback.
-6. **Bucket adoption semantics** when `axibridge-reports` already exists — adopt,
+5. **Bucket adoption semantics** when `axibridge-reports` already exists — adopt,
    suffix, or ask.
 
 ## Probe 1: full provisioning round trip on a first-party OAuth bearer, 2026-08-23

--- a/docs/superpowers/specs/2026-08-23-r2-oauth-phase-c-design.md
+++ b/docs/superpowers/specs/2026-08-23-r2-oauth-phase-c-design.md
@@ -275,7 +275,7 @@ missing; the empty-account-list message should name it.
 ## Open questions
 
 Questions 2 and 4 from the first draft are now answered — see the verified section
-above. What remains:
+above, and the end-to-end probe below. What remains:
 
 1. **Does enabling R2 on a fresh account require a payment method?** The docs say
    "You must purchase R2 before you can generate an API token", which is Cloudflare's
@@ -284,11 +284,14 @@ above. What remains:
    is fully hands-off or ends in one unavoidable dashboard deep-link. **Verify against
    a genuinely fresh account before building.** This is now the only remaining
    prerequisite.
-2. **Does `PUT .../objects/{key}` actually accept an OAuth bearer token?** Reads were
-   confirmed (`GET /accounts/{id}/r2/buckets` succeeds on an OAuth token); the write
-   was not tested, because testing it means writing an object into a real bucket. This
-   is load-bearing for the whole design and needs one round-trip put/delete against a
-   scratch bucket before anything is built.
+2. **Whether a *third-party* client holding `workers-r2.write` gets the same access
+   the probe demonstrated.** The probe (below) ran on wrangler's OAuth session, whose
+   grant is the first-party scope set (`workers:write`, `account:read`, …) — not the
+   third-party catalog scope `workers-r2.write`. So what is proven is that *the
+   endpoints accept an OAuth bearer token at all*, which was the real doubt; what is
+   not proven is that this specific scope name maps onto these specific endpoints.
+   Cheap to settle: register the OAuth client, consent once, re-run the same six calls.
+   Do that before writing implementation code, not after.
 3. **Whether the 1,200-per-5-minutes REST limit counts object operations.** The limit
    is stated as "across all R2 REST API operations on your account", while a separate
    footnote says the bucket-management rate limit does *not* apply to object reads and
@@ -302,6 +305,34 @@ above. What remains:
    fallback.
 6. **Bucket adoption semantics** when `axibridge-reports` already exists — adopt,
    suffix, or ask.
+
+## Probe: full provisioning round trip on an OAuth bearer, 2026-08-23
+
+Run against a live Cloudflare account with an OAuth access token (wrangler's session —
+see open question 2 for what that qualifies). Every call is the one the design proposes,
+in order. All six succeeded, and the scratch bucket was deleted afterwards.
+
+| # | Call | Result |
+|---|------|--------|
+| 1 | `POST /accounts/{id}/r2/buckets` | 200, bucket created |
+| 2 | `PUT  /accounts/{id}/r2/buckets/{b}/objects/probe%2Fslice.json.gz` | 200, `{"key":"probe/slice.json.gz","size":"45","etag":"2082cd45…"}` |
+| 3 | `GET  /accounts/{id}/r2/buckets/{b}/objects/…` | 200, **byte-identical** to what was sent |
+| 4 | `PUT  /accounts/{id}/r2/buckets/{b}/domains/managed` | 200, `pub-<hash>.r2.dev` returned |
+| 5 | `PUT  /accounts/{id}/r2/buckets/{b}/cors` | 200 |
+| 6 | `GET  https://pub-<hash>.r2.dev/probe/slice.json.gz` | 200, valid gzip, `Access-Control-Allow-Origin: *`, `Vary: Origin` |
+
+Two details that matter beyond "it worked":
+
+- **The sidecar encoding contract survives the REST path.** The object came back with
+  `Content-Type: application/gzip` and **no `Content-Encoding`** — exactly the shape
+  Phase B requires, and the shape the SigV4 path produces today. The REST endpoint does
+  not rewrite or re-encode the body.
+- **`domains/managed` returns the public hostname in its own response**, so provisioning
+  does not need a follow-up `GET` to learn the URL. Step 4c of the flow collapses to one
+  call.
+
+Teardown (`DELETE` object → disable managed domain → `DELETE` bucket) also returned 200
+throughout, which is what Disconnect and any failed-provisioning rollback will need.
 
 ## What this does not change
 

--- a/docs/superpowers/specs/2026-08-23-r2-oauth-phase-c-design.md
+++ b/docs/superpowers/specs/2026-08-23-r2-oauth-phase-c-design.md
@@ -155,8 +155,11 @@ Registration is a one-time act by the maintainer, not the user:
   `token_endpoint_auth_method: "none"`
 - Redirect URI: a loopback listener, `http://127.0.0.1:<ephemeral>/oauth/callback`
 - Scopes: `workers-r2.write` (account-wide R2 admin — the REST object endpoints do not
-  accept object-scoped grants), `memberships.read` to enumerate authorizable accounts,
-  and `offline_access` for a refresh token
+  accept object-scoped grants, and this scope **implies read**, so no separate
+  `workers-r2.read` is needed), `memberships.read` to enumerate authorizable accounts,
+  and `offline_access` for a refresh token. In the dashboard picker these live under
+  **Workers R2 Storage**; *not* "Workers R2 Storage Bucket Item", which is S3-API-only
+  and cannot provision. Verified end to end — see probe 2.
 - **Domain verification is required before the client can be made public.** A private
   client only works for members of the registering account, which is useless here.
   This needs a DNS TXT record on a domain we control, plus a logo, client URL, policy
@@ -188,7 +191,10 @@ plainly that third-party clients get authorization code and nothing else.)
    `BrowserWindow` — an embedded browser for a third-party consent screen is both a
    phishing-training pattern and increasingly blocked by identity providers.
 3. On callback: validate `state`, exchange the code + verifier for an access token
-   (and refresh token) at the token endpoint.
+   (and refresh token) at the token endpoint. **Send an explicit `User-Agent` on this
+   and every other Cloudflare request** — Cloudflare's WAF answers default library
+   user-agents with `403 / error code: 1010`, which surfaces here looking like an OAuth
+   failure. See probe 2.
 4. Call the REST API with the access token to:
    a. `GET /accounts` — list accounts the user authorized, and let them pick if more
       than one;
@@ -275,7 +281,8 @@ missing; the empty-account-list message should name it.
 ## Open questions
 
 Questions 2 and 4 from the first draft are now answered — see the verified section
-above, and the end-to-end probe below. What remains:
+above — and the "does the third-party scope actually work" question is now answered
+too, by the second probe below. What remains:
 
 1. **Does enabling R2 on a fresh account require a payment method?** The docs say
    "You must purchase R2 before you can generate an API token", which is Cloudflare's
@@ -284,14 +291,18 @@ above, and the end-to-end probe below. What remains:
    is fully hands-off or ends in one unavoidable dashboard deep-link. **Verify against
    a genuinely fresh account before building.** This is now the only remaining
    prerequisite.
-2. **Whether a *third-party* client holding `workers-r2.write` gets the same access
-   the probe demonstrated.** The probe (below) ran on wrangler's OAuth session, whose
-   grant is the first-party scope set (`workers:write`, `account:read`, …) — not the
-   third-party catalog scope `workers-r2.write`. So what is proven is that *the
-   endpoints accept an OAuth bearer token at all*, which was the real doubt; what is
-   not proven is that this specific scope name maps onto these specific endpoints.
-   Cheap to settle: register the OAuth client, consent once, re-run the same six calls.
-   Do that before writing implementation code, not after.
+2. **Making the client public is irreversible, and needs a domain we do not own.**
+   New OAuth clients default to `visibility: private`, and a private client can only be
+   authorized by members of the registering account — useless for shipping. Promotion is
+   `PATCH /accounts/{id}/oauth_clients/{cid} {"visibility":"public"}` and is **permanent**;
+   the verified domain is frozen afterwards (the route may change later, the domain may
+   not). Verification is a `TXT` record containing the full
+   `cloudflare_oauth_client_publisher=<code>` string, polled by Cloudflare for **up to two
+   days**. AxiBridge's only domains today are `darkharasho.github.io` and `github.com`,
+   neither of which can carry a `TXT` record — so **owning a real domain is a shipping
+   prerequisite for Phase C**, alongside the logo, client URL, policy URL and ToS URL the
+   consent screen requires. Decide the domain before registering the production client,
+   because the choice cannot be undone.
 3. **Whether the 1,200-per-5-minutes REST limit counts object operations.** The limit
    is stated as "across all R2 REST API operations on your account", while a separate
    footnote says the bucket-management rate limit does *not* apply to object reads and
@@ -306,11 +317,12 @@ above, and the end-to-end probe below. What remains:
 6. **Bucket adoption semantics** when `axibridge-reports` already exists — adopt,
    suffix, or ask.
 
-## Probe: full provisioning round trip on an OAuth bearer, 2026-08-23
+## Probe 1: full provisioning round trip on a first-party OAuth bearer, 2026-08-23
 
-Run against a live Cloudflare account with an OAuth access token (wrangler's session —
-see open question 2 for what that qualifies). Every call is the one the design proposes,
-in order. All six succeeded, and the scratch bucket was deleted afterwards.
+Run against a live Cloudflare account with an OAuth access token from wrangler's
+first-party session. This proved *the endpoints accept an OAuth bearer at all*; probe 2
+below proves the third-party scope. Every call is the one the design proposes, in order.
+All six succeeded, and the scratch bucket was deleted afterwards.
 
 | # | Call | Result |
 |---|------|--------|
@@ -333,6 +345,56 @@ Two details that matter beyond "it worked":
 
 Teardown (`DELETE` object → disable managed domain → `DELETE` bucket) also returned 200
 throughout, which is what Disconnect and any failed-provisioning rollback will need.
+
+## Probe 2: the same round trip on a real third-party client, 2026-08-23
+
+Open question 2 from the first draft is **closed, affirmatively.** A self-managed OAuth
+client was registered under the maintainer's account (public client, `authorization_code`
+only, `token_endpoint_auth_method: "none"`, loopback redirect URI on an ephemeral port),
+and the full PKCE-S256 consent + provisioning sequence was driven against it.
+
+The token came back with a refresh token and this grant, verbatim:
+
+```
+GRANTED SCOPES: workers-r2.write memberships.read offline_access
+```
+
+Cloudflare granted exactly the dot-delimited catalog scopes requested — no silent
+substitution, no widening. On that token, every provisioning call from the design
+returned 200: bucket create, object `PUT`, object `GET`, `domains/managed`, `cors`, and
+the public unauthenticated fetch over `r2.dev`. Teardown returned 200 throughout and the
+account was verified back at its original bucket count.
+
+Three findings worth carrying into implementation:
+
+- **`workers-r2.write` implies read.** The object `GET` succeeded on a grant containing
+  no `workers-r2.read`. The consent screen therefore stays at two visible scopes; do not
+  add the read scope "to be safe", it only makes the prompt scarier.
+- **The scope names in the dashboard picker are not the catalog names.** "Workers R2
+  Storage" is `workers-r2.{metadata_read,read,write}`; "Workers R2 Storage Bucket Item"
+  is `workers-r2-bucket-item.{read,write}` and is **S3-API-only** — it cannot create
+  buckets, enable `r2.dev`, or set CORS. It is the narrower-looking option that does not
+  work. "Data Catalog" (`r2-catalog.*`) and "SQL" (`r2-catalog-sql.read`) are unrelated.
+- **Cloudflare's WAF bans default library User-Agents.** `Python-urllib/3.x` — and by
+  extension a bare Node/Electron request — gets a `403` with the `text/plain` body
+  `error code: 1010` from both `dash.cloudflare.com` and `*.r2.dev`. It does *not* need a
+  browser UA; a plain custom one (`AxiBridge/1.0 (+https://github.com/darkharasho/axibridge)`)
+  passes. This is the trap to remember, because the failure surfaces at the **token
+  exchange** and looks exactly like a broken OAuth configuration when it is not one. Set
+  an explicit `User-Agent` on every Cloudflare request the app makes.
+
+**One anomaly, unexplained.** On the first run, step 3's read-back compared unequal while
+still reporting `Content-Type: application/gzip`. The obvious candidate — a stale object
+served after reusing a just-deleted bucket name — was tested directly and **disproven**
+(delete-and-recreate reads back correctly on the first attempt). Six subsequent reads with
+identical code all compared equal, so it is not reproducible and no cause is claimed here.
+It does not block the design, but if provisioning step 6's verification read ever fails in
+the field, start from this note rather than assuming a new bug.
+
+For completeness: the first run's step 6 failure was **not** a Cloudflare behaviour. The
+probe script built that one request inline without the `User-Agent` every other call
+carried, so it hit the WAF rule above and the empty error body trivially compared unequal.
+One script bug, not two findings.
 
 ## What this does not change
 

--- a/docs/superpowers/specs/2026-08-23-r2-oauth-phase-c-design.md
+++ b/docs/superpowers/specs/2026-08-23-r2-oauth-phase-c-design.md
@@ -65,8 +65,9 @@ PUT /accounts/{account_id}/r2/buckets/{bucket_name}/objects/{object_key}
 It takes a plain `Authorization: Bearer` token. So an OAuth access token holding
 `workers-r2.write` can upload a sidecar with **no API token and no SigV4 at all**.
 
-Confirmed empirically: an OAuth access token (Wrangler's, as a stand-in) authenticates
-successfully against `GET /accounts/{id}/r2/buckets`. OAuth bearer → R2 REST API works.
+Confirmed empirically, twice: first on Wrangler's token as a stand-in, then on a real
+third-party client holding `workers-r2.write` (probe 2), which drove the entire
+provisioning sequence. OAuth bearer → R2 REST API works.
 
 Constraints that come with this path:
 
@@ -109,6 +110,10 @@ The R2 scopes that *do* exist:
 | `workers-r2-bucket-item.write` | Workers R2 Storage Bucket Item Write |
 | `workers-r2-bucket-item.read` | Workers R2 Storage Bucket Item Read |
 
+Only the first is needed: `workers-r2.write` implies read, and the `bucket-item` pair
+grants the S3 API only — it cannot create a bucket, enable `r2.dev`, or set CORS. Both
+verified in probe 2.
+
 `POST /accounts/{id}/r2/temp-access-credentials` is not a way around this: it requires
 `parentAccessKeyId`, so it derives from an API token that must already exist.
 
@@ -148,7 +153,11 @@ GA on 2026-06-03. Desktop applications are an explicitly supported client type:
 So AxiBridge registers its own public client — no client secret shipped in the
 binary, no borrowing of Wrangler's client ID.
 
-Registration is a one-time act by the maintainer, not the user:
+Registration is a one-time act by the maintainer, not the user. It can be done in the
+dashboard, or via `POST /accounts/{id}/oauth_clients` — but that endpoint needs Super
+Administrator, Administrator, or the `OAuth Clients Write` permission, which **Wrangler's
+own OAuth grant does not have** (it returns a bare `10000 Authentication error`). Use the
+dashboard unless a token with that permission already exists.
 
 - Create the client under **Manage account → OAuth clients**
 - `grant_types: ["authorization_code"]`, `response_types: ["code"]`,
@@ -277,6 +286,13 @@ One failure mode is invisible from the client side and worth handling by name:
 account that simply does not appear in the consent screen's account list. A user in a
 guild-owned Cloudflare account may hit this and have no idea why their account is
 missing; the empty-account-list message should name it.
+
+A second one is invisible for a different reason: a `403` whose body is the plain text
+`error code: 1010` is Cloudflare's WAF rejecting the request's User-Agent, not an
+authorization failure. It can strike the token exchange, any REST call, or the public
+`r2.dev` verification read. Detect it by body text and say "blocked by Cloudflare, not a
+permissions problem" — never "sign in again", which is the wrong remedy and loses the
+user's session for nothing.
 
 ## Open questions
 


### PR DESCRIPTION
Two docs-only commits following the phase B merge.

**`docs(plan)`** — the phase B plan had 0 ticked and 140 unticked checkboxes because the subagent-driven run never updated the file. Adds a status banner recording the merge commit so the checkbox state stops reading as "nothing shipped".

**`docs(spec)`** — designs phase C: replace the five hand-copied R2 credential fields with a "Sign in with Cloudflare" flow.

The load-bearing finding is that **OAuth cannot authenticate the uploads**. R2's data plane is SigV4-only and a bearer token can't sign it, so OAuth is a *provisioning* mechanism, not an upload credential — it mints the same five values we ask for today and every downstream module stays untouched.

Two open questions are flagged as **prerequisites**, not details, because either can sink the design:

1. Does enabling R2 on a genuinely fresh account require a payment method?
2. Is an OAuth-issued token permitted to mint an R2 API token at all?

If (2) is no, the flow degenerates to "sign in, then still type five fields" and isn't worth building. No implementation plan should be written until both are verified against a real account.

🤖 Generated with [Claude Code](https://claude.com/claude-code)