### PR TITLE
feat(stats): count deaths under Illusion of Life as their own IoL outcome

### DIFF
--- a/src/renderer/stats/__tests__/ReviveDetailSection.test.tsx
+++ b/src/renderer/stats/__tests__/ReviveDetailSection.test.tsx
@@ -77,6 +77,25 @@ describe('ReviveDetailSection', () => {
         expect(screen.getByText(/Survived the fight 3/)).toBeTruthy();
     });
 
+    it('shows deaths under Illusion of Life as their own outcome', () => {
+        const withDeaths = { ...summary, iol: {
+            revives: 10, survived: 3, reDowned: 5, diedUnderIol: 2, medianTimeToReDownMs: 6200,
+            timeToReDownBuckets: [2, 1, 1, 1, 0],
+        } };
+        render(<ReviveDetailSection reviveDetail={withDeaths} />);
+        expect(screen.getByText(/Died under IoL 2/)).toBeTruthy();
+        // Survived percentage is over all three outcomes: 3 of 10.
+        expect(screen.getByText(/Survived the fight 3 \(30%\)/)).toBeTruthy();
+        expect(screen.getByText(/mesmers outside the squad/i)).toBeTruthy();
+    });
+
+    it('omits the died-under-IoL outcome for a report published before it existed', () => {
+        const legacy = { ...summary, iol: { revives: 8, survived: 3, reDowned: 5, medianTimeToReDownMs: 6200 } };
+        render(<ReviveDetailSection reviveDetail={legacy} />);
+        expect(screen.queryByText(/Died under IoL/)).toBeNull();
+        expect(screen.getByText(/Survived the fight 3 \(38%\)/)).toBeTruthy();
+    });
+
     it('renders the skill icon before the utility name', () => {
         const { container } = render(<ReviveDetailSection reviveDetail={summary} />);
         const icon = container.querySelector('img[src="https://example.test/banner.png"]');

--- a/src/renderer/stats/__tests__/computeReviveDetail.test.ts
+++ b/src/renderer/stats/__tests__/computeReviveDetail.test.ts
@@ -196,6 +196,57 @@ describe('computeReviveDetail', () => {
         expect(iol.timeToReDownBuckets!.reduce((a, b) => a + b, 0)).toBe(iol.reDowned);
     });
 
+    it('counts a death that skipped the downed state after an IoL stand-up as died under IoL, not re-downed', () => {
+        const acc = createReviveDetailAccumulator();
+        ingestLogReviveDetail({ details: { skillMap: {}, players: [
+            player({ account: 'Mes', profession: 'Chronomancer',
+                rotation: [{ id: 10244, skills: [{ castTime: 4000, duration: 0 }] }] }),
+            // arcdps records a ~0ms down right before the death.
+            player({ account: 'Instant', down: [[1000, 5000], [7000, 7005]], dead: [[7005, 99000]] }),
+        ] } }, acc);
+
+        const iol = finalizeReviveDetail(acc)!.iol!;
+        expect(iol).toMatchObject({ revives: 1, survived: 0, reDowned: 0, diedUnderIol: 1, medianTimeToReDownMs: null });
+        // Not a re-down, so not a 2s entry skewing the histogram.
+        expect(iol.timeToReDownBuckets).toEqual([0, 0, 0, 0, 0]);
+    });
+
+    it('keeps a short down that the player stood up from as a re-down', () => {
+        const acc = createReviveDetailAccumulator();
+        ingestLogReviveDetail({ details: { skillMap: {}, players: [
+            player({ account: 'Mes', profession: 'Chronomancer',
+                rotation: [{ id: 10244, skills: [{ castTime: 4000, duration: 0 }] }] }),
+            // The blip starts after the 5s IoL cast window, so it is not itself an IoL revive.
+            player({ account: 'Blip', down: [[1000, 5000], [10000, 10005]] }),
+        ] } }, acc);
+        expect(finalizeReviveDetail(acc)!.iol).toMatchObject({ revives: 1, reDowned: 1, diedUnderIol: 0 });
+    });
+
+    it('splits IoL revives into three outcomes that sum to the revive count, through frame merge', () => {
+        const log = () => ({ details: { skillMap: {}, players: [
+            player({ account: 'Mes', profession: 'Chronomancer',
+                rotation: [{ id: 10244, skills: [{ castTime: 4000, duration: 0 }] }] }),
+            player({ account: 'Instant', down: [[1000, 5000], [7000, 7005]], dead: [[7005, 99000]] }),
+            player({ account: 'Slow', down: [[1000, 5000], [18000, 22000]], dead: [[22000, 99000]] }),
+            player({ account: 'Survivor', down: [[1000, 5000]] }),
+        ] } });
+
+        const direct = createReviveDetailAccumulator();
+        ingestLogReviveDetail(log(), direct);
+        ingestLogReviveDetail(log(), direct);
+
+        const target = createReviveDetailAccumulator();
+        const single = createReviveDetailAccumulator();
+        ingestLogReviveDetail(log(), target);
+        ingestLogReviveDetail(log(), single);
+        mergeReviveDetailFrame(target, extractReviveDetailFrame(single));
+
+        const iol = finalizeReviveDetail(target)!.iol!;
+        expect(iol).toMatchObject({ revives: 6, survived: 2, reDowned: 2, diedUnderIol: 2, medianTimeToReDownMs: 13000 });
+        expect(iol.survived + iol.reDowned + iol.diedUnderIol!).toBe(iol.revives);
+        expect(finalizeReviveDetail(target)).toEqual(finalizeReviveDetail(direct));
+    });
+
     it('extracts a frame after ingesting a single uncovered log without throwing', () => {
         const acc = createReviveDetailAccumulator();
         ingestLogReviveDetail({ details: { skillMap: {}, players: [

--- a/src/renderer/stats/computeReviveDetail.ts
+++ b/src/renderer/stats/computeReviveDetail.ts
@@ -1,6 +1,17 @@
-import { deriveReviveLogSummary, reviveePlayerKey, type RevivePlayerCounts } from '@axiapps/bridge-metrics';
+import {
+    DEATH_MATCH_TOLERANCE_MS, deriveReviveLogSummary, reviveePlayerKey, type RevivePlayerCounts,
+} from '@axiapps/bridge-metrics';
 import { REVIVE_RE_DOWN_BUCKETS_MS } from './statsTypes';
 import type { ReviveDetailFrame, ReviveDetailSummary, ReviveUtilityCasterRow } from './statsTypes';
+
+/** A down shorter than this that ends in death is arcdps recording a player who
+ *  skipped the downed state — under Illusion of Life, the buff running out or
+ *  being killed through. A real downed state lasts seconds; across 400 real
+ *  logs every such death after an IoL stand-up was under 50ms. */
+const INSTANT_DEATH_MAX_DOWN_MS = 250;
+
+const intervals = (value: unknown): number[][] =>
+    (Array.isArray(value) ? value : []).filter((entry): entry is number[] => Array.isArray(entry) && entry.length >= 2);
 
 interface ReviveDetailPlayer extends RevivePlayerCounts {
     account: string;
@@ -50,7 +61,7 @@ export interface ReviveDetailAccumulator {
     };
     players: Map<string, ReviveDetailPlayer>;
     utilities: Map<number, ReviveDetailUtility>;
-    iol: { revives: number; survived: number; reDowned: number; timesToReDownMs: number[] };
+    iol: { revives: number; survived: number; reDowned: number; diedUnderIol: number; timesToReDownMs: number[] };
 }
 
 export function createReviveDetailAccumulator(): ReviveDetailAccumulator {
@@ -60,7 +71,7 @@ export function createReviveDetailAccumulator(): ReviveDetailAccumulator {
         squad: { downs: 0, recovered: 0, died: 0, hand: 0, utility: 0, self: 0, unattributed: 0 },
         players: new Map(),
         utilities: new Map(),
-        iol: { revives: 0, survived: 0, reDowned: 0, timesToReDownMs: [] },
+        iol: { revives: 0, survived: 0, reDowned: 0, diedUnderIol: 0, timesToReDownMs: [] },
     };
 }
 
@@ -134,15 +145,21 @@ export function ingestLogReviveDetail(log: any, acc: ReviveDetailAccumulator): v
 
     for (const revive of summary.iolRevives) {
         acc.iol.revives += 1;
-        const down = roster[revive.playerIndex]?.combatReplayData?.down;
-        const next = (Array.isArray(down) ? down : [])
-            .map((interval: number[]) => interval[0])
-            .filter((start: number) => start > revive.at)
-            .sort((a: number, b: number) => a - b)[0];
-        if (next === undefined) acc.iol.survived += 1;
+        const replay = roster[revive.playerIndex]?.combatReplayData;
+        const next = intervals(replay?.down)
+            .filter(([start]) => start > revive.at)
+            .sort((a, b) => a[0] - b[0])[0];
+        if (next === undefined) {
+            acc.iol.survived += 1;
+            continue;
+        }
+        const [downStart, downEnd] = next;
+        const diedInstantly = downEnd - downStart < INSTANT_DEATH_MAX_DOWN_MS
+            && intervals(replay?.dead).some(([deadStart]) => Math.abs(deadStart - downEnd) <= DEATH_MATCH_TOLERANCE_MS);
+        if (diedInstantly) acc.iol.diedUnderIol += 1;
         else {
             acc.iol.reDowned += 1;
-            acc.iol.timesToReDownMs.push(next - revive.at);
+            acc.iol.timesToReDownMs.push(downStart - revive.at);
         }
     }
 }
@@ -236,6 +253,7 @@ export function finalizeReviveDetail(acc: ReviveDetailAccumulator): ReviveDetail
                 revives: acc.iol.revives,
                 survived: acc.iol.survived,
                 reDowned: acc.iol.reDowned,
+                diedUnderIol: acc.iol.diedUnderIol,
                 medianTimeToReDownMs: median(acc.iol.timesToReDownMs),
                 timeToReDownBuckets: bucketTimes(acc.iol.timesToReDownMs),
             }
@@ -296,5 +314,6 @@ export function mergeReviveDetailFrame(target: ReviveDetailAccumulator, frame: R
     target.iol.revives += source.iol.revives;
     target.iol.survived += source.iol.survived;
     target.iol.reDowned += source.iol.reDowned;
+    target.iol.diedUnderIol += source.iol.diedUnderIol;
     target.iol.timesToReDownMs.push(...source.iol.timesToReDownMs);
 }

--- a/src/renderer/stats/sections/ReviveDetailSection.tsx
+++ b/src/renderer/stats/sections/ReviveDetailSection.tsx
@@ -165,12 +165,20 @@ const UtilityName = ({ utility }: { utility: ReviveUtilityRow }) => (
     </>
 );
 
-/** Illusion of Life outcomes: the survived/re-downed split as one stacked bar,
- *  and how quickly the re-downs happened as a histogram. */
+/** Mesmer purple, matching the Illusion of Life buff. No theme token is purple,
+ *  and reusing the error red would read as another shade of "re-downed". */
+const DIED_UNDER_IOL_COLOR = '#b679d5';
+
+/** Illusion of Life outcomes: the survived/re-downed/died-under-IoL split as one
+ *  stacked bar, and how quickly the re-downs happened as a histogram. */
 const IllusionOfLifeCard = ({ iol }: {
     iol: NonNullable<ReviveDetailSummary['iol']>;
 }) => {
-    const total = iol.survived + iol.reDowned;
+    // Absent on reports published before the outcome existed; those rendered
+    // the deaths inside `reDowned`, so the card simply shows two outcomes.
+    const hasDeathOutcome = typeof iol.diedUnderIol === 'number';
+    const diedUnderIol = iol.diedUnderIol ?? 0;
+    const total = iol.survived + iol.reDowned + diedUnderIol;
     const survivedPercent = total > 0 ? Math.round((iol.survived / total) * 100) : null;
     const buckets = iol.timeToReDownBuckets ?? null;
     const peak = buckets ? Math.max(...buckets) : 0;
@@ -191,6 +199,7 @@ const IllusionOfLifeCard = ({ iol }: {
                     <div className="flex h-3 w-full overflow-hidden rounded-full" style={{ background: 'var(--border-subtle)' }}>
                         <div style={{ width: `${(iol.survived / total) * 100}%`, background: 'var(--status-success)' }} />
                         <div style={{ width: `${(iol.reDowned / total) * 100}%`, background: 'var(--status-error)' }} />
+                        <div style={{ width: `${(diedUnderIol / total) * 100}%`, background: DIED_UNDER_IOL_COLOR }} />
                     </div>
                     <div className="flex flex-wrap gap-x-5 gap-y-1 mt-2 text-xs" style={{ color: 'var(--text-secondary)' }}>
                         <span className="flex items-center gap-1.5">
@@ -202,6 +211,12 @@ const IllusionOfLifeCard = ({ iol }: {
                             Re-downed {iol.reDowned}
                             {iol.medianTimeToReDownMs !== null ? ` — median ${formatSeconds(iol.medianTimeToReDownMs)}` : ''}
                         </span>
+                        {hasDeathOutcome && (
+                            <span className="flex items-center gap-1.5">
+                                <span className="w-2 h-2 rounded-full" style={{ background: DIED_UNDER_IOL_COLOR }} />
+                                Died under IoL {diedUnderIol}
+                            </span>
+                        )}
                     </div>
                 </>
             )}
@@ -228,6 +243,7 @@ const IllusionOfLifeCard = ({ iol }: {
 
             <div className="text-[11px] mt-3" style={{ color: 'var(--text-muted)' }}>
                 Time from standing up under Illusion of Life to going down again. Players who never went down again count as survived and are not in the histogram.
+                {hasDeathOutcome && ' Died under IoL means the player skipped the downed state and died outright before going down again. Only IoL cast by squad members is seen — IoL from mesmers outside the squad is not counted.'}
             </div>
         </div>
     );

--- a/src/renderer/stats/slice/sliceTypes.ts
+++ b/src/renderer/stats/slice/sliceTypes.ts
@@ -9,8 +9,12 @@ import type { FightRosterEntry } from '../statsStore';
  *
  *  v3: the revive accumulator's per-utility `byCaster` map changed from a bare
  *  revive count to `{ casts, revives }`, and utility rows carry a skill icon. A
- *  v2 frame merged by a v3 viewer would add numbers to objects. */
-export const SLICE_SIDECAR_VERSION = 3;
+ *  v2 frame merged by a v3 viewer would add numbers to objects.
+ *
+ *  v4: the revive accumulator's Illusion of Life outcomes gained
+ *  `diedUnderIol`. A v3 frame merged by a v4 viewer would add undefined and
+ *  render NaN. */
+export const SLICE_SIDECAR_VERSION = 4;
 
 /** The tray's view of a fight. Deliberately the Phase A roster shape, so
  *  `FightSliceTray` renders sidecar fights with no changes at all. */

--- a/src/renderer/stats/statsTypes.ts
+++ b/src/renderer/stats/statsTypes.ts
@@ -190,11 +190,17 @@ export interface ReviveDetailSummary {
         revives: number;
         survived: number;
         reDowned: number;
+        /** Revived players whose next down was a ~0ms blip straight into death
+         *  — the Illusion of Life buff expiring or being killed through it.
+         *  Counted apart from `reDowned`, so `survived + reDowned +
+         *  diedUnderIol === revives`. Absent on reports published before it
+         *  shipped. */
+        diedUnderIol?: number;
         medianTimeToReDownMs: number | null;
         /** Histogram of time from standing up to going down again, one count
          *  per `REVIVE_RE_DOWN_BUCKETS_MS` boundary plus a trailing unbounded
-         *  bucket. Sums to `reDowned`; survivors are not in it. Absent on
-         *  reports published before the graph shipped. */
+         *  bucket. Sums to `reDowned`; survivors and deaths under IoL are not
+         *  in it. Absent on reports published before the graph shipped. */
         timeToReDownBuckets?: number[];
     } | null;
 }


### PR DESCRIPTION
## Summary

Answers the Discord question about tracking when Illusion of Life kills someone (a player who skips the downed state and dies while holding the IoL buff).

- The IoL card in the Revives section now splits outcomes three ways: **Survived**, **Re-downed**, and a new **Died under IoL** (purple).
- **What counts:** an IoL revive where the player's next down lasts under 250ms and ends in death. arcdps records a ~0ms down right before these deaths.
- **Bug fix:** these deaths were counted as "Re-downed" with a fake 1-8s time-to-re-down, which skewed the histogram and median. They are now kept out of both.
- **Older reports:** `diedUnderIol` is optional, so reports published before this change render the two-outcome card as before.
- **Sidecar:** `SLICE_SIDECAR_VERSION` 3 -> 4, because a v3 frame merged by a v4 viewer would render NaN.

## Limits

- **Detected by the down-then-death pattern, not the buff itself.** axilog only emits uptime for IoL buff 10346, with no timeline. An exact check of the buff at the moment of death would need axilog to emit states for 10346.
- **A zero-length down alone isn't IoL-specific.** 48 of 57 such squad deaths in 400 real logs had no IoL uptime, so the rule only applies after an IoL-attributed revive.
- **IoL from mesmers outside the squad isn't seen.** The card's note says so.

## Verification

- 5 new tests:
  - an instant death is counted as died under IoL, not re-downed
  - a short down the player stood up from stays re-downed
  - the three outcomes sum to the revive total, including through frame merge
  - the card renders the new outcome
  - an older report without the field still renders
- Full unit suite passes (297 files, 2747 tests); typecheck and lint are clean.
- Ran the product code over 400 real logs: 35 IoL revives = 10 survived + 21 re-downed + 4 died under IoL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
