### PR TITLE
fix(native): empty Special Buffs / Sigil+Relic sections and missing skill icons

### DIFF
--- a/packages/bridge-metrics/src/__tests__/specialBuffs.native.test.ts
+++ b/packages/bridge-metrics/src/__tests__/specialBuffs.native.test.ts
@@ -1,0 +1,48 @@
+/**
+ * Pins the special-buff membership test against the real native fixture.
+ *
+ * The old gate sniffed `meta.classification`, defaulting to "this is a boon"
+ * when the field was absent. axilog never emits `classification`, so under the
+ * native backend every buff answered "boon", the pre-filter dropped all of
+ * them, and both the Special Buffs and Sigil/Relic Uptime sections rendered
+ * their empty state. The catalog states `kind` outright -- that is the test.
+ */
+import { describe, expect, it } from 'vitest';
+import * as path from 'path';
+import { parseFile, parseFileEi } from '@axiapps/axilog';
+import { computePlayerAggregation } from '../computePlayerAggregation';
+
+const FIXTURE = path.resolve(__dirname, '../../../../test-fixtures/axilog/wvw-small.anon.zevtc');
+
+describe('special buffs over native', () => {
+    const native: any = parseFile(FIXTURE, { everything: true } as any);
+    const ei: any = parseFileEi(FIXTURE, { everything: true } as any);
+    const details = { ...ei, native } as any;
+
+    const run = () => computePlayerAggregation({
+        validLogs: [{ details }],
+        method: 'count' as any,
+        skillDamageSource: 'target',
+        splitPlayersByClass: false,
+    });
+
+    it('collects non-boon buffs instead of dropping every one of them', () => {
+        const { specialBuffAgg, specialBuffMeta } = run();
+        expect(specialBuffAgg.size).toBeGreaterThan(0);
+        expect(specialBuffMeta.size).toBeGreaterThan(0);
+    });
+
+    it('never admits a boon into the special-buff set', () => {
+        const { specialBuffMeta } = run();
+        const names = [...specialBuffMeta.values()].map((m) => m.name);
+        for (const boon of ['Might', 'Quickness', 'Protection', 'Alacrity', 'Fury']) {
+            expect(names).not.toContain(boon);
+        }
+    });
+
+    it('surfaces the sigil the Sigil/Relic Uptime section filters for', () => {
+        const { specialBuffMeta } = run();
+        const names = [...specialBuffMeta.values()].map((m) => String(m.name || ''));
+        expect(names.some((n) => /\b(sigil|relic)\b/i.test(n))).toBe(true);
+    });
+});

--- a/packages/bridge-metrics/src/computePlayerAggregation.ts
+++ b/packages/bridge-metrics/src/computePlayerAggregation.ts
@@ -13,6 +13,7 @@ import { PlayerRoleClassification } from './roles';
 import { normalizeAccountName, partitionSquadPlayers } from './playerIdentity';
 import { getEntityProfession, squadEntities } from './nativeRoster';
 import { getEntityConditionDamageTakenRows } from './nativeConditions';
