### PR TITLE
chore(deps): bump @axiapps/axilog to 1.7.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
                 "packages/*"
             ],
             "dependencies": {
-                "@axiapps/axilog": "1.7.1",
+                "@axiapps/axilog": "1.7.2",
                 "@axiapps/bridge-metrics": "^0.2.0",
                 "adm-zip": "^0.5.16",
                 "axios": "^1.6.0",
@@ -152,25 +152,25 @@
             "license": "MIT"
         },
         "node_modules/@axiapps/axilog": {
-            "version": "1.7.1",
-            "resolved": "https://registry.npmjs.org/@axiapps/axilog/-/axilog-1.7.1.tgz",
-            "integrity": "sha512-BaBFjLANUKKgUzjnrzhGfP5ipQYw3k3qDGSLs0x83j2sP0F99kTaTw6hzQka96hO4Qe+qpapbhTIP5DqjXck8g==",
+            "version": "1.7.2",
+            "resolved": "https://registry.npmjs.org/@axiapps/axilog/-/axilog-1.7.2.tgz",
+            "integrity": "sha512-3LyGiXdz9lsjYeXEyOBbR8HEOSy3NIl1zt+g0rzIKzPr9tSbtTl9HsvDl0Rm+pkuteoErEhY42XQTJ9e0vZVNA==",
             "license": "MIT",
             "engines": {
                 "node": ">= 18"
             },
             "optionalDependencies": {
-                "@axiapps/axilog-darwin-arm64": "1.7.1",
-                "@axiapps/axilog-darwin-x64": "1.7.1",
-                "@axiapps/axilog-linux-arm64-gnu": "1.7.1",
-                "@axiapps/axilog-linux-x64-gnu": "1.7.1",
-                "@axiapps/axilog-win32-x64-msvc": "1.7.1"
+                "@axiapps/axilog-darwin-arm64": "1.7.2",
+                "@axiapps/axilog-darwin-x64": "1.7.2",
+                "@axiapps/axilog-linux-arm64-gnu": "1.7.2",
+                "@axiapps/axilog-linux-x64-gnu": "1.7.2",
+                "@axiapps/axilog-win32-x64-msvc": "1.7.2"
             }
         },
         "node_modules/@axiapps/axilog-darwin-arm64": {
-            "version": "1.7.1",
-            "resolved": "https://registry.npmjs.org/@axiapps/axilog-darwin-arm64/-/axilog-darwin-arm64-1.7.1.tgz",
-            "integrity": "sha512-59NTb4Dv1kR8cZa+Cga6YUO5qnsW61bJt7PmM59zLR8L1dwAy/lphJjtiVEF6MCElnV65JMl5MCxD29umyyaFA==",
+            "version": "1.7.2",
+            "resolved": "https://registry.npmjs.org/@axiapps/axilog-darwin-arm64/-/axilog-darwin-arm64-1.7.2.tgz",
+            "integrity": "sha512-gRd4dbhpynFTLTZzl6GIolzzhKMwImjtxAlS8D4Lh3z01trsv7oQfNMUjEGKRYo7c8Uw2v49af7YRwxSAA3Z8Q==",
             "cpu": [
                 "arm64"
             ],
@@ -184,9 +184,9 @@
             }
         },
         "node_modules/@axiapps/axilog-darwin-x64": {
-            "version": "1.7.1",
-            "resolved": "https://registry.npmjs.org/@axiapps/axilog-darwin-x64/-/axilog-darwin-x64-1.7.1.tgz",
-            "integrity": "sha512-onGQhyiF7k4QGKQN4gMD7XBsueEnXH0QP5nzP+snJb5h1nll8gyOR3mNm9898+FIdiDzXWkVF94gI+do4p88Vw==",
+            "version": "1.7.2",
+            "resolved": "https://registry.npmjs.org/@axiapps/axilog-darwin-x64/-/axilog-darwin-x64-1.7.2.tgz",
+            "integrity": "sha512-ilKTkxc1mTAtASCq/yirH+L8RMcgEw7VKOCjtQY8S/rFPYSCqSi0QJ9PiGrNldFBHDukFWbMEExYNAav3zTB2g==",
             "cpu": [
                 "x64"
             ],
@@ -200,9 +200,9 @@
             }
         },
         "node_modules/@axiapps/axilog-linux-arm64-gnu": {
-            "version": "1.7.1",
-            "resolved": "https://registry.npmjs.org/@axiapps/axilog-linux-arm64-gnu/-/axilog-linux-arm64-gnu-1.7.1.tgz",
-            "integrity": "sha512-MxEANpY5/lYfM9SwrH/FMrrw7mkAa3zFhwNXmq3W/Z2TpfkU8V33OyFE6argoROaLmvaBf5AMTrNSvl9Upuoqw==",
+            "version": "1.7.2",
+            "resolved": "https://registry.npmjs.org/@axiapps/axilog-linux-arm64-gnu/-/axilog-linux-arm64-gnu-1.7.2.tgz",
+            "integrity": "sha512-DMMjERDtjVYdKAlnA010A3+A5I3DV6G1KETxXL6DtUDmKXpcGgFf+jS04ZB4zCtxFhM/DjnmKXhFNOSUDoA2tw==",
             "cpu": [
                 "arm64"
             ],
@@ -219,9 +219,9 @@
             }
         },
         "node_modules/@axiapps/axilog-linux-x64-gnu": {
-            "version": "1.7.1",
-            "resolved": "https://registry.npmjs.org/@axiapps/axilog-linux-x64-gnu/-/axilog-linux-x64-gnu-1.7.1.tgz",
-            "integrity": "sha512-qHTrPHhfX47aUGR3fGVtp2gEXzakraGVkX8IQbie2uV0q/DxPp7o3zOwWRK5kgE7TiMubySuFSGxTxyZn3EizA==",
+            "version": "1.7.2",
+            "resolved": "https://registry.npmjs.org/@axiapps/axilog-linux-x64-gnu/-/axilog-linux-x64-gnu-1.7.2.tgz",
+            "integrity": "sha512-JzN3eyJEMtLblTBxj8QK2uanXr39eE6titnv4Tai75TaiTgyWa33QOdLad6cLMrJJZyZRLlAquXkmRE7P/ttQQ==",
             "cpu": [
                 "x64"
             ],
@@ -238,9 +238,9 @@
             }
         },
         "node_modules/@axiapps/axilog-win32-x64-msvc": {
-            "version": "1.7.1",
-            "resolved": "https://registry.npmjs.org/@axiapps/axilog-win32-x64-msvc/-/axilog-win32-x64-msvc-1.7.1.tgz",
-            "integrity": "sha512-/8oggXjhkRxCHmUPhF+6J/LnCaR+RSQFZJ8Y+iFjEmPF9Fg5GY8MKWwjB3KWgqf5mXxz16hk+o/ierNFJUKQog==",
+            "version": "1.7.2",
+            "resolved": "https://registry.npmjs.org/@axiapps/axilog-win32-x64-msvc/-/axilog-win32-x64-msvc-1.7.2.tgz",
+            "integrity": "sha512-kPiF5M/Wqco1vdt7P/tHURJNy0ufNndq2Y2Z1qziJcBymhzUMK3CsfDDyqqSaVmuIz2P2CoBFUr8hR6Mc7AL0Q==",
             "cpu": [
                 "x64"
             ],

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
         "ci:local": "npm run validate && npm run audit:boons && npm run audit:metrics && npm run audit:conditions && npm run audit:conditions:consistency && npm run test:unit && npm run test:e2e:web && npm run test:e2e:app && npm run test:e2e:electron"
     },
     "dependencies": {
-        "@axiapps/axilog": "1.7.1",
+        "@axiapps/axilog": "1.7.2",
         "@axiapps/bridge-metrics": "^0.2.0",
         "adm-zip": "^0.5.16",
         "axios": "^1.6.0",


### PR DESCRIPTION
Bumps the native parser pin from `1.7.1` to `1.7.2`.

## What this ships

axilog 1.7.2 adds the **buff-name rung** to skill-name resolution, which fixes the `Skill 30438` / `Skill 54960` placeholders seen in the native parse path.

## Lockfile note

The first regeneration silently produced the versionless optional-dep stub shape — empty `{"optional": true}` entries for `darwin-x64` and `linux-arm64-gnu` nested under `node_modules/@axiapps/axilog/node_modules/`, with the real top-level blocks deleted. That shape breaks `npm ci` in CI ("Invalid Version:" / "Cannot find native binding").

Cause was npm packument CDN lag, not a failed publish — the release job had published all five platforms. Remedy: `git checkout package-lock.json` → `npm cache clean --force` → `npm install`. The committed diff is a clean symmetric 25/25 with all six entries at 1.7.2 and no stubs.

## Verification

- `npm ci` exit 0 from a clean slate; binding loads at 1.7.2 with all four exports
- `npm run validate` clean (typecheck + lint, max-warnings 0)
- 250 test files / 2148 tests pass
- Real-log parse of `testdata/20260117-175120.zevtc`: 156 skills, **0** `Skill <id>` placeholders

🤖 Generated with [Claude Code](https://claude.com/claude-code)