+import { getBuffMeta } from './nativeBoons';
 
 export interface PlayerStats {
     name: string;
@@ -214,9 +215,36 @@ const supportTimeSanityFields = new Set(['boonStripsTime', 'condiCleanseTime', '
 // to `support[0]` so both old and new logs aggregate correctly.
 const supportFieldsMovedToDefenses = new Set(['stunBreak', 'removedStunDuration']);
 
-const isBoon = (meta?: { classification?: string }) => {
-    if (!meta?.classification) return true;
-    return meta.classification === 'Boon';
+/**
+ * Which bucket a buff falls in, asked of whichever backend parsed the log.
+ *
+ * EI states the bucket in a `classification` string; axilog never emits that
+ * field and states `kind` in `catalogs.buffs` instead. The old gate read only
+ * `classification` and defaulted a missing one to "boon", so under native
+ * every buff answered boon, the special-buff pre-filter dropped all of them,
+ * and the Special Buffs and Sigil/Relic Uptime sections rendered empty. Ask
+ * the catalog first, fall back to `classification` for logs parsed by EI, and
+ * keep the old default only when neither backend has an opinion.
+ */
+const makeBuffClassifier = (details: any) => {
+    const hasCatalog = Boolean(details?.native?.catalogs?.buffs);
+    return {
+        isBoon: (buffId: number | string, meta?: { classification?: string }) => {
+            if (hasCatalog) {
+                const kind = getBuffMeta(details, buffId)?.kind;
+                if (kind) return kind === 'boon';
+            }
+            if (!meta?.classification) return true;
+            return meta.classification === 'Boon';
+        },
+        isCondition: (buffId: number | string, meta?: { classification?: string }) => {
+            if (hasCatalog) {
+                const kind = getBuffMeta(details, buffId)?.kind;
+                if (kind) return kind === 'condition';
+            }
+            return !meta?.classification || meta.classification === 'Condition';
+        },
+    };
 };
 
 const createMitigationTotals = (): DamageMitigationTotals => ({
@@ -783,12 +811,13 @@ export const ingestLogPlayerData = (log: any, acc: PlayerAggregationAccumulators
         s.healingActiveMs += activeMs;
 
         if (Array.isArray(p.buffUptimes) && p.buffUptimes.length > 0) {
+            const classifier = makeBuffClassifier(details);
             // OPTIMIZATION: Pre-filter to non-damaging buffs only to skip 30-40 of 50 buffs upfront
             const nonDamagingBuffs = p.buffUptimes.filter((buff: any) => {
                 if (typeof buff?.id !== 'number') return false;
                 const buffId = `b${buff.id}`;
                 const meta = details.buffMap?.[buffId] || details.buffMap?.[String(buff.id)];
-                if (!meta || isBoon(meta)) return false;
+                if (!meta || classifier.isBoon(buff.id, meta)) return false;
                 return true;
             });
 
@@ -810,7 +839,7 @@ export const ingestLogPlayerData = (log: any, acc: PlayerAggregationAccumulators
                 if (!hasTotalMs && !hasUptimeMs) return;
 
                 const conditionName = normalizeConditionLabel(meta?.name);
-                if (conditionName && NON_DAMAGING_CONDITIONS.has(conditionName) && (!meta?.classification || meta.classification === 'Condition')) {
+                if (conditionName && NON_DAMAGING_CONDITIONS.has(conditionName) && classifier.isCondition(buff.id, meta)) {
                     // buffUptimes on squad players = conditions ON the player = incoming from enemies.
                     // Outgoing non-damaging conditions are sourced from target.buffs.statesPerSource
                     // via computeOutgoingConditions() (applicationsFromBuffs / applicationsFromBuffsActive).

--- a/src/main/__tests__/axilogParser.test.ts
+++ b/src/main/__tests__/axilogParser.test.ts
@@ -4,6 +4,7 @@ import * as fs from 'node:fs';
 
 import {
     AxilogManager,
+    GENERIC_SKILL_ICON,
     applyEiCompatShims,
     formatEncounterDuration,
     mapParserSettingsToAxilogOptions,
@@ -586,26 +587,26 @@ describe.runIf(binding && fs.existsSync(FIXTURE))('axilog real parse (anonymized
         // the boon selector, skill usage, heal effectiveness, commander stats),
         // and every one of them rendered blank under the native engine.
         //
-        // Skills are 418 of 508 on this fixture, not all: `/v2/skills` does not
-        // list every id an arcdps log carries. Assert a strong majority rather
-        // than a hardcoded count, which would just churn on every axilog bump.
+        // `/v2/skills` does not list every id an arcdps log carries, so the
+        // catalogs cannot cover the whole map: ~17 of 508 skills here, and
+        // `b30498` (Resolve) / `b78312` (Radiant Resolve) on the buff side,
+        // have no art in any catalog and 404 on `/v2/skills`. Elite Insights
+        // had the same gap and never rendered a blank cell -- `SkillItem`
+        // falls back to `SkillImages.MonsterSkill` -- so the shim substitutes
+        // the same placeholder and EVERY entry ends up with an icon.
         const skillEntries = Object.values(details.skillMap) as any[];
-        const withIcon = skillEntries.filter((s) => typeof s.icon === 'string' && s.icon).length;
-        expect(withIcon).toBeGreaterThan(skillEntries.length * 0.75);
-        // Buffs were an `every` until axilog 1.6.1 routed indirect
-        // (healing-over-time) rows into the buff catalog as well as the skill
-        // one, which is the correct shape — GW2EI's own `BuildHealingDist`
-        // puts an indirect row's id in `buffMap`. It also means `buffMap` now
-        // carries ids whose art nothing has: `b30498` (Resolve) and `b78312`
-        // (Radiant Resolve) are absent from all three icon catalogs and from
-        // `/v2/skills`, so there is no source to backfill from and no amount
-        // of shim work would produce one. A named heal source with a blank
-        // icon beats it not appearing in the healing breakdown at all, so
-        // assert the same strong majority the skill side asserts rather than
-        // pretending the tail is closeable.
+        expect(skillEntries.every((s) => typeof s.icon === 'string' && s.icon)).toBe(true);
         const buffEntries = Object.values(details.buffMap) as any[];
-        const buffsWithIcon = buffEntries.filter((b) => typeof b.icon === 'string' && b.icon).length;
-        expect(buffsWithIcon).toBeGreaterThan(buffEntries.length * 0.95);
+        expect(buffEntries.every((b) => typeof b.icon === 'string' && b.icon)).toBe(true);
+        // The catalog art must still win wherever it exists; the placeholder is
+        // a floor, not a blanket.
+        expect(details.skillMap.s5491?.icon).not.toBe(GENERIC_SKILL_ICON);
+        expect(skillEntries.filter((s) => s.icon === GENERIC_SKILL_ICON).length)
+            .toBeLessThan(skillEntries.length * 0.25);
+        // The exact URL matters: it is what EI emitted, so a report parsed by
+        // either backend renders the same image for an unknown skill.
+        expect(GENERIC_SKILL_ICON)
+            .toBe('https://render.guildwars2.com/file/1D55D34FB4EE20B1962E315245E40CA5E1042D0E/62248.png');
         // Still absent, and still needs EI's bundled GW2 DB: native carries no
         // buff `classification`.
         expect(Object.values(details.buffMap).every((b: any) => b.classification === undefined)).toBe(true);

--- a/src/main/__tests__/skillNameCache.test.ts
+++ b/src/main/__tests__/skillNameCache.test.ts
@@ -1,0 +1,233 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import {
+    SkillNameCache,
+    SKILL_NAME_CACHE_MAX,
+    applyLearnedSkillNames,
+    getSkillNameCache,
+    initSkillNameCache,
+    isPlaceholderSkillName,
+    learnSkillNames,
+    resetSkillNameCache,
+    type SkillNamePersistence,
+} from '../skillNameCache';
+import { applyEiCompatShims } from '../axilogParser';
+
+/** Persistence backed by a plain object, so no fs and no Electron. */
+const memoryStore = (seed: Record<string, string> | null = null) => {
+    let data = seed;
+    return {
+        persistence: {
+            read: () => data,
+            write: (names: Record<string, string>) => {
+                data = names;
+            },
+        } as SkillNamePersistence,
+        get current() {
+            return data;
+        },
+    };
+};
+
+/** Minimal EI-shaped details: `skillMap` keys are prefixed, catalogs are bare. */
+const detailsWith = (skillMap: Record<string, any>, extra: Record<string, any> = {}): any => ({
+    skillMap,
+    ...extra,
+});
+
+beforeEach(() => {
+    resetSkillNameCache();
+});
+
+describe('isPlaceholderSkillName', () => {
+    it('matches axilog\'s `Skill <id>` fallback for that id only', () => {
+        expect(isPlaceholderSkillName('Skill 80224', '80224')).toBe(true);
+        // Right shape, wrong id — this is a real name that merely looks like one.
+        expect(isPlaceholderSkillName('Skill 80224', '12345')).toBe(false);
+        expect(isPlaceholderSkillName('Rend', '80224')).toBe(false);
+        expect(isPlaceholderSkillName(undefined, '80224')).toBe(false);
+    });
+
+    it('handles the negative ids EI uses for synthetic skills', () => {
+        expect(isPlaceholderSkillName('Skill -2', '-2')).toBe(true);
+        expect(isPlaceholderSkillName('Weapon Swap', '-2')).toBe(false);
+    });
+});
+
+describe('SkillNameCache', () => {
+    it('refuses to learn a placeholder as if it were a name', () => {
+        const cache = new SkillNameCache();
+        expect(cache.learn('80224', 'Skill 80224')).toBe(false);
+        expect(cache.learn('80224', '')).toBe(false);
+        expect(cache.learn('80224', undefined)).toBe(false);
+        expect(cache.size).toBe(0);
+    });
+
+    it('keeps the first name it learns for an id', () => {
+        const cache = new SkillNameCache();
+        expect(cache.learn('80224', 'Rend')).toBe(true);
+        expect(cache.learn('80224', 'Something Else')).toBe(false);
+        expect(cache.lookup('80224')).toBe('Rend');
+    });
+
+    it('round-trips through persistence and drops stored placeholders', () => {
+        const store = memoryStore();
+        const writer = new SkillNameCache(store.persistence, 0);
+        writer.learn('80224', 'Rend');
+        writer.learn('873', 'Resolution');
+        writer.flush();
+        expect(store.current).toEqual({ '80224': 'Rend', '873': 'Resolution' });
+
+        // A cache file poisoned with placeholders must not re-import them,
+        // otherwise a bad write would permanently mask a later real name.
+        const poisoned = memoryStore({ '80224': 'Rend', '999': 'Skill 999' });
+        const reader = new SkillNameCache(poisoned.persistence, 0);
+        reader.load();
+        expect(reader.lookup('80224')).toBe('Rend');
+        expect(reader.lookup('999')).toBeUndefined();
+    });
+
+    it('survives an unreadable or corrupt store', () => {
+        const cache = new SkillNameCache(
+            {
+                read: () => {
+                    throw new Error('ENOENT');
+                },
+                write: () => {
+                    throw new Error('EACCES');
+                },
+            },
+            0
+        );
+        expect(() => cache.load()).not.toThrow();
+        // A failed write must not lose the in-memory name or the dirty flag.
+        expect(() => cache.learn('80224', 'Rend')).not.toThrow();
+        expect(cache.lookup('80224')).toBe('Rend');
+    });
+
+    it('debounces writes and flushes on demand', () => {
+        vi.useFakeTimers();
+        const store = memoryStore();
+        const writes = vi.spyOn(store.persistence, 'write');
+        const cache = new SkillNameCache(store.persistence, 5_000);
+        cache.learn('1', 'A');
+        cache.learn('2', 'B');
+        cache.learn('3', 'C');
+        expect(writes).not.toHaveBeenCalled();
+        vi.advanceTimersByTime(5_000);
+        expect(writes).toHaveBeenCalledTimes(1);
+        expect(store.current).toEqual({ '1': 'A', '2': 'B', '3': 'C' });
+        // Nothing changed since — flush must not write again.
+        cache.flush();
+        expect(writes).toHaveBeenCalledTimes(1);
+        vi.useRealTimers();
+    });
+
+    it('stops learning at the cap rather than evicting a name in use', () => {
+        const cache = new SkillNameCache();
+        for (let i = 0; i < SKILL_NAME_CACHE_MAX; i += 1) cache.learn(String(i), `Skill Name ${i}`);
+        expect(cache.size).toBe(SKILL_NAME_CACHE_MAX);
+        expect(cache.learn('overflow', 'Too Late')).toBe(false);
+        // The earliest entry is still there; nothing was evicted to make room.
+        expect(cache.lookup('0')).toBe('Skill Name 0');
+    });
+});
+
+describe('learn / apply over a details object', () => {
+    it('teaches one log from another', () => {
+        const cache = new SkillNameCache();
+        const namedLog = detailsWith({ s80224: { name: 'Rend' } });
+        const placeholderLog = detailsWith({ s80224: { name: 'Skill 80224' } });
+
+        // Before anything is learned the placeholder stands.
+        expect(applyLearnedSkillNames(placeholderLog, cache)).toBe(0);
+        expect(placeholderLog.skillMap.s80224.name).toBe('Skill 80224');
+
+        expect(learnSkillNames(namedLog, cache)).toBe(1);
+        expect(applyLearnedSkillNames(placeholderLog, cache)).toBe(1);
+        expect(placeholderLog.skillMap.s80224.name).toBe('Rend');
+    });
+
+    it('never displaces a real name', () => {
+        const cache = new SkillNameCache();
+        cache.learn('80224', 'Rend');
+        const log = detailsWith({ s80224: { name: 'A Better Name From The Log' } });
+        expect(applyLearnedSkillNames(log, cache)).toBe(0);
+        expect(log.skillMap.s80224.name).toBe('A Better Name From The Log');
+    });
+
+    it('shares one id space across skillMap, buffMap and both native catalogs', () => {
+        const cache = new SkillNameCache();
+        // 873 is Resolution whether read as a buff or as the skill applying it.
+        learnSkillNames(detailsWith({}, { buffMap: { b873: { name: 'Resolution' } } }), cache);
+
+        const log = detailsWith(
+            { s873: { name: 'Skill 873' } },
+            {
+                buffMap: { b873: { name: 'Skill 873' } },
+                native: {
+                    catalogs: {
+                        skills: { '873': { name: 'Skill 873' } },
+                        buffs: { '873': { name: 'Skill 873' } },
+                    },
+                },
+            }
+        );
+        // All four maps must be substituted: EI-shaped views and the views
+        // already migrated to the native catalogs read different halves.
+        expect(applyLearnedSkillNames(log, cache)).toBe(4);
+        expect(log.skillMap.s873.name).toBe('Resolution');
+        expect(log.buffMap.b873.name).toBe('Resolution');
+        expect(log.native.catalogs.skills['873'].name).toBe('Resolution');
+        expect(log.native.catalogs.buffs['873'].name).toBe('Resolution');
+    });
+
+    it('does not confuse a prefixed key with a bare one', () => {
+        const cache = new SkillNameCache();
+        // `s873` must learn under `873`, not under `s873`, or the native
+        // catalog (which keys bare) would never match it.
+        learnSkillNames(detailsWith({ s873: { name: 'Resolution' } }), cache);
+        expect(cache.lookup('873')).toBe('Resolution');
+        expect(cache.lookup('s873')).toBeUndefined();
+    });
+
+    it('tolerates missing maps and junk entries', () => {
+        const cache = new SkillNameCache();
+        expect(() => learnSkillNames(null, cache)).not.toThrow();
+        expect(() => learnSkillNames({ skillMap: 'nope' }, cache)).not.toThrow();
+        expect(() => applyLearnedSkillNames(undefined, cache)).not.toThrow();
+        expect(learnSkillNames(detailsWith({ s1: null, s2: 'string', s3: { name: 'Ok' } }), cache)).toBe(1);
+    });
+});
+
+describe('applyEiCompatShims integration', () => {
+    it('recovers a name across two parses in the order they arrive', () => {
+        initSkillNameCache(memoryStore().persistence, 0);
+
+        // Parse 1: this client had the skill cached, so the log names it.
+        const first: any = { skillMap: { s80224: { name: 'Rend' } } };
+        applyEiCompatShims(first, '/logs/first.zevtc');
+
+        // Parse 2: same skill, same build, but this log carries no name.
+        const second: any = { skillMap: { s80224: { name: 'Skill 80224' } } };
+        applyEiCompatShims(second, '/logs/second.zevtc');
+        expect(second.skillMap.s80224.name).toBe('Rend');
+
+        expect(getSkillNameCache().lookup('80224')).toBe('Rend');
+    });
+
+    it('recovers on re-read of an already-cached details object', () => {
+        // The shim also runs when details come back from the dps.report cache,
+        // which is what lets a name learned today reach a log parsed months ago.
+        initSkillNameCache(memoryStore({ '80224': 'Rend' }).persistence, 0);
+        const stale: any = { skillMap: { s80224: { name: 'Skill 80224' } } };
+        applyEiCompatShims(stale, '/cache/stale.json');
+        expect(stale.skillMap.s80224.name).toBe('Rend');
+    });
+
+    it('leaves an id nothing has ever named alone', () => {
+        initSkillNameCache(memoryStore().persistence, 0);
+        const log: any = { skillMap: { s10667: { name: 'Skill 10667' } } };
+        applyEiCompatShims(log, '/logs/only.zevtc');
+        expect(log.skillMap.s10667.name).toBe('Skill 10667');
+    });
+});

--- a/src/main/axilogParser.ts
+++ b/src/main/axilogParser.ts
@@ -127,6 +127,14 @@ const toStdTimestamp = (epochMs: number): string => {
  * native start is available the timestamps are now left undefined, so callers
  * fall back to `uploadTime` instead of to a fabricated date.
  */
+/**
+ * Elite Insights' placeholder for a skill it has no art for
+ * (`SkillImages.MonsterSkill`, used as `SkillItem.DefaultIcon`). Kept
+ * byte-identical to EI's own URL so a log parsed by either backend renders the
+ * same image for an unknown id.
+ */
+export const GENERIC_SKILL_ICON = 'https://render.guildwars2.com/file/1D55D34FB4EE20B1962E315245E40CA5E1042D0E/62248.png';
+
 export const applyEiCompatShims = (details: any, _logPath: string): any => {
     if (!details || typeof details !== 'object') return details;
 
@@ -174,13 +182,23 @@ export const applyEiCompatShims = (details: any, _logPath: string): any => {
     // Only ever FILLS a missing icon -- an entry that already has one keeps it,
     // so a real Elite Insights parse (which supplies its own) is untouched.
     // Reaches new parses only; re-parse history to backfill stored logs.
+    // The catalogs do not cover every id: `/v2/skills` 404s for a tail of ids
+    // an arcdps log carries (~17 of 508 on the WvW fixture, 87 across 40 real
+    // logs), and axilog honestly emits no icon for them rather than inventing
+    // one. Elite Insights had the identical gap and never rendered a blank
+    // cell -- `SkillItem` falls back to `SkillImages.MonsterSkill` -- so
+    // removing the EI backend turned "generic placeholder" into "empty
+    // square" for every one of those ids, including named skills like Rend.
+    // Substituting EI's own URL keeps a report parsed by either backend
+    // rendering the same image. Applied only after the catalog lookup, so
+    // real art always wins.
     const backfillIcons = (map: any, prefix: string, catalog: any) => {
-        if (!map || typeof map !== 'object' || !catalog) return;
+        if (!map || typeof map !== 'object') return;
         for (const [key, entry] of Object.entries<any>(map)) {
             if (!entry || typeof entry !== 'object' || entry.icon) continue;
             const id = String(key).replace(new RegExp(`^${prefix}`), '');
-            const icon = catalog[id]?.icon;
-            if (typeof icon === 'string' && icon) entry.icon = icon;
+            const icon = catalog?.[id]?.icon;
+            entry.icon = typeof icon === 'string' && icon ? icon : GENERIC_SKILL_ICON;
         }
     };
     backfillIcons(details.skillMap, 's', details.native?.catalogs?.skills);

--- a/src/main/axilogParser.ts
+++ b/src/main/axilogParser.ts
@@ -18,6 +18,7 @@
 import type { ParserSettings } from './parserSettings';
 import { buildNativeCarrySet } from './nativeCarrySet';
 import { normalizeAccountName } from '@axiapps/bridge-metrics/playerIdentity';
+import { applyLearnedSkillNames, getSkillNameCache, learnSkillNames } from './skillNameCache';
 
 // ─── Settings mapping ─────────────────────────────────────────────────────────
 
@@ -203,6 +204,20 @@ export const applyEiCompatShims = (details: any, _logPath: string): any => {
     };
     backfillIcons(details.skillMap, 's', details.native?.catalogs?.skills);
     backfillIcons(details.buffMap, 'b', details.native?.catalogs?.buffs);
+
+    // Names: a `.zevtc` carries every skill's id but only the names the
+    // capturing client had loaded, so the same id reads "Rend" in one log and
+    // "Skill 80224" in the next -- same build, same parser. axilog cannot close
+    // that from inside one file; AxiBridge holds the whole log history and can.
+    // Learn first, then substitute, so a log that names an id teaches the cache
+    // before it is asked about it. See `skillNameCache.ts` for why this is safe
+    // (placeholder-only substitution, ids immutable in GW2) and for the corpus
+    // measurement behind it. Because this shim also runs on details re-read
+    // from the dps.report cache, names learned today reach logs parsed months
+    // ago on their next read -- no re-parse, no schema bump.
+    const nameCache = getSkillNameCache();
+    learnSkillNames(details, nameCache);
+    applyLearnedSkillNames(details, nameCache);
 
     const encounter = details.native?.encounter;
     const nativeMap = typeof encounter?.map === 'string' ? encounter.map.trim() : '';

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -82,6 +82,7 @@ import { registerCloudflareHandlers } from './handlers/cloudflareHandlers';
 import { registerParserHandlers } from './handlers/parserHandlers';
 import { registerReparseHandlers } from './handlers/reparseHandlers';
 import { AxilogManager } from './axilogParser';
+import { getSkillNameCache, initSkillNameCache } from './skillNameCache';
 import { removeEliteInsights } from './eliteInsightsRemoval';
 import { DEFAULT_PARSER_SETTINGS, PARSER_SETTINGS_STORE_KEY, type ParserSettings } from './parserSettings';
 import { parseCliFlags } from './cliFlags';
@@ -213,6 +214,23 @@ const saveUploadRetryState = (state: UploadRetryRuntimeState) => saveUploadRetry
 
 const getLegacyDpsReportCacheDir = () => path.join(app.getPath('userData'), 'dps-report-cache');
 const getDpsReportCacheDir = () => path.join(app.getPath('temp'), 'axibridge-dps-report-cache');
+
+// ─── Learned skill-name cache ────────────────────────────────────────────────
+// Names arcdps omitted from one log, recovered from another that carried them.
+// Its own file rather than a `store` key: it holds thousands of entries and is
+// written from the parse path, and electron-store rewrites the whole settings
+// file on every `set`. See `skillNameCache.ts`.
+const SKILL_NAME_CACHE_FILE = 'skill-name-cache.json';
+const initSkillNameCacheFromDisk = () => {
+    const file = path.join(app.getPath('userData'), SKILL_NAME_CACHE_FILE);
+    const cache = initSkillNameCache({
+        read: () => JSON.parse(fs.readFileSync(file, 'utf8')),
+        write: (names) => {
+            fs.writeFileSync(file, JSON.stringify(names), 'utf8');
+        },
+    });
+    log.info(`[Main] Learned skill-name cache: ${cache.size} names`);
+};
 
 // Local wrappers bind the store- and dir-injected cache functions to this process context.
 const loadDpsReportCacheIndex = () => loadDpsReportCacheIndexFn(store);
@@ -1407,6 +1425,9 @@ app.on('activate', () => {
 app.on('before-quit', () => {
     isQuitting = true;
     axilogManager?.killActiveProcess();
+    // Autosave is debounced; a quit inside that window would otherwise drop
+    // names learned from the last few parses.
+    getSkillNameCache().flush();
 });
 
 app.on('open-url', (event) => {
@@ -1443,6 +1464,7 @@ if (!gotTheLock) {
         migrateLegacySettings();
         migrateLegacyInstallName();
         migrateArcBridgeInstallName();
+        initSkillNameCacheFromDisk();
         if (cliFlags.headless) {
             log.info('[Main] Starting in headless mode — watcher/uploader/publisher only.');
             initServices();

--- a/src/main/skillNameCache.ts
+++ b/src/main/skillNameCache.ts
@@ -1,0 +1,236 @@
+/**
+ * Learned skill-name cache — recovers names arcdps didn't write into a log.
+ *
+ * # Why this exists
+ *
+ * A `.zevtc` always carries the *id* of every skill it records. It carries the
+ * *name* only when the capturing client happened to have that skill's data
+ * loaded at the moment it fired. Two logs from the same night, the same build
+ * and the same parser therefore disagree:
+ *
+ * ```
+ * 20260130-193742.zevtc   s80224 -> "Rend"
+ * 20260130-201115.zevtc   s80224 -> "Skill 80224"
+ * ```
+ *
+ * Nothing downstream can fix that from inside one file. axilog resolves what it
+ * can from the log's own table, then from the GW2 API catalog, GW2EI's name
+ * overrides, the buff tables and `SkillIDs.cs` symbols, and honestly emits
+ * `Skill <id>` when none of them answer. For a tail of ids — NPC, environment
+ * and gathering skills — none of them ever will: `/v2/skills` 404s for them and
+ * they appear in no bundled table.
+ *
+ * But AxiBridge is not limited to one file. It has the user's whole log
+ * history, and across a 4063-log corpus 11 of the 29 ids that resolve to a
+ * placeholder are named outright by some *other* log. So the first log that
+ * names `80224` can teach every log that doesn't — which is exactly what this
+ * module does.
+ *
+ * # Where it runs
+ *
+ * Inside {@link applyEiCompatShims}, learn-then-substitute, because that shim
+ * is applied both to a fresh parse *and* to details re-read from the
+ * dps.report details cache. A name learned today therefore reaches logs parsed
+ * months ago on their next read, with no re-parse and no schema bump.
+ *
+ * # What it will not do
+ *
+ * It only ever replaces a name that is exactly the `Skill <id>` placeholder for
+ * that same id, and it only learns names that are not themselves placeholders.
+ * A real name — from the log, the API catalog or any of axilog's tables — is
+ * never displaced, so this cannot make a correct name wrong. Ids are global and
+ * immutable in GW2, so a name learned from any log is valid for all of them.
+ */
+
+// ─── Placeholder shape ────────────────────────────────────────────────────────
+
+/**
+ * axilog's last-resort name, from `skill_map::resolve_name`:
+ * `None => format!("Skill {id}")`. Matched against the id it is keyed under
+ * rather than by regex, so a genuine skill *called* "Skill 5" (there is no such
+ * thing today, but the check costs nothing) is not mistaken for a placeholder.
+ */
+export const isPlaceholderSkillName = (name: unknown, id: string): boolean =>
+    typeof name === 'string' && name === `Skill ${id}`;
+
+/** A name worth remembering: a non-empty string that is not a placeholder. */
+const isLearnableName = (name: unknown, id: string): name is string =>
+    typeof name === 'string' && name.trim() !== '' && !isPlaceholderSkillName(name, id);
+
+// ─── Persistence ──────────────────────────────────────────────────────────────
+
+/** Injectable backing store, so tests need no filesystem and no Electron. */
+export interface SkillNamePersistence {
+    read(): Record<string, string> | null;
+    write(names: Record<string, string>): void;
+}
+
+/**
+ * Bound above any plausible real total — the union across a 4063-log WvW corpus
+ * is in the low thousands — so this is a runaway guard, not a working limit.
+ * Hitting it stops new learning rather than evicting, because eviction would
+ * silently un-learn a name the UI is already showing.
+ */
+export const SKILL_NAME_CACHE_MAX = 50_000;
+
+// ─── Cache ────────────────────────────────────────────────────────────────────
+
+export class SkillNameCache {
+    private names = new Map<string, string>();
+    private dirty = false;
+    private saveTimer: ReturnType<typeof setTimeout> | null = null;
+
+    constructor(
+        private persistence: SkillNamePersistence | null = null,
+        /** Debounce window for autosave; 0 writes synchronously (tests). */
+        private saveDebounceMs = 5_000
+    ) {}
+
+    /** Populate from the backing store. Never throws; a corrupt store starts empty. */
+    load(): void {
+        let stored: Record<string, string> | null = null;
+        try {
+            stored = this.persistence?.read() ?? null;
+        } catch {
+            stored = null;
+        }
+        if (!stored || typeof stored !== 'object') return;
+        for (const [id, name] of Object.entries(stored)) {
+            if (isLearnableName(name, id)) this.names.set(id, name);
+        }
+    }
+
+    get size(): number {
+        return this.names.size;
+    }
+
+    lookup(id: string): string | undefined {
+        return this.names.get(id);
+    }
+
+    /**
+     * Remember `name` for `id`. First writer wins: names are immutable per id,
+     * so a later log re-teaching the same id is a no-op rather than a rewrite,
+     * which keeps the cache stable and the dirty flag quiet.
+     */
+    learn(id: string, name: unknown): boolean {
+        if (!isLearnableName(name, id)) return false;
+        if (this.names.has(id)) return false;
+        if (this.names.size >= SKILL_NAME_CACHE_MAX) return false;
+        this.names.set(id, name);
+        this.dirty = true;
+        this.scheduleSave();
+        return true;
+    }
+
+    private scheduleSave(): void {
+        if (!this.persistence || this.saveTimer) return;
+        if (this.saveDebounceMs <= 0) {
+            this.flush();
+            return;
+        }
+        this.saveTimer = setTimeout(() => {
+            this.saveTimer = null;
+            this.flush();
+        }, this.saveDebounceMs);
+        // Never hold the event loop open on behalf of a cache write.
+        (this.saveTimer as any)?.unref?.();
+    }
+
+    /** Write immediately if anything changed. Safe to call on shutdown. */
+    flush(): void {
+        if (this.saveTimer) {
+            clearTimeout(this.saveTimer);
+            this.saveTimer = null;
+        }
+        if (!this.dirty || !this.persistence) return;
+        try {
+            this.persistence.write(Object.fromEntries(this.names));
+            this.dirty = false;
+        } catch {
+            // Keep the in-memory cache and the dirty flag; the next learn retries.
+        }
+    }
+}
+
+// ─── Details traversal ────────────────────────────────────────────────────────
+
+/**
+ * The name-bearing maps on a details object, as `[map, keyPrefix]`.
+ *
+ * `skillMap`/`buffMap` are the EI-shaped maps nearly every UI surface reads.
+ * The native catalogs are read by the views migrated off EI, and both halves
+ * come from one axilog parse — so a name substituted in only one of them would
+ * show a placeholder in exactly the views that had already been migrated.
+ *
+ * EI keys these by a prefixed id (`s80224`, `b10243`, and negatives like
+ * `s-2`); the native catalogs key by the bare id. One prefix strip covers both.
+ */
+const nameMapsOf = (details: any): Array<[Record<string, any>, string]> => {
+    const maps: Array<[Record<string, any>, string]> = [];
+    const push = (map: unknown, prefix: string) => {
+        if (map && typeof map === 'object') maps.push([map as Record<string, any>, prefix]);
+    };
+    push(details?.skillMap, 's');
+    push(details?.buffMap, 'b');
+    push(details?.native?.catalogs?.skills, '');
+    push(details?.native?.catalogs?.buffs, '');
+    return maps;
+};
+
+/**
+ * Skills and buffs share one id space in GW2 — `873` is Resolution whether it
+ * is read as a buff or as the skill that applied it — so all four maps learn
+ * into and read from a single table.
+ */
+const bareId = (key: string, prefix: string): string =>
+    prefix && key.startsWith(prefix) ? key.slice(prefix.length) : key;
+
+/** Record every real name this log carries. Returns how many were new. */
+export const learnSkillNames = (details: any, cache: SkillNameCache): number => {
+    let learned = 0;
+    for (const [map, prefix] of nameMapsOf(details)) {
+        for (const [key, entry] of Object.entries(map)) {
+            if (!entry || typeof entry !== 'object') continue;
+            if (cache.learn(bareId(key, prefix), (entry as any).name)) learned += 1;
+        }
+    }
+    return learned;
+};
+
+/** Replace `Skill <id>` placeholders with learned names. Returns how many. */
+export const applyLearnedSkillNames = (details: any, cache: SkillNameCache): number => {
+    let applied = 0;
+    for (const [map, prefix] of nameMapsOf(details)) {
+        for (const [key, entry] of Object.entries(map)) {
+            if (!entry || typeof entry !== 'object') continue;
+            const id = bareId(key, prefix);
+            if (!isPlaceholderSkillName((entry as any).name, id)) continue;
+            const learnedName = cache.lookup(id);
+            if (!learnedName) continue;
+            (entry as any).name = learnedName;
+            applied += 1;
+        }
+    }
+    return applied;
+};
+
+// ─── Process-wide instance ────────────────────────────────────────────────────
+
+let instance = new SkillNameCache();
+
+/** The cache the shim uses. Unconfigured until {@link initSkillNameCache}. */
+export const getSkillNameCache = (): SkillNameCache => instance;
+
+/** Point the cache at a backing store and load it. Called once, from main. */
+export const initSkillNameCache = (persistence: SkillNamePersistence, saveDebounceMs?: number): SkillNameCache => {
+    instance = new SkillNameCache(persistence, saveDebounceMs);
+    instance.load();
+    return instance;
+};
+
+/** Drop back to an unpersisted empty cache. For tests. */
+export const resetSkillNameCache = (): SkillNameCache => {
+    instance = new SkillNameCache();
+    return instance;
+};

--- a/src/renderer/stats/__tests__/commanderBoonScope.native.test.ts
+++ b/src/renderer/stats/__tests__/commanderBoonScope.native.test.ts
@@ -1,0 +1,40 @@
+/**
+ * The commander boon rows share the special-buff gate's old bug, used in the
+ * inverse direction: `isBoon` defaulted a missing `classification` to true, so
+ * under native -- where the field is never emitted -- every condition and
+ * effect the commander carried counted as a boon, diluting the boon-uptime
+ * average and padding `incomingBoonUptimes` with things that are not boons.
+ */
+import { describe, expect, it } from 'vitest';
+import * as path from 'path';
+import { parseFile, parseFileEi } from '@axiapps/axilog';
+import { computeCommanderStats } from '../computeCommanderStats';
+
+const FIXTURE = path.resolve(__dirname, '../../../../test-fixtures/axilog/wvw-small.anon.zevtc');
+
+describe('commander boon rows over native', () => {
+    const native: any = parseFile(FIXTURE, { everything: true } as any);
+    const ei: any = parseFileEi(FIXTURE, { everything: true } as any);
+    const details = { ...ei, native } as any;
+
+    const rows = () => computeCommanderStats([{ log: { id: 'log-0', filePath: 'a.zevtc', details } }]).rows;
+
+    it('finds a commander to measure', () => {
+        expect(rows().length).toBeGreaterThan(0);
+    });
+
+    it('counts only real boons, never the whole catalog of conditions and effects', () => {
+        // The fixture's catalog holds 12 boons; nothing may push the count past that.
+        for (const row of rows()) {
+            expect(row.boonEntries).toBeLessThanOrEqual(12);
+        }
+    });
+
+    it('never lists a condition among the commander incoming boon rows', () => {
+        const names = rows().flatMap((r: any) => (r.incomingBoonBreakdown || []).map((b: any) => String(b.name)));
+        expect(names.length).toBeGreaterThan(0);
+        for (const condition of ['Bleeding', 'Burning', 'Vulnerability', 'Crippled', 'Poison']) {
+            expect(names).not.toContain(condition);
+        }
+    });
+});

--- a/src/renderer/stats/computeCommanderStats.ts
+++ b/src/renderer/stats/computeCommanderStats.ts
@@ -6,12 +6,31 @@ import { resolveProfessionLabel } from './computePlayerAggregation';
 import { partitionSquadPlayers } from '../../shared/playerIdentity';
 import { buildNativeMovement } from '../../shared/movementData';
 import { squadEntities } from '@axiapps/bridge-metrics/nativeRoster';
+import { getBuffMeta } from '@axiapps/bridge-metrics/nativeBoons';
 import { applyLabel, type FrameFightLabels } from './slice/frameLabels';
 
-const isBoon = (meta?: { classification?: string }) => {
-    if (!meta?.classification) return true;
-    return meta.classification === 'Boon';
+/**
+ * Is this buff a boon, asked of whichever backend parsed the log.
+ *
+ * EI says so in a `classification` string. axilog never emits that field and
+ * states `kind` in `catalogs.buffs` instead, so the old default-to-true test
+ * answered "boon" for every condition and effect the commander carried --
+ * padding `boonEntries` and diluting the boon-uptime average with things that
+ * are not boons. Ask the catalog first, fall back to `classification`.
+ */
+const makeIsBoon = (details: any) => {
+    const hasCatalog = Boolean(details?.native?.catalogs?.buffs);
+    return (buffId: number | string, meta?: { classification?: string }) => {
+        if (hasCatalog) {
+            const kind = getBuffMeta(details, buffId)?.kind;
+            if (kind) return kind === 'boon';
+        }
+        if (!meta?.classification) return true;
+        return meta.classification === 'Boon';
+    };
 };
+
+type IsBoon = ReturnType<typeof makeIsBoon>;
 
 const getFightDownsDeaths = (details: any) => {
     const players = details?.players || [];
@@ -53,14 +72,14 @@ const getFightOutcome = (details: any) => {
     return false;
 };
 
-const parseCommanderBoonUptime = (player: any, buffMap: Record<string, any>) => {
+const parseCommanderBoonUptime = (player: any, buffMap: Record<string, any>, isBoon: IsBoon) => {
     const uptimes = Array.isArray(player?.buffUptimes) ? player.buffUptimes : [];
     let weightedPercent = 0;
     let boonCount = 0;
     uptimes.forEach((buff: any) => {
         if (typeof buff?.id !== 'number') return;
         const meta = buffMap?.[`b${buff.id}`] || buffMap?.[String(buff.id)];
-        if (!isBoon(meta)) return;
+        if (!isBoon(buff.id, meta)) return;
         const stacking = Boolean(meta?.stacking);
         const uptime = Number(buff?.buffData?.[0]?.uptime ?? 0);
         const presence = Number(buff?.buffData?.[0]?.presence ?? 0);
@@ -213,7 +232,7 @@ const collectIncomingSkillRows = (
     return Array.from(rowsMap.values())
         .sort((a, b) => b.damage - a.damage || b.hits - a.hits || a.name.localeCompare(b.name));
 };
-const collectIncomingBoonRows = (player: any, buffMap: Record<string, any>, durationMs: number) => {
+const collectIncomingBoonRows = (player: any, buffMap: Record<string, any>, durationMs: number, isBoon: IsBoon) => {
     const rowsMap = new Map<string, {
         id: string;
         name: string;
@@ -229,7 +248,7 @@ const collectIncomingBoonRows = (player: any, buffMap: Record<string, any>, dura
         if (!Number.isFinite(boonIdNum)) return;
         const boonId = `b${boonIdNum}`;
         const meta = buffMap?.[boonId] || buffMap?.[String(boonIdNum)] || {};
-        if (!isBoon(meta)) return;
+        if (!isBoon(boonIdNum, meta)) return;
         const stacking = Boolean(meta?.stacking);
         const uptime = Number(buff?.buffData?.[0]?.uptime ?? 0);
         const presence = Number(buff?.buffData?.[0]?.presence ?? 0);
@@ -557,9 +576,10 @@ export function ingestLogCommanderStats(log: any, idx: number, commanders: Map<s
     const alliesDead = squadPlayers.reduce((sum: number, p: any) => sum + Math.max(0, Number(p?.defenses?.[0]?.deadCount || 0)), 0);
     const buffMap = details?.buffMap && typeof details?.buffMap === 'object' ? details.buffMap : {};
     const skillMap = details?.skillMap && typeof details?.skillMap === 'object' ? details.skillMap : {};
-    const { boonCount, boonUptimePct } = parseCommanderBoonUptime(commander, buffMap);
+    const isBoon = makeIsBoon(details);
+    const { boonCount, boonUptimePct } = parseCommanderBoonUptime(commander, buffMap, isBoon);
     const incomingDamageBySkill = collectIncomingSkillRows(commander?.totalDamageTaken, skillMap, buffMap);
-    const incomingBoonUptimes = collectIncomingBoonRows(commander, buffMap, durationMs);
+    const incomingBoonUptimes = collectIncomingBoonRows(commander, buffMap, durationMs, isBoon);
     const movementMetrics = computeMovementMetrics(commanderPositions, durationMs);
     const bucketCount = Math.max(1, Math.ceil(Math.max(1, durationMs) / 5000));
     const incomingDamageCumulative = extractCumulativeSeries(commander?.powerDamageTaken1S);

--- a/src/renderer/stats/slice/__tests__/mergePlayerAggregation.test.ts
+++ b/src/renderer/stats/slice/__tests__/mergePlayerAggregation.test.ts
@@ -179,9 +179,12 @@ describe('player aggregation merge equivalence', () => {
         expect(Object.keys(acc.incomingCondiTotals).length).toBeGreaterThan(0);
         expect(Object.keys(acc.enemyProfessionCounts).length).toBeGreaterThan(0);
         expect(acc.pendingSkillCasts.size).toBeGreaterThan(0);
-        // NOT exercised by these fixtures: specialBuffAgg / specialBuffOutputAgg /
-        // specialBuffMeta stay empty on the native fixtures, so those combiners
-        // are pinned synthetically below instead.
+        // NOT exercised by these fixtures: they are boon-trimmed, so every
+        // entry in `catalogs.buffs` is a boon or a condition and each player's
+        // `buffUptimes` carries only the 12 boons -- nothing survives the
+        // special-buff gate. The combiners are pinned synthetically below, and
+        // the gate itself is pinned against a full log in bridge-metrics'
+        // `specialBuffs.native.test.ts`.
         expect(acc.specialBuffAgg.size).toBe(0);
     });
 


### PR DESCRIPTION
Fixes the [Discord report](https://discord.com/channels/1466169948035481622/1542569288248860852) "Missing Sections & Skill names". All three defects trace back to the Elite Insights binary removal (#43).

## 1 & 2 — Special Buffs and Sigil/Relic Uptime rendered empty

One bug. The special-buff gate in `computePlayerAggregation.ts` asked EI's `classification` string whether a buff was a boon, and defaulted a **missing** field to "yes, boon":

```ts
if (!meta?.classification) return true;
```

axilog never emits `classification` — it states `kind` in `catalogs.buffs` instead. So under the native parser every buff answered boon, the pre-filter dropped all of them, `specialBuffAgg` stayed empty, and both sections rendered their empty state. Sigil/Relic is a name-filtered subset of Special Buffs, hence both going dark together.

Now asks the catalog first and falls back to `classification`, so logs parsed by the old EI backend keep working. Same precedent already set in `boonGeneration.ts`.

**Verified end to end** through `parseFile` + `applyEiCompatShims` + `computePlayerAggregation` + `computeSpecialTables`: **0 → 161 special-buff tables, 10 of them sigils/relics** (Superior Sigil of Cruelty, Relic of Lyhr, Relic of the Monk…).

## Sibling bug: commander boon uptime

`computeCommanderStats.ts` carried a copy of the same predicate. On the fixture it counted **27 boons against a 12-boon catalog** — commander boon uptime was being diluted by 15 conditions and effects. Fixed the same way; pinned by a new test.

## 3b — missing skill icons

A fallback gap, not a data gap. `/v2/skills` has no art for a tail of ids arcdps logs carry (17 of 508 on the fixture, 87 across 40 real logs, including `80224 Rend` from the screenshot). EI never showed a blank cell — `SkillItem.DefaultIcon` falls back to `SkillImages.MonsterSkill`. Dropping EI turned "generic placeholder" into "empty square".

Restored at `applyEiCompatShims` with EI's byte-identical URL, so a log parsed by either backend renders the same image. Catalog art still wins where it exists (guarded by a test). **161/161 tables now have an icon.**

Note: this lands at the shim, so it reaches **new parses only** — logs already in history keep blank icons until re-parsed.

## 3a — `Skill <id>` name placeholders

Root-caused to **two** independent gaps, fixed in both repos.

**Upstream (axilog [PR #7](https://github.com/darkharasho/axilog/pull/7)).** `resolve_name` walked five rungs and not one of them was a buff table, even though `analysis::buffs::name` already existed. So id `873` — **Resolution**, a core boon — rendered as `"Skill 873"` while the very same document's buff catalog named it. Added the rung, ranked **above** the `SkillIDs.cs` symbol rung: the two tables both cover 2,260 ids and disagree on 1,430, and the buff table carries real display strings where the symbol rung carries de-camel-cased C# identifiers (`57344` symbol "Clove And Veggie Flatbread" vs buff "Clove and Veggie Flatbread"; `32795` "Marked Keep Blue" vs "Marked (Blue Keep)").

**Here (`skillNameCache.ts`).** My earlier A/B conclusion above was wrong — this is not only an upstream table gap. A `.zevtc` always records a skill's *id* but records the *name* only when the capturing client had that skill loaded, so the **same id in the same corpus** reads `"Rend"` in one log and `"Skill 80224"` in the next. No parser can close that from inside one file. AxiBridge holds the whole log history, so the first log that names an id now teaches every log that doesn't.

Safety is narrow by construction: it substitutes only where the name is exactly the `Skill <id>` placeholder **for that same id**, and learns only names that aren't themselves placeholders — a real name is never displaced, so this cannot make a correct name wrong. Ids are global and immutable in GW2.

It runs inside `applyEiCompatShims`, which is load-bearing: that shim is applied to a fresh parse **and** to details re-read from the dps.report cache, so a name learned today reaches a log parsed months ago on its next read — no re-parse, no `DETAILS_SCHEMA_VERSION` bump. All four name-bearing maps are covered (`skillMap`, `buffMap`, both native catalogs), since the migrated views read the native half.

**Measured over a real 4,063-log WvW corpus: placeholder occurrences 555 → 408, 147 rescued (26%) across 33 distinct ids** — Rend, Resolution, Flurry, Vault, Tidal Wave and a long tail of gathering skills. A warm second pass rescues 156, so the cold figure is a floor. The learned table is 4,015 names (~100 KB); it gets its own userData file rather than a `store` key because electron-store rewrites the whole settings file on every `set` and this is written from the parse path. Debounced, flushed on quit.

The ~32 ids still stuck are named by nothing: `/v2/skills` 404s for every one of them (control id `5491` resolves fine) and they appear in no table axilog bundles. They're NPC, environment and gathering internals ArenaNet never published.

## Tests

- `specialBuffs.native.test.ts` — pins the gate against a full log: tables exist, no boons admitted, at least one sigil/relic name.
- `commanderBoonScope.native.test.ts` — pins commander boon count to the 12-boon catalog.
- `axilogParser.test.ts` — icon fallback is universal, catalog art still wins, constant matches EI's URL exactly.
- `skillNameCache.test.ts` — 16 tests: placeholder shape is id-matched not regex (negative ids like `s-2`), refuses to learn placeholders, first-writer-wins, persistence round-trip, survives a corrupt or unwritable store, debounce, cap, one id space across all four maps, and two end-to-end `applyEiCompatShims` cases (second parse recovers, cached re-read recovers).
- Corrected a stale comment in `mergePlayerAggregation.test.ts`: that assertion stays `toBe(0)`, but because those fixtures are boon-trimmed, not because the gate is broken.

`npm run validate` clean. **250 test files / 2148 tests pass**; bridge-metrics' own 227 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
